### PR TITLE
Storage Options: Using Amazon EFS as Persistent Volume with Kubeflow 1.4

### DIFF
--- a/distributions/aws/aws-efs-csi-driver/base/controller-deployment.yaml
+++ b/distributions/aws/aws-efs-csi-driver/base/controller-deployment.yaml
@@ -1,0 +1,84 @@
+---
+# Source: aws-efs-csi-driver/templates/controller-deployment.yaml
+# Controller Service
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: efs-csi-controller
+  labels:
+    app.kubernetes.io/name: aws-efs-csi-driver
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: efs-csi-controller
+      app.kubernetes.io/name: aws-efs-csi-driver
+      app.kubernetes.io/instance: kustomize
+  template:
+    metadata:
+      labels:
+        app: efs-csi-controller
+        app.kubernetes.io/name: aws-efs-csi-driver
+        app.kubernetes.io/instance: kustomize
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: efs-csi-controller-sa
+      priorityClassName: system-cluster-critical
+      containers:
+        - name: efs-plugin
+          securityContext:
+            privileged: true
+          image: amazon/aws-efs-csi-driver:v1.3.4
+          imagePullPolicy: IfNotPresent
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=2
+            - --delete-access-point-root-dir=false
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          ports:
+            - name: healthz
+              containerPort: 9909
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
+        - name: csi-provisioner
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-18-2
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=2
+            - --feature-gates=Topology=true
+            - --extra-create-metadata
+            - --leader-election
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: liveness-probe
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-2
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --health-port=9909
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          emptyDir: {}

--- a/distributions/aws/aws-efs-csi-driver/base/controller-serviceaccount.yaml
+++ b/distributions/aws/aws-efs-csi-driver/base/controller-serviceaccount.yaml
@@ -1,0 +1,49 @@
+---
+# Source: aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-external-provisioner-role
+  labels:
+    app.kubernetes.io/name: aws-efs-csi-driver
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [ "" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "watch", "list" ]
+---
+# Source: aws-efs-csi-driver/templates/controller-serviceaccount.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-provisioner-binding
+  labels:
+    app.kubernetes.io/name: aws-efs-csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: efs-csi-controller-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: efs-csi-external-provisioner-role
+  apiGroup: rbac.authorization.k8s.io

--- a/distributions/aws/aws-efs-csi-driver/base/csidriver.yaml
+++ b/distributions/aws/aws-efs-csi-driver/base/csidriver.yaml
@@ -1,0 +1,12 @@
+---
+# Source: aws-efs-csi-driver/templates/csidriver.yaml
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: efs.csi.aws.com
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/resource-policy": keep
+spec:
+  attachRequired: false

--- a/distributions/aws/aws-efs-csi-driver/base/kustomization.yaml
+++ b/distributions/aws/aws-efs-csi-driver/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+- node-daemonset.yaml
+- node-serviceaccount.yaml
+- csidriver.yaml
+- controller-deployment.yaml
+- controller-serviceaccount.yaml

--- a/distributions/aws/aws-efs-csi-driver/base/node-daemonset.yaml
+++ b/distributions/aws/aws-efs-csi-driver/base/node-daemonset.yaml
@@ -1,0 +1,132 @@
+---
+# Source: aws-efs-csi-driver/templates/node-daemonset.yaml
+# Node Service
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: efs-csi-node
+  labels:
+    app.kubernetes.io/name: aws-efs-csi-driver
+spec:
+  selector:
+    matchLabels:
+      app: efs-csi-node
+      app.kubernetes.io/name: aws-efs-csi-driver
+      app.kubernetes.io/instance: kustomize
+  template:
+    metadata:
+      labels:
+        app: efs-csi-node
+        app.kubernetes.io/name: aws-efs-csi-driver
+        app.kubernetes.io/instance: kustomize
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+      hostNetwork: true
+      dnsPolicy: ClusterFirst
+      serviceAccountName: efs-csi-node-sa
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: efs-plugin
+          securityContext:
+            privileged: true
+          image: amazon/aws-efs-csi-driver:v1.3.4
+          imagePullPolicy: IfNotPresent
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=2
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:/csi/csi.sock
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+            - name: efs-state-dir
+              mountPath: /var/run/efs
+            - name: efs-utils-config
+              mountPath: /var/amazon/efs
+            - name: efs-utils-config-legacy
+              mountPath: /etc/amazon/efs-legacy
+          ports:
+            - name: healthz
+              containerPort: 9809
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+            failureThreshold: 5
+        - name: csi-driver-registrar
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-18-2
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=2
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/efs.csi.aws.com/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: liveness-probe
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-2
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --health-port=9809
+            - --v=2
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/efs.csi.aws.com/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: efs-state-dir
+          hostPath:
+            path: /var/run/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config
+          hostPath:
+            path: /var/amazon/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config-legacy
+          hostPath:
+            path: /etc/amazon/efs
+            type: DirectoryOrCreate

