### PR TITLE
Simplify a few sections in Cognito README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kubeflow Manifests
 
+This repository is forked from the [manifests repository under Kubeflow](https://github.com/kubeflow/manifests) to develop and validate Kubeflow on AWS. You can find the instructions to deploy Kubeflow with AWS managed service integrations under [examples/aws](examples/aws) directory. 
+
 ## Kubeflow Table of Contents
 
 <!-- toc -->
@@ -16,8 +18,6 @@
 
 <!-- tocstop -->
 ## Overview
-
-TODO: change overview
 
 This repo is owned by the [Manifests Working Group](https://github.com/kubeflow/community/blob/master/wg-manifests/charter.md).
 If you are a contributor authoring or editing the packages please see [Best Practices](./docs/KustomizeBestPractices.md).

--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -10,3 +10,5 @@ Installation steps can be found [here](rds-s3)
 ## Components configured for Cognito
 Installation steps can be found [here](cognito)
 
+## Components configured for Cognito, RDS and S3
+Installation steps can be found [here](cognito-rds-s3)

--- a/examples/aws/cognito-rds-s3/README.md
+++ b/examples/aws/cognito-rds-s3/README.md
@@ -21,18 +21,18 @@ Follow the [Configure Katib](../rds-s3/README.md#3-configure-katib) section from
 
 ## Configure Custom Domain and Cognito
 
-1. Follow the [cognito guide](../cognito/README.md#10-custom-domain) from [section 1.0(Custom Domain)](../cognito/README.md#10-custom-domain) upto step 4 of [section 4.0(Building manifests and deploying Kubeflow)](../cognito/README.md#40-building-manifests-and-deploying-kubeflow) i.e. *Setup resources required for ALB controller* (complete this section) to:
+1. Follow the [cognito guide](../cognito/README.md#10-custom-domain) from [section 1.0(Custom Domain)](../cognito/README.md#10-custom-domain) upto [section 4.0(Configure Ingress)](../cognito/README.md#40-configure-ingress) to:
     1. Create a custom domain
     1. Create TLS certificates for the domain
     1. Create a Cognito Userpool
-    1. Configuring Ingress and ALB
+    1. Configure Ingress
 2. Deploy Kubeflow. Choose one of the two options to deploy kubeflow:
     1. **[Option 1]** Install with a single command
-    ```
-    while ! kustomize build examples/aws/cognito-rds-s3 | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
-    ```
+        ```
+        while ! kustomize build examples/aws/cognito-rds-s3 | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+        ```
     1. **[Option 2]** Install individual components
-    ```
+        ```
         # Kubeflow namespace
         kustomize build common/kubeflow-namespace/base | kubectl apply -f -
         
@@ -114,7 +114,7 @@ Follow the [Configure Katib](../rds-s3/README.md#3-configure-katib) section from
         # Envoy filter
         kustomize build distributions/aws/aws-istio-envoy-filter/base | kubectl apply -f -        
         ```
-1. Follow the rest of the cognito guide from [section 5.0(Updating the domain with ALB address)](../cognito/README.md#50-updating-the-domain-with-ALB-address) to:
+1. Follow the rest of the cognito guide from [section 6.0(Updating the domain with ALB address)](../cognito/README.md#60-updating-the-domain-with-ALB-address) to:
     1. Add/Update the DNS records in custom domain with the ALB address
     1. Create a profile for a user from the Cognito user pool
     1. Connect to the central dashboard

--- a/examples/aws/cognito/README.md
+++ b/examples/aws/cognito/README.md
@@ -1,6 +1,6 @@
 # Deploying Kubeflow with AWS Cognito as idP
 
-This guide describes how to deploy Kubeflow on AWS EKS using Cognito as identity provider.
+This guide describes how to deploy Kubeflow on AWS EKS using Cognito as identity provider. Kubeflow uses Istio to manage internal traffic. In this guide we will be creating an Ingress to manage external traffic to the Kubernetes services and an Application Load Balancer(ALB) to provide public DNS and enable TLS authentication at the load balancer. We will also be creating a custom domain to host Kubeflow since certificates(needed for TLS) for ALB's public DNS names are not supported.
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ This guide assumes that you have:
     - [jq](https://stedolan.github.io/jq/download/) - A command line tool for processing JSON.
     - [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) - A command line tool to customize Kubernetes objects through a kustomization file.
 
-2. Created an EKS cluster
+1. Created an EKS cluster
     - If you do not have an existing cluster, run the following command to create an EKS cluster. More details about cluster creation via `eksctl` can be found [here](https://eksctl.io/usage/creating-and-managing-clusters/).
     - Substitute values for the CLUSTER_NAME and CLUSTER_REGION in the script below
         ```
@@ -31,9 +31,9 @@ This guide assumes that you have:
         --nodes-max 10 \
         --managed
         ```
-3. AWS IAM permissions to create roles and attach policies to roles.
+1. AWS IAM permissions to create roles and attach policies to roles.
 
-4. Clone the `awslabs/kubeflow-manifest` repo.
+1. Clone the `awslabs/kubeflow-manifest` repo.
     1. ```
         git clone https://github.com/awslabs/kubeflow-manifests.git
         cd kubeflow-manifests
@@ -45,46 +45,44 @@ Register a domain in any domain provider like [Route 53](https://docs.aws.amazon
 
 1. Goto Route53 and create a subdomain to host kubeflow:
     1. Create a hosted zone for the desired subdomain e.g. `platform.example.com`.
-    2. Copy the value of NS type record from the subdomain hosted zone (`platform.example.com`)
+    1. Copy the value of NS type record from the subdomain hosted zone (`platform.example.com`)
         1. ![subdomain-NS](./images/subdomain-NS.png)
-    3. Create a `NS` type of record in the root `example.com` hosted zone for the subdomain `platform.example.com`.
+    1. Create a `NS` type of record in the root `example.com` hosted zone for the subdomain `platform.example.com`.
         1. ![root-domain-NS-creating-NS](./images/root-domain-NS-creating-NS.png)
-        2.  Following is a screenshot of the record after creation in `example.com` hosted zone.
+        1.  Following is a screenshot of the record after creation in `example.com` hosted zone.
             1. ![root-domain-NS-created](./images/root-domain-NS-created.png)
-2. From this step onwards, we will be creating/updating the DNS records **only in the subdomain**. All the screenshots of hosted zone in the following sections/steps of this guide are for the subdomain.
-3. In order to make Cognito to use custom domain name, A record is required to resolve `platform.example.com` as root domain, which can be a Route53 Alias to the ALB as well. Create a new record of type `A` with an arbitrary IP for now. Once we have ALB created, we will update the value later.
+1. From this step onwards, we will be creating/updating the DNS records **only in the subdomain**. All the screenshots of hosted zone in the following sections/steps of this guide are for the subdomain.
+1. In order to make Cognito to use custom domain name, A record is required to resolve `platform.example.com` as root domain, which can be a Route53 Alias to the ALB as well. Create a new record of type `A` with an arbitrary IP for now. Once we have ALB created, we will update the value later.
     1. Following is a screenshot of `platform.example.com` hosted zone. A record is shown. 
         1. ![subdomain-initial-A-record](./images/subdomain-initial-A-record.png)
 
 ## 2.0 Certificate
 
-Create certificates in Certificate Manager for each `*.example.com` and `*.platform.example.com` in respective order by following [this document](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html#request-public-console).
+In this section, we will be creating certificate to enable TLS authentication at Application Load Balancer. Create the certificates for the domains in the regions mentioned below by following [this document](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html#request-public-console) in the specified order.
 
-> **Note:** 
-> 1. The ceritificates are valid only after successful [validation of domain ownership](https://docs.aws.amazon.com/acm/latest/userguide/domain-ownership-validation.html)
-> 2. If you choose DNS validation for the validation of the certificates(as in this guide), you will be asked to create a CNAME type record in the hosted zone.
+> **Note:**
+> - The ceritificates are valid only after successful [validation of domain ownership](https://docs.aws.amazon.com/acm/latest/userguide/domain-ownership-validation.html)
+    - Following is a screenshot showing a certificate has been issued. Note: Status turns to `Issued` after few minutes of validation.
+        - ![successfully-issued-certificate](./images/successfully-issued-certificate.png)
+> - If you choose DNS validation for the validation of the certificates, you will be asked to create a CNAME type record in the hosted zone.
+    - Following is a screenshot of CNAME record of the certificate in `platform.example.com` hosted zone for DNS validation:
+            - ![DNS-record-for-certificate-validation](./images/DNS-record-for-certificate-validation.png)    
 
-Repeat the following step for `*.example.com` and `*.platform.example.com`:
-1. Create the first certificate in N.Virginia (us-east-1). That is because [Cognito requires](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html) a certificate in N.Virginia in order to have a custom domain for a user pool.
-    1. Following is a screenshot of CNAME record of the certificate in `platform.example.com` hosted zone for DNS validation:
-        1. ![DNS-record-for-certificate-validation](./images/DNS-record-for-certificate-validation.png)
-    2. Following is a screenshot showing a certificate has been issued after DNS validation. Note: Status turns to `Issued` after few minutes of creating the record in hosted zone.
-        1. ![successfully-issued-certificate](./images/successfully-issued-certificate.png)
-
-Follow this step only for `*.platform.example.com`:
-1. Create another certificate in the region where your platform will be running(i.e. EKS cluster region). This required by the ingress-gateway in case the platform does not run in N.Virginia, in this example, Oregon.
+1. Create a certificate in N.Virginia (us-east-1) for `*.example.com`.
+1. Create a certificate in N.Virginia (us-east-1) for `*.platform.example.com`. That is because [Cognito requires](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html) a certificate in N.Virginia in order to have a custom domain for a user pool.
+1. Create a certificate for `*.platform.example.com` in the region where your platform will be running(i.e. EKS cluster region). This required by the ingress-gateway in case the platform does not run in N.Virginia, in this example, Oregon.
 
 ## 3.0 Cognito User Pool
 
 1. Create a user pool in Cognito in the same region as your EKS cluster. Type a pool name and choose `Review defaults` and `Create pool`.
-2. Create some users in `Users and groups`, these are the users who will login to the central dashboard.
+1. Create some users in `Users and groups`, these are the users who will login to the central dashboard.
     1. ![cognito-user-pool-created](./images/cognito-user-pool-created.png)
-3. Add an `App client` with any name and the default options.
+1. Add an `App client` with any name and the default options.
     1. ![cognito-app-client-id](./images/cognito-app-client-id.png)
-4. In the `App client settings`, select `Authorization code grant` flow under OAuth-2.0 and check box `email`, `openid`, `aws.cognito.signin.user.admin` and `profile` scopes. Also check box `Enabled Identity Providers`. 
-    1. Use `https://kubeflow.platform.example.com/oauth2/idpresponse` in the Callback URL(s).
+1. In the `App client settings`, select `Authorization code grant` flow under OAuth-2.0 and check box `email`, `openid`, `aws.cognito.signin.user.admin` and `profile` scopes. Also check box `Enabled Identity Providers`. 
+    1. Substitute `example.com` in this URL - `https://kubeflow.platform.example.com/oauth2/idpresponse` with your domain and use it as the Callback URL(s).
     2. ![cognito-app-client-settings](./images/cognito-app-client-settings.png)
-5. In the `Domain name` choose `Use your domain`, type `auth.platform.example.com` and select the `*.platform.example.com` AWS managed certificate you’ve created in N.Virginia. Creating domain takes up to 15 mins.
+1. In the `Domain name` choose `Use your domain`, type `auth.platform.example.com` and select the `*.platform.example.com` AWS managed certificate you’ve created in N.Virginia. Creating domain takes up to 15 mins.
     1. ![cognito-active-domain](./images/cognito-active-domain.png)
     2. When it’s created, it will return the `Alias target` CloudFront address.
         1. Screenshot of the CloudFront URL for Cognito Domain name:
@@ -94,12 +92,12 @@ Follow this step only for `*.platform.example.com`:
             2. ![cognito-domain-cloudfront-A-record-creating](./images/cognito-domain-cloudfront-A-record-creatin.png)
             3. Following is a screenshot of the A record for `auth.platform.example.com` in `platform.example.com` hosted zone:
                 1. ![cognito-domain-cloudfront-A-record-created](./images/cognito-domain-cloudfront-A-record-created.png)
-6. Take note of the following values:
+1. Take note of the following values:
     1. The Pool ARN of the user pool found in Cognito general settings.
-    2. The App client id, found in Cognito App clients.
-    3. The custom user pool domain (e.g. `auth.platform.example.com`), found in the Cognito domain name.
-    4. The ARN of the certificate from the Certificate Manager in the region where your platform (for the subdomain) in the region where your platform is running.
-    5. Export the values:
+    1. The App client id, found in Cognito App clients.
+    1. The custom user pool domain (e.g. `auth.platform.example.com`), found in the Cognito domain name.
+    1. The ARN of the certificate from the Certificate Manager in the region where your platform (for the subdomain) in the region where your platform is running.
+    1. Export the values:
         1. ```
             export CognitoUserPoolArn=<>
             export CognitoAppClientId=<>
@@ -107,7 +105,7 @@ Follow this step only for `*.platform.example.com`:
             export certArn=<>
             ```
 
-## 4.0 Building manifests and deploying Kubeflow
+## 4.0 Configure Ingress
 
 1. Verify you are connected to right cluster, cluster has compute and the aws region is set to the region of cluster.
     1. Substitute the value of CLUSTER_REGION below
@@ -115,7 +113,7 @@ Follow this step only for `*.platform.example.com`:
         export CLUSTER_REGION=<>
         aws configure set region $CLUSTER_REGION
         ```
-    2. Substitute the value of CLUSTER_NAME below
+    1. Substitute the value of CLUSTER_NAME below
         ```
         export CLUSTER_NAME=<>   
         # Display the current cluster kubeconfig points to
@@ -123,7 +121,12 @@ Follow this step only for `*.platform.example.com`:
         kubectl get nodes
         aws eks describe-cluster --name $CLUSTER_NAME
         ```
-3. Substitute values for setting up Ingress.
+    1. Verify the current directory is the root of the repository by running the following command
+        ```
+        # the output should be <path/to/kubeflow-manifests> directory
+        pwd
+        ```
+1. Substitute values for setting up Ingress.
     1. ```
         printf '
         CognitoUserPoolArn='$CognitoUserPoolArn'
@@ -133,7 +136,7 @@ Follow this step only for `*.platform.example.com`:
         loadBalancerScheme=internet-facing
         ' > distributions/aws/istio-ingress/overlays/cognito/params.env
         ```
-4. Setup resources required for ALB controller
+1. Setup resources required for the application load balancer controller
     1. Make sure all the subnets(public and private) corresponding to the EKS cluster are tagged according to the `Prerequisites` section in this [document](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html). Ignore the requirement to have an existing ALB provisioned on the cluster. We will be deploying ALB controller version 1.1.5 in the later section.
         1. Specifically check if the following tags exist on the subnets:
             1. `kubernetes.io/cluster/cluster-name` (replace `cluster-name` with your cluster name e.g. `kubernetes.io/cluster/my-k8s-cluster`). Add this tag in both private and public subnets. If you created the cluster using eksctl, you might be missing only this tag. Use the following command to tag all subnets by substituting the value of `TAG_VALUE` variable(`owned` or `shared`):
@@ -145,9 +148,9 @@ Follow this step only for `*.platform.example.com`:
                         aws ec2 create-tags --resources ${i} --tags Key=kubernetes.io/cluster/${CLUSTER_NAME},Value=${KIO_TAG_VALUE}
                     done
                     ```
-            2. `kubernetes.io/role/internal-elb`. Add this tag only to private subnet
-            3. `kubernetes.io/role/elb`. Add this tag only to public subnet.
-    2. Create an IAM role to use via service account. [IAM roles for service accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) allows fine-grained roles at the Kubernetes Pod level by combining an OpenID Connect (OIDC) identity provider with Kubernetes Service Account annotations. In this section, we will associate the EKS cluster with an OIDC provider and create an IAM role which will be assumed by the ALB and profiles controller Pod via its Service Account to access AWS services.
+            1. `kubernetes.io/role/internal-elb`. Add this tag only to private subnet
+            1. `kubernetes.io/role/elb`. Add this tag only to public subnet.
+    1. Create an IAM role to use via service account. [IAM roles for service accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) allows fine-grained roles at the Kubernetes Pod level by combining an OpenID Connect (OIDC) identity provider with Kubernetes Service Account annotations. In this section, we will associate the EKS cluster with an OIDC provider and create an IAM role which will be assumed by the ALB and profiles controller Pod via its Service Account to access AWS services.
         1. ```
             # Verify cluster name and region are exported
             echo $CLUSTER_REGION
@@ -192,16 +195,18 @@ Follow this step only for `*.platform.example.com`:
             
             export IAM_ROLE_ARN_FOR_IRSA=$(aws iam get-role --role-name $IRSA_ROLE_NAME --output text --query 'Role.Arn')
             ```
-    3. Annotate the service accounts with the IAM role
+    1. Annotate the service accounts with the IAM role
         1. ```
             yq e '.metadata.annotations."eks.amazonaws.com/role-arn" = env(IAM_ROLE_ARN_FOR_IRSA)' -i distributions/aws/aws-alb-ingress-controller/base/service-account.yaml
             yq e '.metadata.annotations."eks.amazonaws.com/role-arn" = env(IAM_ROLE_ARN_FOR_IRSA)' -i apps/profiles/upstream/manager/service-account.yaml
             ```
-    4. Substitute values for ALB deployment
+    1. Substitute values for ALB deployment
         1. ```
             printf 'clusterName='$CLUSTER_NAME'' > distributions/aws/aws-alb-ingress-controller/base/params.env
             ```
-5. Deploy Kubeflow. Choose one of the two options to deploy kubeflow:
+## 5.0 Building manifests and deploying Kubeflow
+
+1. Deploy Kubeflow. Choose one of the two options to deploy kubeflow:
     1. **[Option 1]** Install with a single command
         ```
         while ! kustomize build examples/aws/cognito | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
@@ -286,7 +291,7 @@ Follow this step only for `*.platform.example.com`:
         kustomize build distributions/aws/aws-istio-envoy-filter/base | kubectl apply -f -
         ```
 
-## 5.0 Updating the domain with ALB address
+## 6.0 Updating the domain with ALB address
 
 1. Check if ALB is provisioned. It takes around 3-5 minutes
     1. ```
@@ -303,7 +308,7 @@ Follow this step only for `*.platform.example.com`:
 1. Screenshot of all the record sets in hosted zone for reference
     1. ![subdomain-records-summary](./images/subdomain-records-summary.png)
 
-## 6.0 Connecting to Central dashboard
+## 7.0 Connecting to Central dashboard
 
 1. The central dashboard should now be available at [https://kubeflow.platform.example.com](https://kubeflow.platform.example.com/). Before connecting to the dashboard, create a profile for a user from the Cognito user pool you created in [section 3.0-2](#30-cognito-user-pool) by [following this guide](https://www.kubeflow.org/docs/components/multi-tenancy/getting-started/#manual-profile-creation). Following is a sample profile for reference:
     1. ```
@@ -319,4 +324,4 @@ Follow this step only for `*.platform.example.com`:
                 # replace with the email of the user
                 name: my_user_email@kubeflow.com
         ```
-2. Open the central dashboard at [https://kubeflow.platform.example.com](https://kubeflow.platform.example.com/). It will redirect to Cognito for login. Use the credentials of the user for which profile was created in previous step.
+1. Open the central dashboard at [https://kubeflow.platform.example.com](https://kubeflow.platform.example.com/). It will redirect to Cognito for login. Use the credentials of the user for which profile was created in previous step.


### PR DESCRIPTION
### Description of your changes:
Cognito readme:
- Added context around why we are creating a custom domain, ALB, Ingress etc.
- Reworded the certificate creation section
- Split section 4.0 of cognito readme to simplify the cognito-rds-s3 readme section references
- updated the callback URL instruction

Main readme:
- Added a pointer in main README to the example directories