### PR TITLE
Bug fix in kustomization for single-line installation

### DIFF
--- a/examples/aws/cognito-rds-s3/README.md
+++ b/examples/aws/cognito-rds-s3/README.md
@@ -109,12 +109,10 @@ Follow the [Configure Katib](../rds-s3/README.md#3-configure-katib) section from
         kustomize build distributions/aws/istio-ingress/overlays/cognito | kubectl apply -f -
 
         # ALB controller
-        kustomize build distributions/aws/aws-alb-ingress-controller/base | kubectl apply -f -
+        kustomize build distributions/aws/aws-alb-ingress-controller/base | kubectl apply -f -        
 
         # Envoy filter
-        kustomize build distributions/aws/aws-istio-envoy-filter/base | kubectl apply -f -
-
-        
+        kustomize build distributions/aws/aws-istio-envoy-filter/base | kubectl apply -f -        
         ```
 1. Follow the rest of the cognito guide from [section 5.0(Updating the domain with ALB address)](../cognito/README.md#50-updating-the-domain-with-ALB-address) to:
     1. Add/Update the DNS records in custom domain with the ALB address

--- a/examples/aws/cognito-rds-s3/README.md
+++ b/examples/aws/cognito-rds-s3/README.md
@@ -109,7 +109,7 @@ Follow the [Configure Katib](../rds-s3/README.md#3-configure-katib) section from
         kustomize build distributions/aws/istio-ingress/overlays/cognito | kubectl apply -f -
 
         # ALB controller
-        kustomize build distributions/aws/aws-alb-ingress-controller/base | kubectl apply -f -        
+        kustomize build distributions/aws/aws-alb-ingress-controller/base | kubectl apply -f -
 
         # Envoy filter
         kustomize build distributions/aws/aws-istio-envoy-filter/base | kubectl apply -f -        

--- a/examples/aws/cognito-rds-s3/kustomization.yaml
+++ b/examples/aws/cognito-rds-s3/kustomization.yaml
@@ -3,9 +3,9 @@ kind: Kustomization
 
 resources:
 # Kubeflow namespace
-- ../../../common/kubeflow-namespace/base | kubectl apply -f -
+- ../../../common/kubeflow-namespace/base
 # Kubeflow Roles
-- ../../../common/kubeflow-roles/base | kubectl apply -f -
+- ../../../common/kubeflow-roles/base
 # Cert-Manager
 - ../../../common/cert-manager/cert-manager/base
 - ../../../common/cert-manager/kubeflow-issuer/base
@@ -14,47 +14,47 @@ resources:
 - ../../../common/istio-1-9/istio-namespace/base
 - ../../../common/istio-1-9/istio-install/base
 # KNative
-- ../../../common/knative/knative-serving/base | kubectl apply -f -
-- ../../../common/knative/knative-eventing/base | kubectl apply -f -
-- ../../../common/istio-1-9/cluster-local-gateway/base | kubectl apply -f -
+- ../../../common/knative/knative-serving/base
+- ../../../common/knative/knative-eventing/base
+- ../../../common/istio-1-9/cluster-local-gateway/base
 # Kubeflow Istio Resources
-- ../../../common/istio-1-9/kubeflow-istio-resources/base | kubectl apply -f -
+- ../../../common/istio-1-9/kubeflow-istio-resources/base
 
 # KFServing
-- ../../../apps/kfserving/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/kfserving/upstream/overlays/kubeflow
 # Central Dashboard
-- ../../../apps/centraldashboard/upstream/overlays/istio | kubectl apply -f -
+- ../../../apps/centraldashboard/upstream/overlays/istio
 # Notebooks
-- ../../../apps/jupyter/notebook-controller/upstream/overlays/kubeflow | kubectl apply -f -
-- ../../../apps/jupyter/jupyter-web-app/upstream/overlays/istio | kubectl apply -f -
+- ../../../apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+- ../../../apps/jupyter/jupyter-web-app/upstream/overlays/istio
 # Admission Webhook
-- ../../../apps/admission-webhook/upstream/overlays/cert-manager | kubectl apply -f -
+- ../../../apps/admission-webhook/upstream/overlays/cert-manager
 # Profiles + KFAM
-- ../../../apps/profiles/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/profiles/upstream/overlays/kubeflow
 # Volumes Web App
-- ../../../apps/volumes-web-app/upstream/overlays/istio | kubectl apply -f -
+- ../../../apps/volumes-web-app/upstream/overlays/istio
 # Tensorboard
-- ../../../apps/tensorboard/tensorboards-web-app/upstream/overlays/istio | kubectl apply -f -
-- ../../../apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+- ../../../apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
 # TFJob Operator
-- ../../../apps/tf-training/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/tf-training/upstream/overlays/kubeflow
 # Pytorch Operator
-- ../../../apps/pytorch-job/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/pytorch-job/upstream/overlays/kubeflow
 # MPI Operator
-- ../../../apps/mpi-job/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/mpi-job/upstream/overlays/kubeflow
 # MXNet Operator
-- ../../../apps/mxnet-job/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/mxnet-job/upstream/overlays/kubeflow
 # XGBoost Operator
-- ../../../apps/xgboost-job/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/xgboost-job/upstream/overlays/kubeflow
 
 # Configured for AWS Cognito
 
 # Ingress
-- ../../../distributions/aws/istio-ingress/overlays/cognito | kubectl apply -f -
+- ../../../distributions/aws/istio-ingress/overlays/cognito
 # ALB controller
-- ../../../distributions/aws/aws-alb-ingress-controller/base | kubectl apply -f -
+- ../../../distributions/aws/aws-alb-ingress-controller/base
 # Envoy filter
-- ../../../distributions/aws/aws-istio-envoy-filter/base | kubectl apply -f -
+- ../../../distributions/aws/aws-istio-envoy-filter/base
 
 # Configured for AWS RDS and AWS S3
 

--- a/examples/aws/cognito/kustomization.yaml
+++ b/examples/aws/cognito/kustomization.yaml
@@ -3,9 +3,9 @@ kind: Kustomization
 
 resources:
 # Kubeflow namespace
-- ../../../common/kubeflow-namespace/base | kubectl apply -f -
+- ../../../common/kubeflow-namespace/base
 # Kubeflow Roles
-- ../../../common/kubeflow-roles/base | kubectl apply -f -
+- ../../../common/kubeflow-roles/base
 # Cert-Manager
 - ../../../common/cert-manager/cert-manager/base
 - ../../../common/cert-manager/kubeflow-issuer/base
@@ -14,48 +14,48 @@ resources:
 - ../../../common/istio-1-9/istio-namespace/base
 - ../../../common/istio-1-9/istio-install/base
 # KNative
-- ../../../common/knative/knative-serving/base | kubectl apply -f -
-- ../../../common/knative/knative-eventing/base | kubectl apply -f -
-- ../../../common/istio-1-9/cluster-local-gateway/base | kubectl apply -f -
+- ../../../common/knative/knative-serving/base
+- ../../../common/knative/knative-eventing/base
+- ../../../common/istio-1-9/cluster-local-gateway/base
 # Kubeflow Istio Resources
-- ../../../common/istio-1-9/kubeflow-istio-resources/base | kubectl apply -f -
+- ../../../common/istio-1-9/kubeflow-istio-resources/base
 
 # Kubeflow Pipelines
-- ../../../apps/pipeline/upstream/env/platform-agnostic-multi-user | kubectl apply -f -
+- ../../../apps/pipeline/upstream/env/platform-agnostic-multi-user
 # KFServing
-- ../../../apps/kfserving/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/kfserving/upstream/overlays/kubeflow
 # Katib
-- ../../../apps/katib/upstream/installs/katib-with-kubeflow | kubectl apply -f -
+- ../../../apps/katib/upstream/installs/katib-with-kubeflow
 # Central Dashboard
-- ../../../apps/centraldashboard/upstream/overlays/istio | kubectl apply -f -
+- ../../../apps/centraldashboard/upstream/overlays/istio
 # Notebooks
-- ../../../apps/jupyter/notebook-controller/upstream/overlays/kubeflow | kubectl apply -f -
-- ../../../apps/jupyter/jupyter-web-app/upstream/overlays/istio | kubectl apply -f -
+- ../../../apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+- ../../../apps/jupyter/jupyter-web-app/upstream/overlays/istio
 # Admission Webhook
-- ../../../apps/admission-webhook/upstream/overlays/cert-manager | kubectl apply -f -
+- ../../../apps/admission-webhook/upstream/overlays/cert-manager
 # Profiles + KFAM
-- ../../../apps/profiles/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/profiles/upstream/overlays/kubeflow
 # Volumes Web App
-- ../../../apps/volumes-web-app/upstream/overlays/istio | kubectl apply -f -
+- ../../../apps/volumes-web-app/upstream/overlays/istio
 # Tensorboard
-- ../../../apps/tensorboard/tensorboards-web-app/upstream/overlays/istio | kubectl apply -f -
-- ../../../apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+- ../../../apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
 # TFJob Operator
-- ../../../apps/tf-training/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/tf-training/upstream/overlays/kubeflow
 # Pytorch Operator
-- ../../../apps/pytorch-job/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/pytorch-job/upstream/overlays/kubeflow
 # MPI Operator
-- ../../../apps/mpi-job/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/mpi-job/upstream/overlays/kubeflow
 # MXNet Operator
-- ../../../apps/mxnet-job/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/mxnet-job/upstream/overlays/kubeflow
 # XGBoost Operator
-- ../../../apps/xgboost-job/upstream/overlays/kubeflow | kubectl apply -f -
+- ../../../apps/xgboost-job/upstream/overlays/kubeflow
 
 # Configured for AWS Cognito
 
 # Ingress
-- ../../../distributions/aws/istio-ingress/overlays/cognito | kubectl apply -f -
+- ../../../distributions/aws/istio-ingress/overlays/cognito
 # ALB controller
-- ../../../distributions/aws/aws-alb-ingress-controller/base | kubectl apply -f -
+- ../../../distributions/aws/aws-alb-ingress-controller/base
 # Envoy filter
-- ../../../distributions/aws/aws-istio-envoy-filter/base | kubectl apply -f -
+- ../../../distributions/aws/aws-istio-envoy-filter/base

--- a/examples/aws/rds-s3/README.md
+++ b/examples/aws/rds-s3/README.md
@@ -14,11 +14,12 @@ The following steps show how to configure and deploy:
 ### 1. Prerequisites
 
 1. Install CLI tools
-    - [eksctl](https://eksctl.io/introduction/#installation)
-    - [kubectl](https://kubernetes.io/docs/tasks/tools)
-    - [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/)
-    - [awscli](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
-    - [yq](https://github.com/mikefarah/yq/#install)
+    - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) - A command line tool for interacting with AWS services.
+    - [eksctl](https://eksctl.io/introduction/#installation) - A command line tool for working with EKS clusters.
+    - [kubectl](https://kubernetes.io/docs/tasks/tools) - A command line tool for working with Kubernetes clusters.
+    - [yq](https://mikefarah.gitbook.io/yq) - A command line tool for YAML processing. (For Linux environments, use the [wget plain binary installation](https://mikefarah.gitbook.io/yq/#wget))
+    - [jq](https://stedolan.github.io/jq/download/) - A command line tool for processing JSON.
+    - [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) - A command line tool to customize Kubernetes objects through a kustomization file.
 
 2. Clone the repo and checkout the `v1.3-branch` branch
 
@@ -65,66 +66,49 @@ Follow this [doc](https://www.kubeflow.org/docs/distributions/aws/customizing-aw
 
 ### 2. Configure Kubeflow Pipelines
 
-1. Go to the pipelines manifest directory `<KUBEFLOW_MANIFESTS_REPO_PATH>/apps/pipeline/upstream/env/aws`
-```
-cd <KUBEFLOW_MANIFESTS_REPO_PATH>/apps/pipeline/upstream/env/aws/
-```
+1. Configure the following files in `apps/pipeline/upstream/env/aws` directory:
 
-2. Configure `params.env` with the RDS endpoint URL, S3 bucket name, and S3 bucket region that were configured when following the steps in [Create RDS Instance](#create-rds-instance) and [Create S3 Bucket](#create-s3-bucket). 
+    1. Configure `apps/pipeline/upstream/env/aws/params.env` file with the RDS endpoint URL, S3 bucket name, and S3 bucket region that were configured when following the steps in [Create RDS Instance](#create-rds-instance) and [Create S3 Bucket](#create-s3-bucket). 
+        - For example, if your RDS endpoint URL is `rm12abc4krxxxxx.xxxxxxxxxxxx.us-west-2.rds.amazonaws.com`, S3 bucket name is `kf-aws-demo-bucket`, and s3 bucket region is `us-west-2` your `params.env` file should look like:
+        - ```
+          dbHost=rm12abc4krxxxxx.xxxxxxxxxxxx.us-west-2.rds.amazonaws.com
 
-- For example if your RDS endpoint URL is `rm12abc4krxxxxx.xxxxxxxxxxxx.us-west-2.rds.amazonaws.com`, S3 bucket name is `kf-aws-demo-bucket`, and s3 bucket region is `us-west-2` your `params.env` file should look like:
-
-```
-dbHost=rm12abc4krxxxxx.xxxxxxxxxxxx.us-west-2.rds.amazonaws.com
-
-bucketName=kf-aws-demo-bucket
-minioServiceHost=s3.amazonaws.com
-minioServiceRegion=us-west-2
-```
-
-3. Configure `secret.env` with your RDS database username and password that were configured when following the steps in [Create RDS Instance](#create-rds-instance). 
-
-- For example if your username is `admin` and your password is `Kubefl0w` then your `secret.env` file should look like:
-
-```
-username=admin
-password=Kubefl0w
-```
-
-4. Configure `minio-artifact-secret-patch.env` with your AWS credentials. These need to be long term credentials from an IAM user and not temporary. 
-
-Find more details about configuring/getting your AWS credentials here:
-https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
-
-```
-accesskey=AXXXXXXXXXXXXXXXXXX6
-secretkey=eXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXq
-```
+          bucketName=kf-aws-demo-bucket
+          minioServiceHost=s3.amazonaws.com
+          minioServiceRegion=us-west-2
+          ```
+    1. Configure `apps/pipeline/upstream/env/aws/secret.env` file with your RDS database username and password that were configured when following the steps in [Create RDS Instance](#create-rds-instance).
+        - For example, if your username is `admin` and your password is `Kubefl0w` then your `secret.env` file should look like:
+        - ```
+          username=admin
+          password=Kubefl0w
+          ```
+    1. Configure `apps/pipeline/upstream/env/aws/minio-artifact-secret-patch.env` file with your AWS credentials. These need to be long term credentials from an IAM user and not temporary. 
+        - Find more details about configuring/getting your AWS credentials here:
+        https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
+        - ```
+          accesskey=AXXXXXXXXXXXXXXXXXX6
+          secretkey=eXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXq
+          ```
 
 ### 3. Configure Katib
 
 
-1. Go to the katib manifests directory `apps/katib/upstream/installs/katib-external-db-with-kubeflow`
-```
-cd <KUBEFLOW_MANIFESTS_REPO_PATH>/apps/katib/upstream/installs/katib-external-db
-```
-
-2. Configure `secrets.env` with the RDS DB name, RDS endpoint URL, RDS DB port, and RDS DB credentials that were configured when following the steps in [Create RDS Instance](#create-rds-instance).
-
-- For example if your database name is `KubeflowRDS`, your endpoint URL is `rm12abc4krxxxxx.xxxxxxxxxxxx.us-west-2.rds.amazonaws.com`, your DB port is `3306`, your DB username is `admin`, and your DB password is `Kubefl0w` your `secrets.env` file should look like:
-```
-KATIB_MYSQL_DB_DATABASE=KubeflowRDS1
-KATIB_MYSQL_DB_HOST=rm12abc4krxxxxx.xxxxxxxxxxxx.us-west-2.rds.amazonaws.com
-KATIB_MYSQL_DB_PORT=3306
-DB_USER=admin
-DB_PASSWORD=Kubefl0w
-```
+1. Configure the `apps/katib/upstream/installs/katib-external-db-with-kubeflow/secrets.env` file with the RDS DB name, RDS endpoint URL, RDS DB port, and RDS DB credentials that were configured when following the steps in [Create RDS Instance](#create-rds-instance).
+    - For example, if your database name is `KubeflowRDS`, your endpoint URL is `rm12abc4krxxxxx.xxxxxxxxxxxx.us-west-2.rds.amazonaws.com`, your DB port is `3306`, your DB username is `admin`, and your DB password is `Kubefl0w` your `secrets.env` file should look like:
+    - ```
+      KATIB_MYSQL_DB_DATABASE=kubeflow
+      KATIB_MYSQL_DB_HOST=rm12abc4krxxxxx.xxxxxxxxxxxx.us-west-2.rds.amazonaws.com
+      KATIB_MYSQL_DB_PORT=3306
+      DB_USER=admin
+      DB_PASSWORD=Kubefl0w
+      ```
 
 
 ### 4. Install using the following command:
 
 ```sh
-while ! kustomize build . | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+while ! kustomize build examples/aws/rds-s3 | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
 ```
 
 Once, everything is installed successfully, you can access the Kubeflow Central Dashboard [by logging in to your cluster](../../../README.md#connect-to-your-kubeflow-cluster).
@@ -137,7 +121,7 @@ Congratulations! You can now start experimenting and running your end-to-end ML 
 Run the following command to uninstall:
 
 ```sh
-kustomize build . | kubectl delete -f -
+kustomize build examples/aws/rds-s3 | kubectl delete -f -
 ```
 
 

--- a/examples/generic/kustomization.yaml
+++ b/examples/generic/kustomization.yaml
@@ -3,60 +3,60 @@ kind: Kustomization
 
 resources:
 # Cert-Manager
-- ../../../common/cert-manager/cert-manager/base
-- ../../../common/cert-manager/kubeflow-issuer/base
+- ../../common/cert-manager/cert-manager/base
+- ../../common/cert-manager/kubeflow-issuer/base
 # Istio
-- ../../../common/istio-1-9/istio-crds/base
-- ../../../common/istio-1-9/istio-namespace/base
-- ../../../common/istio-1-9/istio-install/base
+- ../../common/istio-1-9/istio-crds/base
+- ../../common/istio-1-9/istio-namespace/base
+- ../../common/istio-1-9/istio-install/base
 # OIDC Authservice
-- ../../../common/oidc-authservice/base
+- ../../common/oidc-authservice/base
 # Dex
-- ../../../common/dex/overlays/istio
+- ../../common/dex/overlays/istio
 # KNative
-- ../../../common/knative/knative-serving/base
-- ../../../common/knative/knative-eventing/base
-- ../../../common/istio-1-9/cluster-local-gateway/base
+- ../../common/knative/knative-serving/base
+- ../../common/knative/knative-eventing/base
+- ../../common/istio-1-9/cluster-local-gateway/base
 # Kubeflow namespace
-- ../../../common/kubeflow-namespace/base
+- ../../common/kubeflow-namespace/base
 # Kubeflow Roles
-- ../../../common/kubeflow-roles/base
+- ../../common/kubeflow-roles/base
 # Kubeflow Istio Resources
-- ../../../common/istio-1-9/kubeflow-istio-resources/base
+- ../../common/istio-1-9/kubeflow-istio-resources/base
 
 
 # Kubeflow Pipelines
-- ../../../apps/pipeline/upstream/env/platform-agnostic-multi-user
+- ../../apps/pipeline/upstream/env/platform-agnostic-multi-user
 # KFServing
-- ../../../apps/kfserving/upstream/overlays/kubeflow
+- ../../apps/kfserving/upstream/overlays/kubeflow
 # Katib
-- ../../../apps/katib/upstream/installs/katib-with-kubeflow
+- ../../apps/katib/upstream/installs/katib-with-kubeflow
 # Central Dashboard
-- ../../../apps/centraldashboard/upstream/overlays/istio
+- ../../apps/centraldashboard/upstream/overlays/istio
 # Admission Webhook
-- ../../../apps/admission-webhook/upstream/overlays/cert-manager
+- ../../apps/admission-webhook/upstream/overlays/cert-manager
 # Notebook Controller
-- ../../../apps/jupyter/jupyter-web-app/upstream/overlays/istio
+- ../../apps/jupyter/jupyter-web-app/upstream/overlays/istio
 # Jupyter Web App
-- ../../../apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+- ../../apps/jupyter/notebook-controller/upstream/overlays/kubeflow
 # Profiles + KFAM
-- ../../../apps/profiles/upstream/overlays/kubeflow
+- ../../apps/profiles/upstream/overlays/kubeflow
 # Volumes Web App
-- ../../../apps/volumes-web-app/upstream/overlays/istio
+- ../../apps/volumes-web-app/upstream/overlays/istio
 # Tensorboards Web App
-- ../../../apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+- ../../apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
 # Tensorboard Controller
--  ../../../apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+-  ../../apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
 # TFJob Operator
-- ../../../apps/tf-training/upstream/overlays/kubeflow
+- ../../apps/tf-training/upstream/overlays/kubeflow
 # Pytorch Operator
-- ../../../apps/pytorch-job/upstream/overlays/kubeflow
+- ../../apps/pytorch-job/upstream/overlays/kubeflow
 # MPI Operator
-- ../../../apps/mpi-job/upstream/overlays/kubeflow
+- ../../apps/mpi-job/upstream/overlays/kubeflow
 # MXNet Operator
-- ../../../apps/mxnet-job/upstream/overlays/kubeflow
+- ../../apps/mxnet-job/upstream/overlays/kubeflow
 # XGBoost Operator
-- ../../../apps/xgboost-job/upstream/overlays/kubeflow
+- ../../apps/xgboost-job/upstream/overlays/kubeflow
 
 # User namespace
-- ../../../common/user-namespace/base
+- ../../common/user-namespace/base


### PR DESCRIPTION
### Description of your changes:
- Update `kustomization.yaml` for single-line installation in cognito and all combined
- Update the rds-s3 instructions with the directory customer is expected to be in
- Add missing pre-req `jq`
- Add command to tag all subnets in cognito instructions