### PR TITLE
Utilize aws secrets manager for RDS and Minio

### DIFF
--- a/apps/pipeline/upstream/env/aws/disable-default-secrets.yaml
+++ b/apps/pipeline/upstream/env/aws/disable-default-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-secret
+$patch: delete
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mlpipeline-minio-artifact
+$patch: delete

--- a/apps/pipeline/upstream/env/aws/kustomization.yaml
+++ b/apps/pipeline/upstream/env/aws/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
+resources:
+- secrets-manager.yaml
+- secrets-mount.yaml
 bases:
 - ../../env/platform-agnostic-multi-user
 configMapGenerator:
@@ -15,16 +18,10 @@ configMapGenerator:
   behavior: replace
   files:
   - viewer-pod-template.json
-secretGenerator:
-- name: mysql-secret
-  env: secret.env
-  behavior: merge
-- name: mlpipeline-minio-artifact
-  env: minio-artifact-secret-patch.env
-  behavior: merge
 generatorOptions:
   disableNameSuffixHash: true
 patchesStrategicMerge:
+- disable-default-secrets.yaml
 - aws-configuration-patch.yaml
 # Identifier for application manager to apply ownerReference.
 # The ownerReference ensures the resources get garbage collected

--- a/apps/pipeline/upstream/env/aws/minio-artifact-secret-patch.env
+++ b/apps/pipeline/upstream/env/aws/minio-artifact-secret-patch.env
@@ -1,2 +1,0 @@
-accesskey=YOUR_AWS_ACCESS_ID
-secretkey=YOUR_AWS_SECRET_KEY

--- a/apps/pipeline/upstream/env/aws/secret.env
+++ b/apps/pipeline/upstream/env/aws/secret.env
@@ -1,2 +1,0 @@
-username=YOUR_RDS_USERNAME
-password=YOUR_RDS_PASSWORD

--- a/apps/pipeline/upstream/env/aws/secrets-manager.yaml
+++ b/apps/pipeline/upstream/env/aws/secrets-manager.yaml
@@ -1,0 +1,36 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: aws-secrets
+  namespace: kubeflow
+spec:
+  provider: aws   
+  secretObjects:
+  - secretName: mysql-secret
+    type: Opaque
+    data:
+    - objectName: "user"
+      key: username
+    - objectName: "pass"
+      key: password
+  - secretName: mlpipeline-minio-artifact
+    type: Opaque
+    data:
+    - objectName: "access"
+      key: accesskey
+    - objectName: "secret"
+      key: secretkey
+  parameters:
+    objects: | 
+      - objectName: "kubeflow-secrets"
+        objectType: "secretsmanager"
+        jmesPath:
+            - path: "username"
+              objectAlias: "user"
+            - path: "password"
+              objectAlias: "pass"
+            - path: "accesskey"
+              objectAlias: "access"
+            - path: "secretkey"
+              objectAlias: "secret"
+            

--- a/apps/pipeline/upstream/env/aws/secrets-manager.yaml
+++ b/apps/pipeline/upstream/env/aws/secrets-manager.yaml
@@ -29,7 +29,7 @@ spec:
               objectAlias: "user"
             - path: "password"
               objectAlias: "pass"
-      - objectName: "aws-secrets"
+      - objectName: "s3-secret"
         objectType: "secretsmanager"
         jmesPath:
             - path: "accesskey"

--- a/apps/pipeline/upstream/env/aws/secrets-manager.yaml
+++ b/apps/pipeline/upstream/env/aws/secrets-manager.yaml
@@ -22,15 +22,17 @@ spec:
       key: secretkey
   parameters:
     objects: | 
-      - objectName: "kubeflow-secrets"
+      - objectName: "rds-secret"
         objectType: "secretsmanager"
         jmesPath:
             - path: "username"
               objectAlias: "user"
             - path: "password"
               objectAlias: "pass"
+      - objectName: "aws-secrets"
+        objectType: "secretsmanager"
+        jmesPath:
             - path: "accesskey"
               objectAlias: "access"
             - path: "secretkey"
-              objectAlias: "secret"
-            
+              objectAlias: "secret"           

--- a/apps/pipeline/upstream/env/aws/secrets-mount.yaml
+++ b/apps/pipeline/upstream/env/aws/secrets-mount.yaml
@@ -7,13 +7,22 @@ spec:
   serviceAccountName: kubeflow-secrets-manager-sa
   containers:
   - name: secrets
-    image: nginx:1.14.2
+    image: public.ecr.aws/xray/aws-xray-daemon:latest
     volumeMounts:
-    - name: kubeflow-secrets
-      mountPath: "/mnt/secrets-store"
+    - name: rds-secret
+      mountPath: "/mnt/rds-store"
+      readOnly: true
+    - name: aws-secrets
+      mountPath: "/mnt/aws-store"
       readOnly: true
   volumes:
-    - name: kubeflow-secrets
+    - name: rds-secret
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "aws-secrets"
+    - name: aws-secrets
       csi:
         driver: secrets-store.csi.k8s.io
         readOnly: true