--- a/distributions/aws/aws-efs-csi-driver/base/node-serviceaccount.yaml
+++ b/distributions/aws/aws-efs-csi-driver/base/node-serviceaccount.yaml
@@ -1,0 +1,8 @@
+---
+# Source: aws-efs-csi-driver/templates/node-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: efs-csi-node-sa
+  labels:
+    app.kubernetes.io/name: aws-efs-csi-driver

--- a/distributions/aws/aws-efs-csi-driver/overlays/stable/ecr/kustomization.yaml
+++ b/distributions/aws/aws-efs-csi-driver/overlays/stable/ecr/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../../base
+images:
+  - name: amazon/aws-efs-csi-driver
+    newName: 602401143452.dkr.ecr.us-west-1.amazonaws.com/eks/aws-efs-csi-driver
+    newTag: v1.3.4
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
+    newTag: v2.2.0
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
+    newTag: v2.1.0
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
+    newTag: v2.1.1

--- a/distributions/aws/aws-efs-csi-driver/overlays/stable/kustomization.yaml
+++ b/distributions/aws/aws-efs-csi-driver/overlays/stable/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+images:
+  - name: amazon/aws-efs-csi-driver
+    newTag: v1.3.4
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+    newTag: v2.2.0-eks-1-18-2
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+    newTag: v2.1.0-eks-1-18-2
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+    newTag: v2.1.1-eks-1-18-2