--- a/apps/pipeline/upstream/env/aws/secrets-mount.yaml
+++ b/apps/pipeline/upstream/env/aws/secrets-mount.yaml
@@ -12,7 +12,7 @@ spec:
     - name: rds-secret
       mountPath: "/mnt/rds-store"
       readOnly: true
-    - name: aws-secrets
+    - name: s3-secret
       mountPath: "/mnt/aws-store"
       readOnly: true
   volumes:
@@ -22,7 +22,7 @@ spec:
         readOnly: true
         volumeAttributes:
           secretProviderClass: "aws-secrets"
-    - name: aws-secrets
+    - name: s3-secret
       csi:
         driver: secrets-store.csi.k8s.io
         readOnly: true

--- a/apps/pipeline/upstream/env/aws/secrets-mount.yaml
+++ b/apps/pipeline/upstream/env/aws/secrets-mount.yaml
@@ -1,0 +1,21 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: kubeflow-secrets-pod
+  namespace: kubeflow
+spec:
+  serviceAccountName: kubeflow-secrets-manager-sa
+  containers:
+  - name: secrets
+    image: nginx:1.14.2
+    volumeMounts:
+    - name: kubeflow-secrets
+      mountPath: "/mnt/secrets-store"
+      readOnly: true
+  volumes:
+    - name: kubeflow-secrets
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "aws-secrets"

--- a/distributions/aws/examples/rds-s3/README.md
+++ b/distributions/aws/examples/rds-s3/README.md
@@ -72,7 +72,7 @@ eksctl utils associate-iam-oidc-provider --region=$CLUSTER_REGION --cluster=$CLU
 
 kubectl create namespace kubeflow
 
-eksctl create iamserviceaccount  --name kubeflow-secrets-manager-sa  --namespace kubeflow  --cluster $CLUSTER_NAME --attach-policy-arn \ arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess --attach-policy-arn arn:aws:iam::aws:policy/SecretsManagerReadWrite --override-existing-serviceaccounts   --approve --region $CLUSTER_REGION
+eksctl create iamserviceaccount  --name kubeflow-secrets-manager-sa  --namespace kubeflow  --cluster $CLUSTER_NAME --attach-policy-arn  arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess --attach-policy-arn arn:aws:iam::aws:policy/SecretsManagerReadWrite --override-existing-serviceaccounts   --approve --region $CLUSTER_REGION
 ```
 
 Run these commands to install AWS Secrets & Configuration Provider with Kubernetes Secrets Store CSI driver
@@ -105,20 +105,14 @@ kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-
     1. Configure an AWS secret with your RDS database username and password that were configured when following the steps in Create RDS Instance.
         - **Note:** These are the default values for database credentials in cloudformation template for creating the RDS instance, change these according to the values you used
         - ```
-          username=admin
-          password=Kubefl0w
+          aws secretsmanager create-secret --name rds-secret --secret-string '{"username":"admin","password":"Kubefl0w"}'  --region $CLUSTER_REGION
           ```
     1. Configure an AWS secret with your AWS credentials. These need to be long term credentials from an IAM user and not temporary. 
         - Find more details about configuring/getting your AWS credentials here:
         https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
         - ```
-          accesskey=AXXXXXXXXXXXXXXXXXX6
-          secretkey=eXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXq
+          aws secretsmanager create-secret --name aws-secrets --secret-string '{"accesskey":"AXXXXXXXXXXXXXXXXXX6","secretkey":"eXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXq"}'  --region $CLUSTER_REGION
           ```
-    Example command to create an AWS Secret
-    ```
-    aws secretsmanager create-secret --name kubeflow-secrets --secret-string '{"username":"admin","password":"Kubefl0w","accesskey":"AXXXXXXXXXXXXXXXXXX6","secretkey":"eXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXq"}'  --region $CLUSTER_REGION
-    ```
 
 ### 3. Configure Katib
 

--- a/distributions/aws/examples/rds-s3/README.md
+++ b/distributions/aws/examples/rds-s3/README.md
@@ -76,11 +76,17 @@ eksctl create iamserviceaccount  --name kubeflow-secrets-manager-sa  --namespace
 ```
 
 Run these commands to install AWS Secrets & Configuration Provider with Kubernetes Secrets Store CSI driver
-
 ```
-helm repo add secrets-store-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
-helm -n kube-system install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver  --set syncSecret.enabled=true
-curl -s https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml | kubectl apply -f - 
+# You will first need to clone the secrets-store-csi-driver repo.
+git clone https://github.com/kubernetes-sigs/secrets-store-csi-driver.git && cd secrets-store-csi-driver
+kubectl apply -f deploy/rbac-secretproviderclass.yaml
+kubectl apply -f deploy/csidriver.yaml
+kubectl apply -f deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+kubectl apply -f deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+kubectl apply -f deploy/secrets-store-csi-driver.yaml
+kubectl apply -f deploy/rbac-secretprovidersyncing.yaml
+
+kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml
 ```
 
 ### 2. Configure Kubeflow Pipelines

--- a/distributions/aws/examples/rds-s3/README.md
+++ b/distributions/aws/examples/rds-s3/README.md
@@ -78,7 +78,7 @@ eksctl create iamserviceaccount  --name kubeflow-secrets-manager-sa  --namespace
 Run these commands to install AWS Secrets & Configuration Provider with Kubernetes Secrets Store CSI driver
 ```
 # You will first need to clone the secrets-store-csi-driver repo.
-git clone https://github.com/kubernetes-sigs/secrets-store-csi-driver.git && cd secrets-store-csi-driver
+git clone -b v1.0.0 --single-branch https://github.com/kubernetes-sigs/secrets-store-csi-driver.git && cd secrets-store-csi-driver
 kubectl apply -f deploy/rbac-secretproviderclass.yaml
 kubectl apply -f deploy/csidriver.yaml
 kubectl apply -f deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -104,6 +104,7 @@ kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-
           ```
     1. Configure an AWS secret with your RDS database username and password that were configured when following the steps in Create RDS Instance.
         - **Note:** These are the default values for database credentials in cloudformation template for creating the RDS instance, change these according to the values you used
+        - For example, if your username is `admin` and your password is `Kubefl0w` then your secret should look like:
         - ```
           aws secretsmanager create-secret --name rds-secret --secret-string '{"username":"admin","password":"Kubefl0w"}'  --region $CLUSTER_REGION
           ```
@@ -111,7 +112,7 @@ kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-
         - Find more details about configuring/getting your AWS credentials here:
         https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html
         - ```
-          aws secretsmanager create-secret --name aws-secrets --secret-string '{"accesskey":"AXXXXXXXXXXXXXXXXXX6","secretkey":"eXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXq"}'  --region $CLUSTER_REGION
+          aws secretsmanager create-secret --name s3-secret --secret-string '{"accesskey":"AXXXXXXXXXXXXXXXXXX6","secretkey":"eXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXq"}'  --region $CLUSTER_REGION
           ```
 
 ### 3. Configure Katib

--- a/distributions/aws/examples/rds-s3/README.md
+++ b/distributions/aws/examples/rds-s3/README.md
@@ -96,7 +96,7 @@ curl -s https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-
           minioServiceHost=s3.amazonaws.com
           minioServiceRegion=us-west-2
           ```
-    1. Configure an AWS secret at https://aws.amazon.com/secrets-manager/ with your RDS database username and password that were configured when following the steps in Create RDS Instance.
+    1. Configure an AWS secret with your RDS database username and password that were configured when following the steps in Create RDS Instance.
         - **Note:** These are the default values for database credentials in cloudformation template for creating the RDS instance, change these according to the values you used
         - ```
           username=admin
@@ -109,6 +109,10 @@ curl -s https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-
           accesskey=AXXXXXXXXXXXXXXXXXX6
           secretkey=eXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXq
           ```
+    Example command to create an AWS Secret
+    ```
+    aws secretsmanager create-secret --name kubeflow-secrets --secret-string '{"username":"admin","password":"Kubefl0w","accesskey":"AXXXXXXXXXXXXXXXXXX6","secretkey":"eXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXq"}'  --region $CLUSTER_REGION
+    ```
 
 ### 3. Configure Katib
 

--- a/distributions/aws/examples/rds-s3/README.md
+++ b/distributions/aws/examples/rds-s3/README.md
@@ -103,8 +103,8 @@ kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-
           minioServiceRegion=us-west-2
           ```
     1. Configure an AWS secret with your RDS database username and password that were configured when following the steps in Create RDS Instance.
-        - **Note:** These are the default values for database credentials in cloudformation template for creating the RDS instance, change these according to the values you used
         - For example, if your username is `admin` and your password is `Kubefl0w` then your secret should look like:
+        - **Note:** These are the default values for database credentials in cloudformation template for creating the RDS instance, change these according to the values you used
         - ```
           aws secretsmanager create-secret --name rds-secret --secret-string '{"username":"admin","password":"Kubefl0w"}'  --region $CLUSTER_REGION
           ```


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

- Use secrets-manager instead of .env files for secrets

**Description of your changes:**

- README instructions to install AWS Secrets & Configuration Provider with Kubernetes Secrets Store CSI driver
- Yaml files to mount and sync Secrets manager with Kubernetes secrets
- Patch to delete default mysql-secret and mlpipeline-minio-artifact secrets from kustomization as to not interfere with Secrets Manager secrets.

**Testing**
Logged in and ran Xgboost and data passing pipelines successfully and then verified using mysql that rds populated.

<img width="1540" alt="Screen Shot 2021-12-16 at 4 25 31 PM" src="https://user-images.githubusercontent.com/37981995/146469195-ad555bb4-953d-4b18-9cfd-cfb1f317deb8.png">

<img width="1474" alt="Screen Shot 2021-12-16 at 4 32 45 PM" src="https://user-images.githubusercontent.com/37981995/146469188-4d05de53-6c0d-4f5b-99e4-e286291fe78e.png">

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