--- a/examples/aws/storage-efs/README.md
+++ b/examples/aws/storage-efs/README.md
@@ -1,0 +1,214 @@
+# Deploying Kubeflow with AWS EFS as Persistent Storage
+
+This guide describes how to deploy Kubeflow on AWS EKS using EFS as the Persistent Storage. <complete intro>
+
+## Prerequisites
+
+This guide assumes that you have:
+
+1. Installed the following tools on the client machine
+    - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) - A command line tool for interacting with AWS services.
+    - [eksctl](https://eksctl.io/introduction/#installation) - A command line tool for working with EKS clusters.
+    - [kubectl](https://kubernetes.io/docs/tasks/tools) - A command line tool for working with Kubernetes clusters.
+    - [yq](https://mikefarah.gitbook.io/yq) - A command line tool for YAML processing. (For Linux environments, use the [wget plain binary installation](https://mikefarah.gitbook.io/yq/#wget))
+    - [jq](https://stedolan.github.io/jq/download/) - A command line tool for processing JSON.
+    - [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) - A command line tool to customize Kubernetes objects through a kustomization file.
+
+1. set the environment variables - 
+
+        export CLUSTER_NAME=<clustername>
+        export CLUSTER_REGION=<clusterregion>
+        export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+
+1. Created an EKS cluster
+    - If you do not have an existing cluster, run the following command to create an EKS cluster. More details about cluster creation via `eksctl` can be found [here](https://eksctl.io/usage/creating-and-managing-clusters/).
+    - Substitute values for the CLUSTER_NAME and CLUSTER_REGION in the script below
+        ```
+        eksctl create cluster \
+        --name ${CLUSTER_NAME} \
+        --version 1.19 \
+        --region ${CLUSTER_REGION} \
+        --nodegroup-name linux-nodes \
+        --node-type m5.xlarge \
+        --nodes 5 \
+        --nodes-min 1 \
+        --nodes-max 10 \
+        --managed
+        ```
+
+1. AWS IAM permissions to create roles and attach policies to roles.
+
+1. Clone the `awslabs/kubeflow-manifest` repo.
+
+        git clone https://github.com/awslabs/kubeflow-manifests.git
+        cd kubeflow-manifests
+        git checkout v1.4-branch
+
+
+
+## 1.0 Create the IAM Policy for the CSI Driver
+Create an IAM policy that allows the CSI driver's service account to make calls to AWS APIs on your behalf.
+
+a. Download the IAM policy document from GitHub as follows - 
+
+```
+curl -o iam-policy-example.json https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v1.3.2/docs/iam-policy-example.json
+```
+
+b. Create the policy - 
+```
+aws iam create-policy \
+    --policy-name AmazonEKS_EFS_CSI_Driver_Policy \
+    --policy-document file://iam-policy-example.json
+```
+
+c. Create an IAM role and attach the IAM policy to it. Annotate the Kubernetes service account with the IAM role ARN and the IAM role with the Kubernetes service account name. You can create the role using eksctl as follows - 
+
+```
+eksctl create iamserviceaccount \
+    --name efs-csi-controller-sa \
+    --namespace kube-system \
+    --cluster $CLUSTER_NAME \
+    --attach-policy-arn arn:aws:iam::$ACCOUNT_ID:policy/AmazonEKS_EFS_CSI_Driver_Policy \
+    --approve \
+    --override-existing-serviceaccounts \
+    --region $CLUSTER_REGION
+```
+
+
+## 2.0 Configure the EFS CSI Driver Image
+
+In the file `distributions/aws/aws-efs-csi-driver/overlays/stable/ecr/kustomization.yaml` check the image region. If your cluster is not in the us-west-2 region, [replace the image URI with the correct URI for your region](https://docs.aws.amazon.com/eks/latest/userguide/add-ons-images.html). Once you've made the change, save your modified manifest.
+
+
+## 3.0 Building manifests and deploying Kubeflow
+
+Deploy Kubeflow using the following single line installation command -
+
+```
+while ! kustomize build examples/aws/storage-efs | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+```
+
+This should have installed the EFS CSI Driver into the default kube-system namespace for you. You can check using the following command - 
+```
+kubectl get csidriver
+
+NAME              ATTACHREQUIRED   PODINFOONMOUNT   MODES        AGE
+efs.csi.aws.com   false            false            Persistent   5d17h
+```
+
+
+## 4.0 Create an Instance of the EFS Filesystem
+This section creates a new EFS volume using for your cluster. Please refer to the official [AWS Documents](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html) for more details. 
+
+1. Retrieve the VPC ID that your cluster is in and store it in a variable for use in a later step.
+```
+vpc_id=$(aws eks describe-cluster \
+    --name $CLUSTER_NAME\
+    --query "cluster.resourcesVpcConfig.vpcId" \
+    --output text)
+```
+
+2. Retrieve the CIDR range for your cluster's VPC and store it in a variable for use in a later step.
+```
+cidr_range=$(aws ec2 describe-vpcs \
+    --vpc-ids $vpc_id \
+    --query "Vpcs[].CidrBlock" \
+    --output text)
+```
+
+3. Create a security group with an inbound rule that allows inbound NFS traffic for your Amazon EFS mount points.
+    a. Create a security group. 
+    ```
+    security_group_id=$(aws ec2 create-security-group \
+        --group-name MyEfsSecurityGroup \
+        --description "My EFS security group" \
+        --vpc-id $vpc_id \
+        --output text)
+    ```
+
+    b. Create an inbound rule that allows inbound NFS traffic from the CIDR for your cluster's VPC.
+    ```
+    aws ec2 authorize-security-group-ingress \
+        --group-id $security_group_id \
+        --protocol tcp \
+        --port 2049 \
+        --cidr $cidr_range
+    ```
+
+4. Create an Amazon EFS file system for your Amazon EKS cluster.
+```
+file_system_id=$(aws efs create-file-system \
+    --region $CLUSTER_REGION \
+    --performance-mode generalPurpose \
+    --query 'FileSystemId' \
+    --output text)
+```
+
+## 5.0 Create Mount Targets for your cluster
+1. [Optional] If you are re-using an existing EFS Volume, you will first have to delete any old mount targets. You can use the following commands for this - 
+```
+aws efs describe-mount-targets --file-system-id $file_system_id
+aws efs delete-mount-target --mount-target-id <each-id>
+```
+
+2. Determine the IP address of your cluster nodes.
+```
+kubectl get nodes
+```
+
+3. Determine the IDs of the subnets in your VPC and which Availability Zone the subnet is in.
+```
+aws ec2 describe-subnets \
+    --filters "Name=vpc-id,Values=$vpc_id" \
+    --query 'Subnets[*].{SubnetId: SubnetId,AvailabilityZone: AvailabilityZone,CidrBlock: CidrBlock}' \
+    --output table
+```
+
+4. Add mount targets for the subnets that your nodes are in. If are more than 1 nodes in the cluster, you'd run the command once for a subnet in each AZ that you had a node in, replacing subnet-EXAMPLEe2ba886490 with the appropriate subnet ID from the previous command
+```
+aws efs create-mount-target \
+    --file-system-id $file_system_id \
+    --security-groups $security_group_id \
+    --subnet-id subnet-EXAMPLEe2ba886490
+```
+
+
+## 6.0 Using the EFS Storage in Kubeflow
+
+### Sample 1 - Static Provisioning
+[Using this sample from official AWS Docs](https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/examples/kubernetes/multiple_pods) we have provided the required spec files in the sample subdirectory but you can create the PVC another way. 
+
+1. Use the `$file_system_id` you recorded before or use the following command to get the efs filesystem id - 
+```
+aws efs describe-file-systems --query "FileSystems[*].FileSystemId" --output text
+```
+
+2. Now edit the sample/pv.yaml and edit the `volumeHandle` to point to your EFS filesystem
+
+3. Now create the required persistentvolume, persistentvolumeclaim and storageclass resources as -
+```
+kubectl apply -f examples/aws/storage-efs/sample/pv.yaml
+kubectl apply -f examples/aws/storage-efs/sample/pvc.yaml
+kubectl apply -f examples/aws/storage-efs/sample/sc.yaml
+```
+
+
+## 7.0 Connecting to Central dashboard
+Logon to http://localhost:8080 using default credentials.
+
+## 8.0 Test your Setup
+Check the `Volumes` tab in Kubeflow and you should be able to see your PVC is available for use within Kubeflow as follows - 
+
+### 8.1 Additional Permissions 
+You might need to specify some additional directory permissions on your worker node before you can use these as mount points. The set-permission-job.yaml is an example of how you could set these permissions to be able to use the efs as your workspace in your kubeflow notebook. Edit the spec file as needed for your usecase
+```
+kubectl apply -f examples/aws/storage-efs/sample/set-permission-job.yaml
+```
+
+### 8.2 Using Kubeflow Notebooks
+1. Spin up a new Kubeflow notebook server and specify the name of the PVC to be used as the workspace volume or the data volume and specify your desired mount point. 
+2. In case the server does not start up in the expected time, do make sure to check - 
+    - The Notebook Controller Logs
+    - The specific notebook server instance pod's logs
+

--- a/examples/aws/storage-efs/kustomization.yaml
+++ b/examples/aws/storage-efs/kustomization.yaml
@@ -1,0 +1,55 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+# Cert-Manager
+- ../../../common/cert-manager/cert-manager/base
+- ../../../common/cert-manager/kubeflow-issuer/base
+# Istio
+- ../../../common/istio-1-9/istio-crds/base
+- ../../../common/istio-1-9/istio-namespace/base
+- ../../../common/istio-1-9/istio-install/base
+# OIDC Authservice
+- ../../../common/oidc-authservice/base
+# Dex
+- ../../../common/dex/overlays/istio
+# KNative
+- ../../../common/knative/knative-serving/overlays/gateways
+- ../../../common/knative/knative-eventing/base
+- ../../../common/istio-1-9/cluster-local-gateway/base
+# Kubeflow namespace
+- ../../../common/kubeflow-namespace/base
+# Kubeflow Roles
+- ../../../common/kubeflow-roles/base
+# Kubeflow Istio Resources
+- ../../../common/istio-1-9/kubeflow-istio-resources/base
+# Kubeflow Pipelines
+- ../../../apps/pipeline/upstream/env/platform-agnostic-multi-user
+# KFServing
+- ../../../apps/kfserving/upstream/overlays/kubeflow
+# Katib
+- ../../../apps/katib/upstream/installs/katib-with-kubeflow
+# Central Dashboard
+- ../../../apps/centraldashboard/upstream/overlays/istio
+# Admission Webhook
+- ../../../apps/admission-webhook/upstream/overlays/cert-manager
+# Notebook Controller
+- ../../../apps/jupyter/jupyter-web-app/upstream/overlays/istio
+# Jupyter Web App
+- ../../../apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+# Profiles + KFAM
+- ../../../apps/profiles/upstream/overlays/kubeflow
+# Volumes Web App
+- ../../../apps/volumes-web-app/upstream/overlays/istio
+# Tensorboards Web App
+-  ../../../apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+# Tensorboard Controller
+-  ../../../apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+# Training Operator
+- ../../../apps/training-operator/upstream/overlays/kubeflow
+
+# User namespace
+- ../../../common/user-namespace/base
+
+# Configured for AWS EFS 
+- ../../../distributions/aws/aws-efs-csi-driver/overlays/stable/ecr

--- a/examples/aws/storage-efs/sample/pv.yaml
+++ b/examples/aws/storage-efs/sample/pv.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: efs-pv
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: efs-sc
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: <fs-idxxxxx>

--- a/examples/aws/storage-efs/sample/pvc.yaml
+++ b/examples/aws/storage-efs/sample/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: efs-claim
+  namespace: kubeflow-user-example-com
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: efs-sc
+  resources:
+    requests:
+      storage: 5Gi

--- a/examples/aws/storage-efs/sample/sc.yaml
+++ b/examples/aws/storage-efs/sample/sc.yaml
@@ -1,0 +1,5 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com

--- a/examples/aws/storage-efs/sample/set-permission-job.yaml
+++ b/examples/aws/storage-efs/sample/set-permission-job.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: set-permission
+  namespace: kubeflow-user-example-com
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: app
+        image: centos
+        command: ["/bin/sh"]
+        args:
+        - "-c"
+        - "chmod 2775 /data && chown root:users /data"
+        volumeMounts:
+        - name: persistent-storage
+          mountPath: /data
+      volumes:
+      - name: persistent-storage
+        persistentVolumeClaim:
+          claimName: efs-claim

--- a/examples/aws/storage-efs/training-sample/Dockerfile
+++ b/examples/aws/storage-efs/training-sample/Dockerfile
@@ -1,0 +1,4 @@
+FROM public.ecr.aws/c9e4w0g3/notebook-servers/jupyter-tensorflow:2.6.0-cpu-py38
+
+COPY training.py /
+ENTRYPOINT ["python", "/training.py"]

--- a/examples/aws/storage-efs/training-sample/tfjob.yaml
+++ b/examples/aws/storage-efs/training-sample/tfjob.yaml
@@ -1,0 +1,24 @@
+apiVersion: kubeflow.org/v1
+kind: TFJob
+metadata:
+  name: image-classification-pvc
+  namespace: kubeflow-user-example-com
+spec:
+  runPolicy:
+    cleanPodPolicy: None
+  tfReplicaSpecs:
+    Worker:
+      replicas: 2
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: tensorflow
+              image: <dockerimage:tag>
+              volumeMounts:
+                - mountPath: /train
+                  name: training
+          volumes:
+            - name: training
+              persistentVolumeClaim:
+                claimName: efs-claim

--- a/examples/aws/storage-efs/training-sample/training.py
+++ b/examples/aws/storage-efs/training-sample/training.py
@@ -1,0 +1,73 @@
+# Source: https://www.tensorflow.org/tutorials/load_data/images
+import numpy as np
+import tensorflow as tf
+
+from tensorflow import keras
+from tensorflow.keras import layers
+from tensorflow.keras.models import Sequential
+
+DATA_DIR = "/train/.keras/datasets/flower_photos"
+IMG_HEIGHT = 180
+IMG_WIDTH = 180
+BATCH_SIZE = 32
+
+def create_model(num_classes):
+    model = Sequential([
+    layers.Rescaling(1./255, input_shape=(IMG_HEIGHT, IMG_WIDTH, 3)),
+    layers.Conv2D(16, 3, padding='same', activation='relu'),
+    layers.MaxPooling2D(),
+    layers.Conv2D(32, 3, padding='same', activation='relu'),
+    layers.MaxPooling2D(),
+    layers.Conv2D(64, 3, padding='same', activation='relu'),
+    layers.MaxPooling2D(),
+    layers.Flatten(),
+    layers.Dense(128, activation='relu'),
+    layers.Dense(num_classes)
+    ])
+
+    model.compile(optimizer='adam',
+                loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+                metrics=['accuracy'])
+
+    # Print the model details
+    model.summary()
+
+    return model
+
+def get_data_split(subset_type):
+    ds = tf.keras.utils.image_dataset_from_directory(
+    DATA_DIR,
+    validation_split=0.2,
+    subset=subset_type,
+    seed=123,
+    image_size=(IMG_HEIGHT, IMG_WIDTH),
+    batch_size=BATCH_SIZE)
+
+    return ds
+
+def main():    
+    # Define the datasets based on images already loaded onto the EFS Volume
+    train_ds = get_data_split("training")
+    val_ds = get_data_split("validation")
+
+    class_names = train_ds.class_names
+    print(class_names)
+
+    AUTOTUNE = tf.data.AUTOTUNE
+    train_ds = train_ds.cache().shuffle(1000).prefetch(buffer_size=AUTOTUNE)
+    val_ds = val_ds.cache().prefetch(buffer_size=AUTOTUNE)
+
+    # Define and Compile the model
+    num_classes = len(class_names)
+    model = create_model(num_classes)
+
+    # Training
+    epochs = 2
+    history = model.fit(
+    train_ds,
+    validation_data=val_ds,
+    epochs=epochs
+    )
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Adds the option to use Amazon EFS as Storage with Kubeflow 1.4

**Description of your changes:**
This is an initial PR with the following changes - 
1. Pulls in the latest stable version of the Amazon EFS CSI Driver from the upstream repo - https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/release-1.3/deploy/kubernetes
2. Adds the `examples/aws/storage-efs/kustomization.yaml` file for one line install with the CSI Driver.
3. Adds the README with complete steps to create the required IAM Policy, create an instance of the EFS Volume and mount targets, install the driver using the manifest. 
4. The `examples/aws/storage-efs/sample` directory includes 4 spec files to demonstrate creating a persistentVolume, PersistentVolumeClaim, StorageClass and the README has instructions on how to use the same for static provisioning and usage via the Kubeflow Notebooks. 
5. Also Includes a file to edit the directory permissions as required to be able to use it via Notebooks.  
6. Adds a sample TFjob which uses data from the mounted EFS Volume

**Testing Done:**
1. Tested I can use as a workspace volume in a kubeflow notebook across multiple clusters.
2. Tested that I can run a TFJob using data already downloaded to the EFS Volume using the previous notebook. 
3. Both samples provided in the README

**TBD:**
1. Add Steps for dynamic provisioning
3. Unit Tests 


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
