### PR TITLE
Add RDS and S3 e2e tests

### DIFF
--- a/distributions/aws/test/e2e/conftest.py
+++ b/distributions/aws/test/e2e/conftest.py
@@ -51,11 +51,14 @@ def keep_successfully_created_resource(request):
 def load_metadata_file(request):
     return request.config.getoption("--metadata")
 
+
 def get_accesskey(request):
     return request.config.getoption("--accesskey")
 
+
 def get_secretkey(request):
     return request.config.getoption("--secretkey")
+
 
 @pytest.fixture(scope="class")
 def region(metadata, request):

--- a/distributions/aws/test/e2e/conftest.py
+++ b/distributions/aws/test/e2e/conftest.py
@@ -32,6 +32,16 @@ def pytest_addoption(parser):
         action="store",
         help="Hosted zone id of the root domain. Required for tests which use cognito",
     )
+    parser.addoption(
+        "--accesskey",
+        action="store",
+        help="AWS account accesskey",
+    )
+    parser.addoption(
+        "--secretkey",
+        action="store",
+        help="AWS account secretkey",
+    )
 
 
 def keep_successfully_created_resource(request):
@@ -41,6 +51,11 @@ def keep_successfully_created_resource(request):
 def load_metadata_file(request):
     return request.config.getoption("--metadata")
 
+def get_accesskey(request):
+    return request.config.getoption("--accesskey")
+
+def get_secretkey(request):
+    return request.config.getoption("--secretkey")
 
 @pytest.fixture(scope="class")
 def region(metadata, request):

--- a/distributions/aws/test/e2e/fixtures/clients.py
+++ b/distributions/aws/test/e2e/fixtures/clients.py
@@ -41,12 +41,15 @@ def k8s_custom_objects_api_client(cluster, region):
 
     return client.CustomObjectsApi(api_client=client_from_config(cluster, region))
 
+
 def create_k8s_admission_registration_api_client(cluster, region):
     """
     API client for interacting with k8s core API, e.g. describe_pods, etc.
     """
 
-    return client.AdmissionregistrationV1Api(api_client=client_from_config(cluster, region))
+    return client.AdmissionregistrationV1Api(
+        api_client=client_from_config(cluster, region)
+    )
 
 
 # todo make port random
@@ -143,12 +146,15 @@ def cfn_client(region):
 def ec2_client(region):
     return boto3.client("ec2", region_name=region)
 
+
 @pytest.fixture(scope="class")
 def s3_client(region):
     return boto3.client("s3", region_name=region)
 
 
-def create_mysql_client(user, password, host, database) ->  mysql.connector.MySQLConnection:
-    return mysql.connector.connect(user=user, password=password,
-                              host=host,
-                              database=database)
+def create_mysql_client(
+    user, password, host, database
+) -> mysql.connector.MySQLConnection:
+    return mysql.connector.connect(
+        user=user, password=password, host=host, database=database
+    )

--- a/distributions/aws/test/e2e/fixtures/clients.py
+++ b/distributions/aws/test/e2e/fixtures/clients.py
@@ -136,28 +136,3 @@ def kfp_client(port_forward, host, client_namespace, session_cookie):
 @pytest.fixture(scope="class")
 def account_id():
     return boto3.client("sts").get_caller_identity().get("Account")
-
-@pytest.fixture(scope="class")
-def cfn_client(region):
-    return boto3.client("cloudformation", region_name=region)
-
-
-@pytest.fixture(scope="class")
-def ec2_client(region):
-    return boto3.client("ec2", region_name=region)
-
-
-@pytest.fixture(scope="class")
-def s3_client(region):
-    return boto3.client("s3", region_name=region)
-
-def create_secrets_manager_client(region):
-    return boto3.client("secretsmanager", region_name=region)
-
-
-def create_mysql_client(
-    user, password, host, database
-) -> mysql.connector.MySQLConnection:
-    return mysql.connector.connect(
-        user=user, password=password, host=host, database=database
-    )

--- a/distributions/aws/test/e2e/fixtures/clients.py
+++ b/distributions/aws/test/e2e/fixtures/clients.py
@@ -26,7 +26,7 @@ def client_from_config(cluster, region):
     return config.new_client_from_config()
 
 
-def k8s_core_api_client(cluster, region):
+def create_k8s_core_api_client(cluster, region):
     """
     API client for interacting with k8s core API, e.g. describe_pods, etc.
     """
@@ -34,7 +34,7 @@ def k8s_core_api_client(cluster, region):
     return client.CoreV1Api(api_client=client_from_config(cluster, region))
 
 
-def k8s_custom_objects_api_client(cluster, region):
+def create_k8s_custom_objects_api_client(cluster, region):
     """
     API client for performing CRUD operations on custom resources.
     """

--- a/distributions/aws/test/e2e/fixtures/clients.py
+++ b/distributions/aws/test/e2e/fixtures/clients.py
@@ -151,6 +151,9 @@ def ec2_client(region):
 def s3_client(region):
     return boto3.client("s3", region_name=region)
 
+def create_secrets_manager_client(region):
+    return boto3.client("secretsmanager", region_name=region)
+
 
 def create_mysql_client(
     user, password, host, database

--- a/distributions/aws/test/e2e/fixtures/clients.py
+++ b/distributions/aws/test/e2e/fixtures/clients.py
@@ -11,6 +11,8 @@ import pytest
 
 from kubernetes import client, config
 import kfp
+import boto3
+import mysql.connector
 
 from e2e.utils.constants import (
     DEFAULT_HOST,
@@ -38,6 +40,13 @@ def k8s_custom_objects_api_client(cluster, region):
     """
 
     return client.CustomObjectsApi(api_client=client_from_config(cluster, region))
+
+def create_k8s_admission_registration_api_client(cluster, region):
+    """
+    API client for interacting with k8s core API, e.g. describe_pods, etc.
+    """
+
+    return client.AdmissionregistrationV1Api(api_client=client_from_config(cluster, region))
 
 
 # todo make port random
@@ -124,3 +133,22 @@ def kfp_client(port_forward, host, client_namespace, session_cookie):
 @pytest.fixture(scope="class")
 def account_id():
     return boto3.client("sts").get_caller_identity().get("Account")
+
+@pytest.fixture(scope="class")
+def cfn_client(region):
+    return boto3.client("cloudformation", region_name=region)
+
+
+@pytest.fixture(scope="class")
+def ec2_client(region):
+    return boto3.client("ec2", region_name=region)
+
+@pytest.fixture(scope="class")
+def s3_client(region):
+    return boto3.client("s3", region_name=region)
+
+
+def create_mysql_client(user, password, host, database) ->  mysql.connector.MySQLConnection:
+    return mysql.connector.connect(user=user, password=password,
+                              host=host,
+                              database=database)

--- a/distributions/aws/test/e2e/fixtures/cluster.py
+++ b/distributions/aws/test/e2e/fixtures/cluster.py
@@ -45,6 +45,25 @@ def associate_iam_oidc_provider(cluster_name, region):
     subprocess.call(cmd)
 
 
+def create_iam_service_account(
+    service_account_name, namespace, cluster_name, region, iam_policy_arns
+):
+    cmd = []
+    cmd += "eksctl create iamserviceaccount".split()
+    cmd += f"--name {service_account_name}".split()
+    cmd += f"--namespace {namespace}".split()
+    cmd += f"--cluster {cluster_name}".split()
+    cmd += f"--region {region}".split()
+
+    for arn in iam_policy_arns:
+        cmd += f"--attach-policy-arn {arn}".split()
+
+    cmd += "--override-existing-serviceaccounts".split()
+    cmd += "--approve".split()
+
+    subprocess.call(cmd)
+
+
 @pytest.fixture(scope="class")
 def cluster(metadata, region, request):
     """

--- a/distributions/aws/test/e2e/fixtures/cognito_dependencies.py
+++ b/distributions/aws/test/e2e/fixtures/cognito_dependencies.py
@@ -33,14 +33,12 @@ def cognito_bootstrap(
     metadata, region, request, root_domain_name, root_domain_hosted_zone_id
 ):
     if not root_domain_name or not root_domain_hosted_zone_id:
-        pytest.fail("--root-domain-name and --root-domain-hosted-zone-id required for cognito related tests")
+        pytest.fail(
+            "--root-domain-name and --root-domain-hosted-zone-id required for cognito related tests"
+        )
 
     subdomain_name = rand_name("platform") + "." + root_domain_name
-    cognito_deps = {
-        "kubeflow": {
-            "region": region
-        }
-    }
+    cognito_deps = {"kubeflow": {"region": region}}
 
     def on_create():
         root_hosted_zone, subdomain_hosted_zone = create_subdomain_hosted_zone(
@@ -151,9 +149,7 @@ def configure_kf_admin_role(metadata, region, request, account_id, cluster):
         role_arn = response["Role"]["Arn"]
         alb_sa_filepath = "../../aws-alb-ingress-controller/base/service-account.yaml"
         alb_sa = load_cfg(alb_sa_filepath)
-        alb_sa["metadata"]["annotations"] = {
-            "eks.amazonaws.com/role-arn": role_arn
-        }
+        alb_sa["metadata"]["annotations"] = {"eks.amazonaws.com/role-arn": role_arn}
         write_cfg(alb_sa, alb_sa_filepath)
 
         profile_controller_policy = iam_resource.RolePolicy(
@@ -168,9 +164,7 @@ def configure_kf_admin_role(metadata, region, request, account_id, cluster):
             "../../aws-alb-ingress-controller/base/service-account.yaml"
         )
         profile_sa = load_cfg(profile_sa_filepath)
-        profile_sa["metadata"]["annotations"] = {
-            "eks.amazonaws.com/role-arn": role_arn
-        }
+        profile_sa["metadata"]["annotations"] = {"eks.amazonaws.com/role-arn": role_arn}
         write_cfg(profile_sa, profile_sa_filepath)
 
     def on_delete():
@@ -237,14 +231,21 @@ def wait_for_alb_dns(cluster, region):
         assert ingress.get("status") is not None
         assert ingress["status"]["loadBalancer"] is not None
         assert len(ingress["status"]["loadBalancer"]["ingress"]) > 0
-        assert ingress["status"]["loadBalancer"]["ingress"][0].get("hostname", None) is not None
+        assert (
+            ingress["status"]["loadBalancer"]["ingress"][0].get("hostname", None)
+            is not None
+        )
+
     wait_for(callback)
 
 
 @pytest.fixture(scope="class")
-def post_deployment_dns_update(metadata, region, request, cluster, cognito_bootstrap, kustomize):
+def post_deployment_dns_update(
+    metadata, region, request, cluster, cognito_bootstrap, kustomize
+):
 
     alb_dns = None
+
     def on_create():
         wait_for_alb_dns(cluster, region)
         ingress = get_ingress(cluster, region)

--- a/distributions/aws/test/e2e/fixtures/kustomize.py
+++ b/distributions/aws/test/e2e/fixtures/kustomize.py
@@ -40,9 +40,11 @@ def delete_kustomize(path):
         assert build_retcode == 0
         subprocess.call(f"kubectl delete -f {tmp.name}".split())
 
+
 @pytest.fixture(scope="class")
 def configure_manifests():
     pass
+
 
 @pytest.fixture(scope="class")
 def kustomize(metadata, cluster, configure_manifests, kustomize_path, request):

--- a/distributions/aws/test/e2e/fixtures/kustomize.py
+++ b/distributions/aws/test/e2e/fixtures/kustomize.py
@@ -40,6 +40,9 @@ def delete_kustomize(path):
         assert build_retcode == 0
         subprocess.call(f"kubectl delete -f {tmp.name}".split())
 
+@pytest.fixture(scope="class")
+def configure_manifests():
+    pass
 
 @pytest.fixture(scope="class")
 def kustomize(metadata, cluster, configure_manifests, kustomize_path, request):

--- a/distributions/aws/test/e2e/fixtures/secrets.py
+++ b/distributions/aws/test/e2e/fixtures/secrets.py
@@ -9,14 +9,17 @@ from e2e.utils.k8s_core_api import create_namespace
 
 from e2e.utils.constants import (
     KUBEFLOW_NAMESPACE,
-    KUBEFLOW_SERVICE_ACCOUNT_NAME,
-    IAM_AWS_SSM_READ_ONLY_POLICY,
-    IAM_SECRETS_MANAGER_READ_WRITE_POLICY,
 )
 
 from e2e.resources.external import (
     secrets_store_csi_driver,
     secrets_store_csi_driver_provider_aws,
+)
+
+KUBEFLOW_SERVICE_ACCOUNT_NAME = "kubeflow-secrets-manager-sa"
+IAM_AWS_SSM_READ_ONLY_POLICY = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+IAM_SECRETS_MANAGER_READ_WRITE_POLICY = (
+    "arn:aws:iam::aws:policy/SecretsManagerReadWrite"
 )
 
 

--- a/distributions/aws/test/e2e/fixtures/secrets.py
+++ b/distributions/aws/test/e2e/fixtures/secrets.py
@@ -1,0 +1,40 @@
+import json
+
+import pytest
+
+from e2e.utils.utils import kubectl_apply
+
+from e2e.fixtures.cluster import associate_iam_oidc_provider, create_iam_service_account
+from e2e.utils.k8s_core_api import create_namespace
+
+from e2e.utils.constants import (
+    KUBEFLOW_NAMESPACE,
+    KUBEFLOW_SERVICE_ACCOUNT_NAME,
+    IAM_AWS_SSM_READ_ONLY_POLICY,
+    IAM_SECRETS_MANAGER_READ_WRITE_POLICY,
+)
+
+from e2e.resources.external import (
+    secrets_store_csi_driver,
+    secrets_store_csi_driver_provider_aws,
+)
+
+
+@pytest.fixture(scope="class")
+def aws_secrets_driver(cluster, region):
+
+    associate_iam_oidc_provider(cluster, region)
+    create_namespace(cluster, region, "kubeflow")
+
+    iam_policies = [IAM_AWS_SSM_READ_ONLY_POLICY, IAM_SECRETS_MANAGER_READ_WRITE_POLICY]
+
+    create_iam_service_account(
+        KUBEFLOW_SERVICE_ACCOUNT_NAME, KUBEFLOW_NAMESPACE, cluster, region, iam_policies
+    )
+
+    secrets_store_csi_driver.install()
+    secrets_store_csi_driver_provider_aws.install()
+
+
+def create_secret_string(secrets_dict):
+    return json.dumps(secrets_dict)

--- a/distributions/aws/test/e2e/requirements.txt
+++ b/distributions/aws/test/e2e/requirements.txt
@@ -4,3 +4,4 @@ kubernetes==12.0.1
 pytest==6.2.5
 PyYAML==5.4
 black==21.12b0
+mysql-connector-python==8.0.27

--- a/distributions/aws/test/e2e/resources/cloudformation-templates/rds-s3.yaml
+++ b/distributions/aws/test/e2e/resources/cloudformation-templates/rds-s3.yaml
@@ -65,23 +65,23 @@ Parameters:
     Default: 'false'
     AllowedValues: ['true', 'false']
     ConstraintDescription: must be true or false.
-  RDSSecretString:
-    Description: Secret string for RDS secrets
-    Type: String
-  S3SecretString:
-    Description: Secret string for S3 secrets
-    Type: String
+  # RDSSecretString:
+  #   Description: Secret string for RDS secrets
+  #   Type: String
+  # S3SecretString:
+  #   Description: Secret string for S3 secrets
+  #   Type: String
 Resources:
-  MyRDSSecret:
-    Type: 'AWS::SecretsManager::Secret'
-    Properties:
-      Name: rds-secret
-      SecretString: !Ref RDSSecretString
-  MyS3Secret:
-    Type: 'AWS::SecretsManager::Secret'
-    Properties:
-      Name: s3-secret
-      SecretString: !Ref S3SecretString
+  # MyRDSSecret:
+  #   Type: 'AWS::SecretsManager::Secret'
+  #   Properties:
+  #     Name: rds-secret
+  #     SecretString: !Ref RDSSecretString
+  # MyS3Secret:
+  #   Type: 'AWS::SecretsManager::Secret'
+  #   Properties:
+  #     Name: s3-secret
+  #     SecretString: !Ref S3SecretString
   MySQLSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -117,12 +117,12 @@ Resources:
       EngineVersion: '8.0.17'
       MultiAZ:
         Ref: MultiAZ
-      # MasterUsername:
-        # Ref: DBUsername
-      # MasterUserPassword:
-      #   Ref: DBPassword
-      MasterUsername: '{{resolve:secretsmanager:rds-secret:SecretString:username}}'
-      MasterUserPassword: '{{resolve:secretsmanager:rds-secret:SecretString:password}}'
+      MasterUsername:
+        Ref: DBUsername
+      MasterUserPassword:
+        Ref: DBPassword
+      # MasterUsername: '{{resolve:secretsmanager:rds-secret:SecretString:username}}'
+      # MasterUserPassword: '{{resolve:secretsmanager:rds-secret:SecretString:password}}'
       DBSubnetGroupName:
         Ref: MyDBSubnetGroup
       VPCSecurityGroups:

--- a/distributions/aws/test/e2e/resources/cloudformation-templates/rds-s3.yaml
+++ b/distributions/aws/test/e2e/resources/cloudformation-templates/rds-s3.yaml
@@ -65,7 +65,23 @@ Parameters:
     Default: 'false'
     AllowedValues: ['true', 'false']
     ConstraintDescription: must be true or false.
+  RDSSecretString:
+    Description: Secret string for RDS secrets
+    Type: String
+  S3SecretString:
+    Description: Secret string for S3 secrets
+    Type: String
 Resources:
+  MyRDSSecret:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Name: rds-secret
+      SecretString: !Ref RDSSecretString
+  MyS3Secret:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Name: s3-secret
+      SecretString: !Ref S3SecretString
   MySQLSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -101,10 +117,12 @@ Resources:
       EngineVersion: '8.0.17'
       MultiAZ:
         Ref: MultiAZ
-      MasterUsername:
-        Ref: DBUsername
-      MasterUserPassword:
-        Ref: DBPassword
+      # MasterUsername:
+        # Ref: DBUsername
+      # MasterUserPassword:
+      #   Ref: DBPassword
+      MasterUsername: '{{resolve:secretsmanager:rds-secret:SecretString:username}}'
+      MasterUserPassword: '{{resolve:secretsmanager:rds-secret:SecretString:password}}'
       DBSubnetGroupName:
         Ref: MyDBSubnetGroup
       VPCSecurityGroups:

--- a/distributions/aws/test/e2e/resources/cloudformation-templates/rds-s3.yaml
+++ b/distributions/aws/test/e2e/resources/cloudformation-templates/rds-s3.yaml
@@ -1,16 +1,18 @@
-AWSTemplateFormatVersion: '2010-09-09'
-Description: 'WARNING: This is not a recommended solution for using AWS RDS and is for testing only.
-              
-              Creates an S3 Bucket and a RDS instance. The RDS instance is accessible from outside the VPC
-              so do not publicly expose the MYSQL username and password.'
+AWSTemplateFormatVersion: "2010-09-09"
+Description:
+  "WARNING: This is not a recommended solution for using AWS RDS and is for testing only.
+
+  Creates an S3 Bucket and a RDS instance. The RDS instance is accessible from outside the VPC
+  so do not publicly expose the MYSQL username and password."
 Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: VpcId of your existing Virtual Private Cloud (VPC)
     ConstraintDescription: must be the VPC Id of an existing Virtual Private Cloud.
   Subnets:
-    Type: 'List<AWS::EC2::Subnet::Id>'
-    Description: The list of SubnetIds, for at least two Availability Zones in the
+    Type: "List<AWS::EC2::Subnet::Id>"
+    Description:
+      The list of SubnetIds, for at least two Availability Zones in the
       region in your Virtual Private Cloud (VPC)
     ConstraintDescription: Select at least two SubnetIds that are Private
   SecurityGroupId:
@@ -21,24 +23,24 @@ Parameters:
     Default: kubeflow
     Description: Database name for Kubeflow
     Type: String
-    MinLength: '1'
-    MaxLength: '64'
+    MinLength: "1"
+    MaxLength: "64"
     AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
     ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
   DBUsername:
-    NoEcho: 'true'
+    NoEcho: "true"
     Description: The database admin account username
     Type: String
-    MinLength: '1'
-    MaxLength: '16'
+    MinLength: "1"
+    MaxLength: "16"
     AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
     ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
   DBPassword:
-    NoEcho: 'true'
+    NoEcho: "true"
     Description: The database admin account password
     Type: String
-    MinLength: '8'
-    MaxLength: '41'
+    MinLength: "8"
+    MaxLength: "41"
     AllowedPattern: ".*"
     ConstraintDescription: must contain only alphanumeric characters.
   DBClass:
@@ -46,42 +48,30 @@ Parameters:
     Description: Database instance class
     Type: String
     AllowedValues:
-    - db.m5.large
-    - db.m5.xlarge
-    - db.m5.2xlarge
-    - db.m5.4xlarge
-    - db.m5.12xlarge
+      - db.m5.large
+      - db.m5.xlarge
+      - db.m5.2xlarge
+      - db.m5.4xlarge
+      - db.m5.12xlarge
     ConstraintDescription: must select a valid database instance type.
   DBAllocatedStorage:
-    Default: '20'
+    Default: "20"
     Description: The size of the database (Gb)
     Type: Number
-    MinValue: '20'
-    MaxValue: '65536'
+    MinValue: "20"
+    MaxValue: "65536"
     ConstraintDescription: must be between 20 and 65536Gb.
   MultiAZ:
     Description: Multi-AZ master database
     Type: String
-    Default: 'false'
-    AllowedValues: ['true', 'false']
+    Default: "false"
+    AllowedValues: ["true", "false"]
     ConstraintDescription: must be true or false.
-  # RDSSecretString:
-  #   Description: Secret string for RDS secrets
-  #   Type: String
+  # See MyRDSSecret and MyS3Secret below
   # S3SecretString:
   #   Description: Secret string for S3 secrets
   #   Type: String
 Resources:
-  # MyRDSSecret:
-  #   Type: 'AWS::SecretsManager::Secret'
-  #   Properties:
-  #     Name: rds-secret
-  #     SecretString: !Ref RDSSecretString
-  # MyS3Secret:
-  #   Type: 'AWS::SecretsManager::Secret'
-  #   Properties:
-  #     Name: s3-secret
-  #     SecretString: !Ref S3SecretString
   MySQLSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -89,15 +79,15 @@ Resources:
       VpcId:
         Ref: VpcId
       SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: 3306
-        ToPort: 3306
-        CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 3306
+          ToPort: 3306
+          CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
-      - IpProtocol: -1
-        CidrIp: 0.0.0.0/0
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
   MyS3Bucket:
-    Type: 'AWS::S3::Bucket'
+    Type: "AWS::S3::Bucket"
   MyDBSubnetGroup:
     Type: AWS::RDS::DBSubnetGroup
     Properties:
@@ -114,15 +104,13 @@ Resources:
       DBInstanceClass:
         Ref: DBClass
       Engine: MySQL
-      EngineVersion: '8.0.17'
+      EngineVersion: "8.0.17"
       MultiAZ:
         Ref: MultiAZ
       MasterUsername:
         Ref: DBUsername
       MasterUserPassword:
         Ref: DBPassword
-      # MasterUsername: '{{resolve:secretsmanager:rds-secret:SecretString:username}}'
-      # MasterUserPassword: '{{resolve:secretsmanager:rds-secret:SecretString:password}}'
       DBSubnetGroupName:
         Ref: MyDBSubnetGroup
       VPCSecurityGroups:
@@ -130,6 +118,20 @@ Resources:
         - !Ref MySQLSecurityGroup
       PubliclyAccessible: True
     DeletionPolicy: Snapshot
+
+  # Currently the secret names must be rds-secret and s3-secret, however SecretsManager in CFN appends a random string to the end of a provided name
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secret.html
+  # Uncomment this section when we make secret names a configurable parameter for our secrets manager implementation
+  # MyRDSSecret:
+  #   Type: "AWS::SecretsManager::Secret"
+  #   Properties:
+  #     Name: rds-secret
+  #     SecretString: !Sub '{"username":${DBUsername},"password":${DBPassword},"database":${DBName},"host":${MyDB.Endpoint.Address},"port":${MyDB.Endpoint.Port}}'
+  # MyS3Secret:
+  #   Type: "AWS::SecretsManager::Secret"
+  #   Properties:
+  #     Name: s3-secret
+  #     SecretString: !Sub S3SecretString # This doesn't depend on any resource outputs so lets pass it in directly
 Outputs:
   RDSEndpoint:
     Description: RDS Endpoint

--- a/distributions/aws/test/e2e/resources/cloudformation-templates/rds-s3.yaml
+++ b/distributions/aws/test/e2e/resources/cloudformation-templates/rds-s3.yaml
@@ -1,0 +1,124 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'WARNING: This is not a recommended solution for using AWS RDS and is for testing only.
+              
+              Creates an S3 Bucket and a RDS instance. The RDS instance is accessible from outside the VPC
+              so do not publicly expose the MYSQL username and password.'
+Parameters:
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VpcId of your existing Virtual Private Cloud (VPC)
+    ConstraintDescription: must be the VPC Id of an existing Virtual Private Cloud.
+  Subnets:
+    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: The list of SubnetIds, for at least two Availability Zones in the
+      region in your Virtual Private Cloud (VPC)
+    ConstraintDescription: Select at least two SubnetIds that are Private
+  SecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+    Description: SecurityGroup Id of your EKS Worker Node
+    ConstraintDescription: must be SecurityGroupId of an existing Instance
+  DBName:
+    Default: kubeflow
+    Description: Database name for Kubeflow
+    Type: String
+    MinLength: '1'
+    MaxLength: '64'
+    AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
+    ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
+  DBUsername:
+    NoEcho: 'true'
+    Description: The database admin account username
+    Type: String
+    MinLength: '1'
+    MaxLength: '16'
+    AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
+    ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
+  DBPassword:
+    NoEcho: 'true'
+    Description: The database admin account password
+    Type: String
+    MinLength: '8'
+    MaxLength: '41'
+    AllowedPattern: ".*"
+    ConstraintDescription: must contain only alphanumeric characters.
+  DBClass:
+    Default: db.m5.large
+    Description: Database instance class
+    Type: String
+    AllowedValues:
+    - db.m5.large
+    - db.m5.xlarge
+    - db.m5.2xlarge
+    - db.m5.4xlarge
+    - db.m5.12xlarge
+    ConstraintDescription: must select a valid database instance type.
+  DBAllocatedStorage:
+    Default: '20'
+    Description: The size of the database (Gb)
+    Type: Number
+    MinValue: '20'
+    MaxValue: '65536'
+    ConstraintDescription: must be between 20 and 65536Gb.
+  MultiAZ:
+    Description: Multi-AZ master database
+    Type: String
+    Default: 'false'
+    AllowedValues: ['true', 'false']
+    ConstraintDescription: must be true or false.
+Resources:
+  MySQLSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow external access to MySQL on RDS
+      VpcId:
+        Ref: VpcId
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 3306
+        ToPort: 3306
+        CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+      - IpProtocol: -1
+        CidrIp: 0.0.0.0/0
+  MyS3Bucket:
+    Type: 'AWS::S3::Bucket'
+  MyDBSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Subnets available for the RDS DB Instance
+      SubnetIds:
+        Ref: Subnets
+  MyDB:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBName:
+        Ref: DBName
+      AllocatedStorage:
+        Ref: DBAllocatedStorage
+      DBInstanceClass:
+        Ref: DBClass
+      Engine: MySQL
+      EngineVersion: '8.0.17'
+      MultiAZ:
+        Ref: MultiAZ
+      MasterUsername:
+        Ref: DBUsername
+      MasterUserPassword:
+        Ref: DBPassword
+      DBSubnetGroupName:
+        Ref: MyDBSubnetGroup
+      VPCSecurityGroups:
+        - !Ref SecurityGroupId
+        - !Ref MySQLSecurityGroup
+      PubliclyAccessible: True
+    DeletionPolicy: Snapshot
+Outputs:
+  RDSEndpoint:
+    Description: RDS Endpoint
+    Value:
+      Fn::GetAtt:
+        - MyDB
+        - Endpoint.Address
+  S3BucketName:
+    Description: S3 bucket name
+    Value: !Ref MyS3Bucket

--- a/distributions/aws/test/e2e/resources/custom-resource-templates/katib-experiment-random.yaml
+++ b/distributions/aws/test/e2e/resources/custom-resource-templates/katib-experiment-random.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   objective:
     type: maximize
-    goal: 0.99
+    goal: 0.90
     objectiveMetricName: Validation-accuracy
     additionalMetricNames:
       - Train-accuracy
@@ -52,6 +52,9 @@ spec:
       kind: Job
       spec:
         template:
+          metadata:
+            annotations:
+              sidecar.istio.io/inject: 'false'
           spec:
             containers:
               - name: training-container

--- a/distributions/aws/test/e2e/resources/custom-resource-templates/patch-disable-pipeline-caching.yaml
+++ b/distributions/aws/test/e2e/resources/custom-resource-templates/patch-disable-pipeline-caching.yaml
@@ -1,0 +1,12 @@
+webhooks:
+- name: cache-server.kubeflow.svc
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - pods
+    scope: '*'

--- a/distributions/aws/test/e2e/resources/external/secrets_store_csi_driver.py
+++ b/distributions/aws/test/e2e/resources/external/secrets_store_csi_driver.py
@@ -2,7 +2,7 @@ from e2e.utils.utils import kubectl_apply
 
 RBAC_SECRETS_PROVIDER_CLASS = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/rbac-secretproviderclass.yaml"
 
-CSI_DRIVER = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/csidriver.yaml"
+CSI_DRIVER_V_1_0_0 = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/csidriver.yaml"
 
 SECRETS_STORE_SECRETS_PROVIDER_CLASSES = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml"
 
@@ -15,7 +15,7 @@ RBAC_SECRETS_PROVIDER_SYNCING = "https://raw.githubusercontent.com/kubernetes-si
 
 def install():
     kubectl_apply(RBAC_SECRETS_PROVIDER_CLASS)
-    kubectl_apply(CSI_DRIVER)
+    kubectl_apply(CSI_DRIVER_V_1_0_0)
     kubectl_apply(SECRETS_STORE_SECRETS_PROVIDER_CLASSES)
     kubectl_apply(SECRETS_STORE_SECRETS_PROVIDER_CLASS_POD_STATUSES)
     kubectl_apply(SECRETS_STORE_CSI_DRIVER)

--- a/distributions/aws/test/e2e/resources/external/secrets_store_csi_driver.py
+++ b/distributions/aws/test/e2e/resources/external/secrets_store_csi_driver.py
@@ -1,0 +1,22 @@
+from e2e.utils.utils import kubectl_apply
+
+RBAC_SECRETS_PROVIDER_CLASS = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/rbac-secretproviderclass.yaml"
+
+CSI_DRIVER = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/csidriver.yaml"
+
+SECRETS_STORE_SECRETS_PROVIDER_CLASSES = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml"
+
+SECRETS_STORE_SECRETS_PROVIDER_CLASS_POD_STATUSES = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml"
+
+SECRETS_STORE_CSI_DRIVER = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store-csi-driver.yaml"
+
+RBAC_SECRETS_PROVIDER_SYNCING = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/rbac-secretprovidersyncing.yaml"
+
+
+def install():
+    kubectl_apply(RBAC_SECRETS_PROVIDER_CLASS)
+    kubectl_apply(CSI_DRIVER)
+    kubectl_apply(SECRETS_STORE_SECRETS_PROVIDER_CLASSES)
+    kubectl_apply(SECRETS_STORE_SECRETS_PROVIDER_CLASS_POD_STATUSES)
+    kubectl_apply(SECRETS_STORE_CSI_DRIVER)
+    kubectl_apply(RBAC_SECRETS_PROVIDER_SYNCING)

--- a/distributions/aws/test/e2e/resources/external/secrets_store_csi_driver_provider_aws.py
+++ b/distributions/aws/test/e2e/resources/external/secrets_store_csi_driver_provider_aws.py
@@ -1,0 +1,7 @@
+from e2e.utils.utils import kubectl_apply
+
+AWS_PROVIDER_INSTALLER = "https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml"
+
+
+def install():
+    kubectl_apply(AWS_PROVIDER_INSTALLER)

--- a/distributions/aws/test/e2e/tests/test_rds_s3.py
+++ b/distributions/aws/test/e2e/tests/test_rds_s3.py
@@ -5,7 +5,12 @@ import pytest
 
 
 from e2e.utils.constants import DEFAULT_USER_NAMESPACE
-from e2e.utils.utils import wait_for, rand_name, WaitForCircuitBreakerError, unmarshal_yaml
+from e2e.utils.utils import (
+    wait_for,
+    rand_name,
+    WaitForCircuitBreakerError,
+    unmarshal_yaml,
+)
 from e2e.utils.config import metadata, configure_env_file
 
 from e2e.conftest import region, get_accesskey, get_secretkey
@@ -24,12 +29,15 @@ from e2e.fixtures.clients import (
     ec2_client,
     s3_client,
     create_k8s_admission_registration_api_client,
-    create_mysql_client
+    create_mysql_client,
 )
 
 from e2e.utils import mysql
 
-from e2e.utils.cloudformation_resources import create_cloudformation_fixture, get_stack_outputs
+from e2e.utils.cloudformation_resources import (
+    create_cloudformation_fixture,
+    get_stack_outputs,
+)
 from e2e.utils.custom_resources import (
     create_katib_experiment_from_yaml,
     get_katib_experiment,
@@ -42,7 +50,9 @@ from kubernetes.client.exceptions import ApiException as K8sApiException
 RDS_S3_KUSTOMIZE_MANIFEST_PATH = "../../examples/rds-s3/"
 RDS_S3_CLOUDFORMATION_TEMPLATE_PATH = "./resources/cloudformation-templates/rds-s3.yaml"
 CUSTOM_RESOURCE_TEMPLATES_FOLDER = "./resources/custom-resource-templates"
-DISABLE_PIPELINE_CACHING_PATCH_FILE = './resources/custom-resource-templates/patch-disable-pipeline-caching.yaml'
+DISABLE_PIPELINE_CACHING_PATCH_FILE = (
+    "./resources/custom-resource-templates/patch-disable-pipeline-caching.yaml"
+)
 
 
 @pytest.fixture(scope="class")
@@ -107,58 +117,66 @@ def cfn_stack(metadata, cluster, cfn_client, ec2_client, request):
         },
     )
 
-KFP_MANIFEST_FOLDER = '../../../../apps/pipeline/upstream/env/aws'
-KATIB_MANIFEST_FOLDER = '../../../../apps/katib/upstream/installs/katib-external-db-with-kubeflow'
 
-KFP_MINIO_ARTIFACT_SECRET_PATCH_ENV_FILE = KFP_MANIFEST_FOLDER + '/minio-artifact-secret-patch.env'
-KFP_PARAMS_ENV_FILE = KFP_MANIFEST_FOLDER + '/params.env'
-KFP_SECRET_ENV_FILE = KFP_MANIFEST_FOLDER + '/secret.env'
+KFP_MANIFEST_FOLDER = "../../../../apps/pipeline/upstream/env/aws"
+KATIB_MANIFEST_FOLDER = (
+    "../../../../apps/katib/upstream/installs/katib-external-db-with-kubeflow"
+)
 
-KATIB_SECRETS_ENV_FILE = KATIB_MANIFEST_FOLDER + '/secrets.env'
+KFP_MINIO_ARTIFACT_SECRET_PATCH_ENV_FILE = (
+    KFP_MANIFEST_FOLDER + "/minio-artifact-secret-patch.env"
+)
+KFP_PARAMS_ENV_FILE = KFP_MANIFEST_FOLDER + "/params.env"
+KFP_SECRET_ENV_FILE = KFP_MANIFEST_FOLDER + "/secret.env"
+
+KATIB_SECRETS_ENV_FILE = KATIB_MANIFEST_FOLDER + "/secrets.env"
+
 
 @pytest.fixture(scope="class")
 def configure_manifests(cfn_client, cfn_stack, region, request):
-    stack_outputs = get_stack_outputs(cfn_client, cfn_stack['stack_name'])
+    stack_outputs = get_stack_outputs(cfn_client, cfn_stack["stack_name"])
 
     configure_env_file(
         env_file_path=KFP_MINIO_ARTIFACT_SECRET_PATCH_ENV_FILE,
         env_dict={
-            'accesskey': get_accesskey(request),
-            'secretkey': get_secretkey(request),
-        }
+            "accesskey": get_accesskey(request),
+            "secretkey": get_secretkey(request),
+        },
     )
 
     configure_env_file(
         env_file_path=KFP_PARAMS_ENV_FILE,
         env_dict={
-            'dbHost': stack_outputs['RDSEndpoint'],
-            'bucketName': stack_outputs['S3BucketName'],
-            'minioServiceHost': 's3.amazonaws.com',
-            'minioServiceRegion': region
-        }
+            "dbHost": stack_outputs["RDSEndpoint"],
+            "bucketName": stack_outputs["S3BucketName"],
+            "minioServiceHost": "s3.amazonaws.com",
+            "minioServiceRegion": region,
+        },
     )
 
     configure_env_file(
         env_file_path=KFP_SECRET_ENV_FILE,
         env_dict={
-            'username': cfn_stack['params']['DBUsername'],
-            'password': cfn_stack['params']['DBPassword'],
-        }
+            "username": cfn_stack["params"]["DBUsername"],
+            "password": cfn_stack["params"]["DBPassword"],
+        },
     )
 
     configure_env_file(
         env_file_path=KATIB_SECRETS_ENV_FILE,
         env_dict={
-            'KATIB_MYSQL_DB_DATABASE': 'kubeflow',
-            'KATIB_MYSQL_DB_HOST': stack_outputs['RDSEndpoint'],
-            'KATIB_MYSQL_DB_PORT': '3306',
-            'DB_USER': cfn_stack['params']['DBUsername'],
-            'DB_PASSWORD': cfn_stack['params']['DBPassword'],
-        }
+            "KATIB_MYSQL_DB_DATABASE": "kubeflow",
+            "KATIB_MYSQL_DB_HOST": stack_outputs["RDSEndpoint"],
+            "KATIB_MYSQL_DB_PORT": "3306",
+            "DB_USER": cfn_stack["params"]["DBUsername"],
+            "DB_PASSWORD": cfn_stack["params"]["DBPassword"],
+        },
     )
+
 
 PIPELINE_NAME = "[Demo] XGBoost - Iterative model training"
 KATIB_EXPERIMENT_FILE = "katib-experiment-random.yaml"
+
 
 def wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id):
     def callback():
@@ -167,15 +185,16 @@ def wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id):
         assert resp.run.name == job_name
         assert resp.run.pipeline_spec.pipeline_id == pipeline_id
 
-        if 'Failed' == resp.run.status:
+        if "Failed" == resp.run.status:
             print(resp.run)
-            raise WaitForCircuitBreakerError('Pipeline run Failed')
+            raise WaitForCircuitBreakerError("Pipeline run Failed")
 
         assert resp.run.status == "Succeeded"
 
         return resp
 
     return wait_for(callback)
+
 
 def wait_for_katib_experiment_succeeded(cluster, region, namespace, name):
     def callback():
@@ -185,18 +204,21 @@ def wait_for_katib_experiment_succeeded(cluster, region, namespace, name):
         assert resp["metadata"]["name"] == name
         assert resp["metadata"]["namespace"] == namespace
 
-        assert resp['status']['completionTime'] != None
-        condition_types = { condition['type'] for condition in resp['status']['conditions'] }
+        assert resp["status"]["completionTime"] != None
+        condition_types = {
+            condition["type"] for condition in resp["status"]["conditions"]
+        }
 
-        if 'Failed' in condition_types:
+        if "Failed" in condition_types:
             print(resp)
-            raise WaitForCircuitBreakerError('Katib experiment Failed')
+            raise WaitForCircuitBreakerError("Katib experiment Failed")
 
-        assert 'Succeeded' in condition_types
+        assert "Succeeded" in condition_types
 
     wait_for(callback)
 
-class TestRDSS3():
+
+class TestRDSS3:
     @pytest.fixture(scope="class")
     def setup(self, metadata, port_forward, cluster, region):
 
@@ -204,15 +226,19 @@ class TestRDSS3():
         # By default KFP will cache previous pipeline runs and subsequent runs will skip cached steps
         # This prevents artifacts from being uploaded to s3 for subsequent runs
         patch_body = unmarshal_yaml(DISABLE_PIPELINE_CACHING_PATCH_FILE)
-        k8s_admission_registration_api_client = create_k8s_admission_registration_api_client(cluster, region)
-        k8s_admission_registration_api_client.patch_mutating_webhook_configuration('cache-webhook-kubeflow', patch_body)
+        k8s_admission_registration_api_client = (
+            create_k8s_admission_registration_api_client(cluster, region)
+        )
+        k8s_admission_registration_api_client.patch_mutating_webhook_configuration(
+            "cache-webhook-kubeflow", patch_body
+        )
 
         metadata_file = metadata.to_file()
         print(metadata.params)  # These needed to be logged
         print("Created metadata file for TestRDSS3", metadata_file)
 
     def test_kfp_experiment(self, setup, kfp_client, cfn_stack, cfn_client):
-        stack_outputs = get_stack_outputs(cfn_client, cfn_stack['stack_name'])
+        stack_outputs = get_stack_outputs(cfn_client, cfn_stack["stack_name"])
 
         name = rand_name("experiment-")
         description = rand_name("description-")
@@ -225,17 +251,19 @@ class TestRDSS3():
         assert DEFAULT_USER_NAMESPACE == experiment.resource_references[0].key.id
 
         mysql_client = create_mysql_client(
-            user=cfn_stack['params']['DBUsername'],
-            password=cfn_stack['params']['DBPassword'],
-            host=stack_outputs['RDSEndpoint'],
-            database='mlpipeline'
+            user=cfn_stack["params"]["DBUsername"],
+            password=cfn_stack["params"]["DBPassword"],
+            host=stack_outputs["RDSEndpoint"],
+            database="mlpipeline",
         )
 
-        resp = mysql.query(mysql_client, f"select * from experiments where Name='{name}'")
+        resp = mysql.query(
+            mysql_client, f"select * from experiments where Name='{name}'"
+        )
         assert len(resp) == 1
-        assert resp[0]['Name'] == experiment.name
-        assert resp[0]['Description'] == experiment.description
-        assert resp[0]['Namespace'] == experiment.resource_references[0].key.id
+        assert resp[0]["Name"] == experiment.name
+        assert resp[0]["Description"] == experiment.description
+        assert resp[0]["Namespace"] == experiment.resource_references[0].key.id
 
         resp = kfp_client.get_experiment(
             experiment_id=experiment.id, namespace=DEFAULT_USER_NAMESPACE
@@ -247,7 +275,9 @@ class TestRDSS3():
 
         kfp_client.delete_experiment(experiment.id)
 
-        resp = mysql.query(mysql_client, f"select * from experiments where Name='{name}'")
+        resp = mysql.query(
+            mysql_client, f"select * from experiments where Name='{name}'"
+        )
         assert len(resp) == 0
 
         try:
@@ -261,7 +291,7 @@ class TestRDSS3():
         mysql_client.close()
 
     def test_run_pipeline(self, setup, kfp_client, cfn_stack, cfn_client, s3_client):
-        stack_outputs = get_stack_outputs(cfn_client, cfn_stack['stack_name'])
+        stack_outputs = get_stack_outputs(cfn_client, cfn_stack["stack_name"])
 
         experiment_name = rand_name("experiment-")
         experiment_description = rand_name("description-")
@@ -288,42 +318,44 @@ class TestRDSS3():
         workflow_manifest = json.loads(workflow_manifest_json)
 
         s3_artifact_keys = []
-        for _, node in workflow_manifest['status']['nodes'].items():
-            if 'outputs' not in node:
+        for _, node in workflow_manifest["status"]["nodes"].items():
+            if "outputs" not in node:
                 continue
-            if 'artifacts' not in node['outputs']:
+            if "artifacts" not in node["outputs"]:
                 continue
 
-            for artifact in node['outputs']['artifacts']:
-                if 's3' not in artifact:
+            for artifact in node["outputs"]["artifacts"]:
+                if "s3" not in artifact:
                     continue
-                s3_artifact_keys.append(artifact['s3']['key'])
+                s3_artifact_keys.append(artifact["s3"]["key"])
 
-        bucket_objects = s3_client.list_objects_v2(Bucket=stack_outputs['S3BucketName'])
-        content_keys = {content['Key'] for content in bucket_objects['Contents']}
+        bucket_objects = s3_client.list_objects_v2(Bucket=stack_outputs["S3BucketName"])
+        content_keys = {content["Key"] for content in bucket_objects["Contents"]}
 
-        assert f'pipelines/{pipeline_id}' in content_keys
+        assert f"pipelines/{pipeline_id}" in content_keys
         for key in s3_artifact_keys:
             assert key in content_keys
 
         mysql_client = create_mysql_client(
-            user=cfn_stack['params']['DBUsername'],
-            password=cfn_stack['params']['DBPassword'],
-            host=stack_outputs['RDSEndpoint'],
-            database='mlpipeline'
+            user=cfn_stack["params"]["DBUsername"],
+            password=cfn_stack["params"]["DBPassword"],
+            host=stack_outputs["RDSEndpoint"],
+            database="mlpipeline",
         )
 
-        resp = mysql.query(mysql_client, f"select * from run_details where UUID='{run.id}'")
+        resp = mysql.query(
+            mysql_client, f"select * from run_details where UUID='{run.id}'"
+        )
 
         assert len(resp) == 1
-        assert resp[0]['DisplayName'] == job_name
-        assert resp[0]['PipelineId'] == pipeline_id
-        assert resp[0]['Conditions'] == 'Succeeded'
+        assert resp[0]["DisplayName"] == job_name
+        assert resp[0]["PipelineId"] == pipeline_id
+        assert resp[0]["Conditions"] == "Succeeded"
 
         kfp_client.delete_experiment(experiment.id)
 
     def test_katib_experiment(self, setup, cluster, region, cfn_stack, cfn_client):
-        stack_outputs = get_stack_outputs(cfn_client, cfn_stack['stack_name'])
+        stack_outputs = get_stack_outputs(cfn_client, cfn_stack["stack_name"])
 
         filepath = os.path.abspath(
             os.path.join(CUSTOM_RESOURCE_TEMPLATES_FOLDER, KATIB_EXPERIMENT_FILE)
@@ -344,15 +376,18 @@ class TestRDSS3():
         wait_for_katib_experiment_succeeded(cluster, region, namespace, name)
 
         mysql_client = create_mysql_client(
-            user=cfn_stack['params']['DBUsername'],
-            password=cfn_stack['params']['DBPassword'],
-            host=stack_outputs['RDSEndpoint'],
-            database='kubeflow'
+            user=cfn_stack["params"]["DBUsername"],
+            password=cfn_stack["params"]["DBPassword"],
+            host=stack_outputs["RDSEndpoint"],
+            database="kubeflow",
         )
 
-        resp = mysql.query(mysql_client, f"select count(*) as count from observation_logs where trial_name like '{name}%'")
+        resp = mysql.query(
+            mysql_client,
+            f"select count(*) as count from observation_logs where trial_name like '{name}%'",
+        )
 
-        assert resp[0]['count'] > 0
+        assert resp[0]["count"] > 0
 
         resp = delete_katib_experiment(cluster, region, namespace, name)
 

--- a/distributions/aws/test/e2e/tests/test_rds_s3.py
+++ b/distributions/aws/test/e2e/tests/test_rds_s3.py
@@ -146,7 +146,7 @@ def rds_s3_secrets(cfn_client, cfn_stack, region, metadata, request):
     rds_secret = {
         "username": cfn_stack["params"]["DBUsername"],
         "password": cfn_stack["params"]["DBPassword"],
-        "dbname": "kubeflow",
+        "database": "kubeflow",
         "host": stack_outputs["RDSEndpoint"],
         "port": "3306",
     }

--- a/distributions/aws/test/e2e/tests/test_rds_s3.py
+++ b/distributions/aws/test/e2e/tests/test_rds_s3.py
@@ -1,0 +1,367 @@
+import os
+import json
+
+import pytest
+
+
+from e2e.utils.constants import DEFAULT_USER_NAMESPACE
+from e2e.utils.utils import wait_for, rand_name, WaitForCircuitBreakerError, unmarshal_yaml
+from e2e.utils.config import metadata, configure_env_file
+
+from e2e.conftest import region, get_accesskey, get_secretkey
+
+from e2e.fixtures.cluster import cluster
+from e2e.fixtures.kustomize import kustomize
+from e2e.fixtures.clients import (
+    kfp_client,
+    port_forward,
+    session_cookie,
+    host,
+    login,
+    password,
+    client_namespace,
+    cfn_client,
+    ec2_client,
+    s3_client,
+    create_k8s_admission_registration_api_client,
+    create_mysql_client
+)
+
+from e2e.utils import mysql
+
+from e2e.utils.cloudformation_resources import create_cloudformation_fixture, get_stack_outputs
+from e2e.utils.custom_resources import (
+    create_katib_experiment_from_yaml,
+    get_katib_experiment,
+    delete_katib_experiment,
+)
+
+from kfp_server_api.exceptions import ApiException as KFPApiException
+from kubernetes.client.exceptions import ApiException as K8sApiException
+
+RDS_S3_KUSTOMIZE_MANIFEST_PATH = "../../examples/rds-s3/"
+RDS_S3_CLOUDFORMATION_TEMPLATE_PATH = "./resources/cloudformation-templates/rds-s3.yaml"
+CUSTOM_RESOURCE_TEMPLATES_FOLDER = "./resources/custom-resource-templates"
+DISABLE_PIPELINE_CACHING_PATCH_FILE = './resources/custom-resource-templates/patch-disable-pipeline-caching.yaml'
+
+
+@pytest.fixture(scope="class")
+def kustomize_path():
+    return RDS_S3_KUSTOMIZE_MANIFEST_PATH
+
+
+@pytest.fixture(scope="class")
+def cfn_stack(metadata, cluster, cfn_client, ec2_client, request):
+    stack_name = rand_name("test-e2e-rds-stack-")
+
+    resp = ec2_client.describe_vpcs(
+        Filters=[
+            {
+                "Name": "tag:alpha.eksctl.io/cluster-name",
+                "Values": [cluster],
+            },
+        ],
+    )
+    vpc_id = resp["Vpcs"][0]["VpcId"]
+
+    resp = ec2_client.describe_subnets(
+        Filters=[
+            {
+                "Name": "tag:alpha.eksctl.io/cluster-name",
+                "Values": [cluster],
+            },
+            {
+                "Name": "tag:aws:cloudformation:logical-id",
+                "Values": ["SubnetPublic*"],
+            },
+        ],
+    )
+    public_subnets = [s["SubnetId"] for s in resp["Subnets"]]
+
+    resp = ec2_client.describe_instances(
+        Filters=[
+            {
+                "Name": "tag:eks:cluster-name",
+                "Values": [cluster],
+            }
+        ],
+    )
+    instances = [i for r in resp["Reservations"] for i in r["Instances"]]
+    security_groups = [i["SecurityGroups"][0]["GroupId"] for i in instances]
+
+    return create_cloudformation_fixture(
+        metadata=metadata,
+        request=request,
+        cfn_client=cfn_client,
+        template_path=RDS_S3_CLOUDFORMATION_TEMPLATE_PATH,
+        stack_name=stack_name,
+        metadata_key="test_rds_s3_cfn_stack",
+        create_timeout=10 * 60,
+        delete_timeout=10 * 60,
+        params={
+            "VpcId": vpc_id,
+            "Subnets": ",".join(public_subnets),
+            "SecurityGroupId": security_groups[0],
+            "DBUsername": rand_name("admin"),
+            "DBPassword": rand_name("Kubefl0w"),
+        },
+    )
+
+KFP_MANIFEST_FOLDER = '../../../../apps/pipeline/upstream/env/aws'
+KATIB_MANIFEST_FOLDER = '../../../../apps/katib/upstream/installs/katib-external-db-with-kubeflow'
+
+KFP_MINIO_ARTIFACT_SECRET_PATCH_ENV_FILE = KFP_MANIFEST_FOLDER + '/minio-artifact-secret-patch.env'
+KFP_PARAMS_ENV_FILE = KFP_MANIFEST_FOLDER + '/params.env'
+KFP_SECRET_ENV_FILE = KFP_MANIFEST_FOLDER + '/secret.env'
+
+KATIB_SECRETS_ENV_FILE = KATIB_MANIFEST_FOLDER + '/secrets.env'
+
+@pytest.fixture(scope="class")
+def configure_manifests(cfn_client, cfn_stack, region, request):
+    stack_outputs = get_stack_outputs(cfn_client, cfn_stack['stack_name'])
+
+    configure_env_file(
+        env_file_path=KFP_MINIO_ARTIFACT_SECRET_PATCH_ENV_FILE,
+        env_dict={
+            'accesskey': get_accesskey(request),
+            'secretkey': get_secretkey(request),
+        }
+    )
+
+    configure_env_file(
+        env_file_path=KFP_PARAMS_ENV_FILE,
+        env_dict={
+            'dbHost': stack_outputs['RDSEndpoint'],
+            'bucketName': stack_outputs['S3BucketName'],
+            'minioServiceHost': 's3.amazonaws.com',
+            'minioServiceRegion': region
+        }
+    )
+
+    configure_env_file(
+        env_file_path=KFP_SECRET_ENV_FILE,
+        env_dict={
+            'username': cfn_stack['params']['DBUsername'],
+            'password': cfn_stack['params']['DBPassword'],
+        }
+    )
+
+    configure_env_file(
+        env_file_path=KATIB_SECRETS_ENV_FILE,
+        env_dict={
+            'KATIB_MYSQL_DB_DATABASE': 'kubeflow',
+            'KATIB_MYSQL_DB_HOST': stack_outputs['RDSEndpoint'],
+            'KATIB_MYSQL_DB_PORT': '3306',
+            'DB_USER': cfn_stack['params']['DBUsername'],
+            'DB_PASSWORD': cfn_stack['params']['DBPassword'],
+        }
+    )
+
+PIPELINE_NAME = "[Demo] XGBoost - Iterative model training"
+KATIB_EXPERIMENT_FILE = "katib-experiment-random.yaml"
+
+def wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id):
+    def callback():
+        resp = kfp_client.get_run(run.id)
+
+        assert resp.run.name == job_name
+        assert resp.run.pipeline_spec.pipeline_id == pipeline_id
+
+        if 'Failed' == resp.run.status:
+            print(resp.run)
+            raise WaitForCircuitBreakerError('Pipeline run Failed')
+
+        assert resp.run.status == "Succeeded"
+
+        return resp
+
+    return wait_for(callback)
+
+def wait_for_katib_experiment_succeeded(cluster, region, namespace, name):
+    def callback():
+        resp = get_katib_experiment(cluster, region, namespace, name)
+
+        assert resp["kind"] == "Experiment"
+        assert resp["metadata"]["name"] == name
+        assert resp["metadata"]["namespace"] == namespace
+
+        assert resp['status']['completionTime'] != None
+        condition_types = { condition['type'] for condition in resp['status']['conditions'] }
+
+        if 'Failed' in condition_types:
+            print(resp)
+            raise WaitForCircuitBreakerError('Katib experiment Failed')
+
+        assert 'Succeeded' in condition_types
+
+    wait_for(callback)
+
+class TestRDSS3():
+    @pytest.fixture(scope="class")
+    def setup(self, metadata, port_forward, cluster, region):
+
+        # Disable caching in KFP
+        # By default KFP will cache previous pipeline runs and subsequent runs will skip cached steps
+        # This prevents artifacts from being uploaded to s3 for subsequent runs
+        patch_body = unmarshal_yaml(DISABLE_PIPELINE_CACHING_PATCH_FILE)
+        k8s_admission_registration_api_client = create_k8s_admission_registration_api_client(cluster, region)
+        k8s_admission_registration_api_client.patch_mutating_webhook_configuration('cache-webhook-kubeflow', patch_body)
+
+        metadata_file = metadata.to_file()
+        print(metadata.params)  # These needed to be logged
+        print("Created metadata file for TestRDSS3", metadata_file)
+
+    def test_kfp_experiment(self, setup, kfp_client, cfn_stack, cfn_client):
+        stack_outputs = get_stack_outputs(cfn_client, cfn_stack['stack_name'])
+
+        name = rand_name("experiment-")
+        description = rand_name("description-")
+        experiment = kfp_client.create_experiment(
+            name, description=description, namespace=DEFAULT_USER_NAMESPACE
+        )
+
+        assert name == experiment.name
+        assert description == experiment.description
+        assert DEFAULT_USER_NAMESPACE == experiment.resource_references[0].key.id
+
+        mysql_client = create_mysql_client(
+            user=cfn_stack['params']['DBUsername'],
+            password=cfn_stack['params']['DBPassword'],
+            host=stack_outputs['RDSEndpoint'],
+            database='mlpipeline'
+        )
+
+        resp = mysql.query(mysql_client, f"select * from experiments where Name='{name}'")
+        assert len(resp) == 1
+        assert resp[0]['Name'] == experiment.name
+        assert resp[0]['Description'] == experiment.description
+        assert resp[0]['Namespace'] == experiment.resource_references[0].key.id
+
+        resp = kfp_client.get_experiment(
+            experiment_id=experiment.id, namespace=DEFAULT_USER_NAMESPACE
+        )
+
+        assert name == resp.name
+        assert description == resp.description
+        assert DEFAULT_USER_NAMESPACE == resp.resource_references[0].key.id
+
+        kfp_client.delete_experiment(experiment.id)
+
+        resp = mysql.query(mysql_client, f"select * from experiments where Name='{name}'")
+        assert len(resp) == 0
+
+        try:
+            kfp_client.get_experiment(
+                experiment_id=experiment.id, namespace=DEFAULT_USER_NAMESPACE
+            )
+            raise AssertionError("Expected KFPApiException Not Found")
+        except KFPApiException as e:
+            assert "Not Found" == e.reason
+
+        mysql_client.close()
+
+    def test_run_pipeline(self, setup, kfp_client, cfn_stack, cfn_client, s3_client):
+        stack_outputs = get_stack_outputs(cfn_client, cfn_stack['stack_name'])
+
+        experiment_name = rand_name("experiment-")
+        experiment_description = rand_name("description-")
+        experiment = kfp_client.create_experiment(
+            experiment_name,
+            description=experiment_description,
+            namespace=DEFAULT_USER_NAMESPACE,
+        )
+
+        pipeline_id = kfp_client.get_pipeline_id(PIPELINE_NAME)
+        job_name = rand_name("run-")
+
+        run = kfp_client.run_pipeline(
+            experiment.id, job_name=job_name, pipeline_id=pipeline_id
+        )
+
+        assert run.name == job_name
+        assert run.pipeline_spec.pipeline_id == pipeline_id
+        assert run.status == None
+
+        resp = wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id)
+
+        workflow_manifest_json = resp.pipeline_runtime.workflow_manifest
+        workflow_manifest = json.loads(workflow_manifest_json)
+
+        s3_artifact_keys = []
+        for _, node in workflow_manifest['status']['nodes'].items():
+            if 'outputs' not in node:
+                continue
+            if 'artifacts' not in node['outputs']:
+                continue
+
+            for artifact in node['outputs']['artifacts']:
+                if 's3' not in artifact:
+                    continue
+                s3_artifact_keys.append(artifact['s3']['key'])
+
+        bucket_objects = s3_client.list_objects_v2(Bucket=stack_outputs['S3BucketName'])
+        content_keys = {content['Key'] for content in bucket_objects['Contents']}
+
+        assert f'pipelines/{pipeline_id}' in content_keys
+        for key in s3_artifact_keys:
+            assert key in content_keys
+
+        mysql_client = create_mysql_client(
+            user=cfn_stack['params']['DBUsername'],
+            password=cfn_stack['params']['DBPassword'],
+            host=stack_outputs['RDSEndpoint'],
+            database='mlpipeline'
+        )
+
+        resp = mysql.query(mysql_client, f"select * from run_details where UUID='{run.id}'")
+
+        assert len(resp) == 1
+        assert resp[0]['DisplayName'] == job_name
+        assert resp[0]['PipelineId'] == pipeline_id
+        assert resp[0]['Conditions'] == 'Succeeded'
+
+        kfp_client.delete_experiment(experiment.id)
+
+    def test_katib_experiment(self, setup, cluster, region, cfn_stack, cfn_client):
+        stack_outputs = get_stack_outputs(cfn_client, cfn_stack['stack_name'])
+
+        filepath = os.path.abspath(
+            os.path.join(CUSTOM_RESOURCE_TEMPLATES_FOLDER, KATIB_EXPERIMENT_FILE)
+        )
+
+        name = rand_name("katib-random-")
+        namespace = DEFAULT_USER_NAMESPACE
+        replacements = {"NAME": name, "NAMESPACE": namespace}
+
+        resp = create_katib_experiment_from_yaml(
+            cluster, region, filepath, namespace, replacements
+        )
+
+        assert resp["kind"] == "Experiment"
+        assert resp["metadata"]["name"] == name
+        assert resp["metadata"]["namespace"] == namespace
+
+        wait_for_katib_experiment_succeeded(cluster, region, namespace, name)
+
+        mysql_client = create_mysql_client(
+            user=cfn_stack['params']['DBUsername'],
+            password=cfn_stack['params']['DBPassword'],
+            host=stack_outputs['RDSEndpoint'],
+            database='kubeflow'
+        )
+
+        resp = mysql.query(mysql_client, f"select count(*) as count from observation_logs where trial_name like '{name}%'")
+
+        assert resp[0]['count'] > 0
+
+        resp = delete_katib_experiment(cluster, region, namespace, name)
+
+        assert resp["kind"] == "Experiment"
+        assert resp["metadata"]["name"] == name
+        assert resp["metadata"]["namespace"] == namespace
+
+        try:
+            get_katib_experiment(cluster, region, namespace, name)
+            raise AssertionError("Expected K8sApiException Not Found")
+        except K8sApiException as e:
+            assert "Not Found" == e.reason

--- a/distributions/aws/test/e2e/tests/test_rds_s3.py
+++ b/distributions/aws/test/e2e/tests/test_rds_s3.py
@@ -14,7 +14,7 @@ from e2e.utils.utils import (
 )
 from e2e.utils.config import metadata, configure_env_file
 
-from e2e.conftest import region, get_accesskey, get_secretkey
+from e2e.conftest import region, get_accesskey, get_secretkey, keep_successfully_created_resource
 
 from e2e.fixtures.cluster import cluster
 from e2e.fixtures.kustomize import kustomize
@@ -47,8 +47,6 @@ from e2e.utils.custom_resources import (
 
 from kfp_server_api.exceptions import ApiException as KFPApiException
 from kubernetes.client.exceptions import ApiException as K8sApiException
-
-from conftest import keep_successfully_created_resource
 
 RDS_S3_KUSTOMIZE_MANIFEST_PATH = "../../examples/rds-s3/"
 RDS_S3_CLOUDFORMATION_TEMPLATE_PATH = "./resources/cloudformation-templates/rds-s3.yaml"

--- a/distributions/aws/test/e2e/utils/cloudformation_resources.py
+++ b/distributions/aws/test/e2e/utils/cloudformation_resources.py
@@ -55,14 +55,14 @@ def delete_stack(cfn_client, stack_name, timeout=300, interval=10):
         WaiterConfig={"Delay": interval, "MaxAttempts": timeout // interval + 1},
     )
 
+
 def describe_stack(cfn_client, stack_name):
     """
     Describes a cloudformation stack
     """
 
-    return cfn_client.describe_stacks(
-        StackName=stack_name
-    )['Stacks'][0]
+    return cfn_client.describe_stacks(StackName=stack_name)["Stacks"][0]
+
 
 def get_stack_outputs(cfn_client, stack_name):
     """
@@ -74,7 +74,8 @@ def get_stack_outputs(cfn_client, stack_name):
 
     resp = describe_stack(cfn_client, stack_name)
 
-    return {o['OutputKey']: o['OutputValue'] for o in resp['Outputs']}
+    return {o["OutputKey"]: o["OutputValue"] for o in resp["Outputs"]}
+
 
 def create_cloudformation_fixture(
     metadata,
@@ -96,6 +97,7 @@ def create_cloudformation_fixture(
     Takes care of adding the resource details to the metadata and creating and tearing
     down the stack.
     """
+
     def on_create():
         create_stack(
             cfn_client=cfn_client,

--- a/distributions/aws/test/e2e/utils/cloudformation_resources.py
+++ b/distributions/aws/test/e2e/utils/cloudformation_resources.py
@@ -98,6 +98,8 @@ def create_cloudformation_fixture(
     down the stack.
     """
 
+    resource_details = {'stack_name': stack_name, 'params': params}
+
     def on_create():
         create_stack(
             cfn_client=cfn_client,
@@ -110,15 +112,15 @@ def create_cloudformation_fixture(
         )
 
     def on_delete():
-        name = metadata.get(metadata_key) or stack_name
+        details = metadata.get(metadata_key) or resource_details
+        
         delete_stack(
             cfn_client=cfn_client,
-            stack_name=name,
+            stack_name=details['stack_name'],
             timeout=delete_timeout,
             interval=delete_interval,
         )
 
-    resource_details = {"stack_name": stack_name, "params": params}
 
     return configure_resource_fixture(
         metadata=metadata,

--- a/distributions/aws/test/e2e/utils/cloudformation_resources.py
+++ b/distributions/aws/test/e2e/utils/cloudformation_resources.py
@@ -8,7 +8,7 @@ def create_stack(
     params={},
     capabilities=[],
     timeout=300,
-    interval=10,
+    interval=30,
 ):
     """
     Creates a cloudformation stack from a cloudformation template

--- a/distributions/aws/test/e2e/utils/cloudformation_resources.py
+++ b/distributions/aws/test/e2e/utils/cloudformation_resources.py
@@ -98,7 +98,7 @@ def create_cloudformation_fixture(
     down the stack.
     """
 
-    resource_details = {'stack_name': stack_name, 'params': params}
+    resource_details = {"stack_name": stack_name, "params": params}
 
     def on_create():
         create_stack(
@@ -113,14 +113,13 @@ def create_cloudformation_fixture(
 
     def on_delete():
         details = metadata.get(metadata_key) or resource_details
-        
+
         delete_stack(
             cfn_client=cfn_client,
-            stack_name=details['stack_name'],
+            stack_name=details["stack_name"],
             timeout=delete_timeout,
             interval=delete_interval,
         )
-
 
     return configure_resource_fixture(
         metadata=metadata,

--- a/distributions/aws/test/e2e/utils/cloudformation_resources.py
+++ b/distributions/aws/test/e2e/utils/cloudformation_resources.py
@@ -1,0 +1,128 @@
+from e2e.utils.config import configure_resource_fixture
+
+
+def create_stack(
+    cfn_client,
+    template_path,
+    stack_name,
+    params={},
+    capabilities=[],
+    timeout=300,
+    interval=10,
+):
+    """
+    Creates a cloudformation stack from a cloudformation template
+    """
+
+    with open(template_path) as file:
+        body = file.read()
+
+    stack_params = [
+        {"ParameterKey": key, "ParameterValue": value, "UsePreviousValue": False}
+        for key, value in params.items()
+    ]
+
+    resp = cfn_client.create_stack(
+        StackName=stack_name,
+        TemplateBody=body,
+        Parameters=stack_params,
+        Capabilities=capabilities,
+    )
+
+    stack_id = resp["StackId"]
+
+    print(f"Creating stack {stack_name}, waiting for stack create complete")
+    waiter = cfn_client.get_waiter("stack_create_complete")
+    waiter.wait(
+        StackName=stack_name,
+        WaiterConfig={"Delay": interval, "MaxAttempts": timeout // interval + 1},
+    )
+
+    return stack_name, stack_id
+
+
+def delete_stack(cfn_client, stack_name, timeout=300, interval=10):
+    """
+    Deletes a cloudformation stack
+    """
+
+    cfn_client.delete_stack(StackName=stack_name)
+
+    print(f"Deleting stack {stack_name}, waiting for stack delete complete")
+    waiter = cfn_client.get_waiter("stack_delete_complete")
+    waiter.wait(
+        StackName=stack_name,
+        WaiterConfig={"Delay": interval, "MaxAttempts": timeout // interval + 1},
+    )
+
+def describe_stack(cfn_client, stack_name):
+    """
+    Describes a cloudformation stack
+    """
+
+    return cfn_client.describe_stacks(
+        StackName=stack_name
+    )['Stacks'][0]
+
+def get_stack_outputs(cfn_client, stack_name):
+    """
+    Cloudformation stacks can be configured to output certain values upon stack
+    creation, such as an RDS endpoint URL or S3 bucket name.
+
+    This function returns the outputs of a stack as a dictionary.
+    """
+
+    resp = describe_stack(cfn_client, stack_name)
+
+    return {o['OutputKey']: o['OutputValue'] for o in resp['Outputs']}
+
+def create_cloudformation_fixture(
+    metadata,
+    request,
+    cfn_client,
+    template_path,
+    stack_name,
+    metadata_key,
+    params={},
+    capabilities=[],
+    create_timeout=300,
+    create_interval=10,
+    delete_timeout=300,
+    delete_interval=10,
+):
+    """
+    Helper function to create a cloudformation fixture.
+
+    Takes care of adding the resource details to the metadata and creating and tearing
+    down the stack.
+    """
+    def on_create():
+        create_stack(
+            cfn_client=cfn_client,
+            template_path=template_path,
+            stack_name=stack_name,
+            params=params,
+            capabilities=capabilities,
+            timeout=create_timeout,
+            interval=create_interval,
+        )
+
+    def on_delete():
+        name = metadata.get(metadata_key) or stack_name
+        delete_stack(
+            cfn_client=cfn_client,
+            stack_name=name,
+            timeout=delete_timeout,
+            interval=delete_interval,
+        )
+
+    resource_details = {"stack_name": stack_name, "params": params}
+
+    return configure_resource_fixture(
+        metadata=metadata,
+        request=request,
+        resource_details=resource_details,
+        metadata_key=metadata_key,
+        on_create=on_create,
+        on_delete=on_delete,
+    )

--- a/distributions/aws/test/e2e/utils/cognito_bootstrap/aws/elbv2.py
+++ b/distributions/aws/test/e2e/utils/cognito_bootstrap/aws/elbv2.py
@@ -25,7 +25,11 @@ class ElasticLoadBalancingV2:
 
     def describe(self) -> dict:
         try:
-            response = self.elbv2_client.describe_load_balancers(Names=[self.name,])
+            response = self.elbv2_client.describe_load_balancers(
+                Names=[
+                    self.name,
+                ]
+            )
         except ClientError:
             logger.exception(f"Failed to describe load balancer {self.name}")
         else:
@@ -44,12 +48,14 @@ class ElasticLoadBalancingV2:
             return dns[:last_hypen_index]
         else:
             return dns_prefix
-    
+
     def get_registered_target_groups(self, alb_arn: str) -> dict:
         try:
             response = self.elbv2_client.describe_target_groups(LoadBalancerArn=alb_arn)
         except ClientError:
-            logger.exception(f"Failed to get registered target groups for load balancer {self.name}")
+            logger.exception(
+                f"Failed to get registered target groups for load balancer {self.name}"
+            )
         else:
             return response["TargetGroups"]
 
@@ -64,7 +70,7 @@ class ElasticLoadBalancingV2:
             except ClientError:
                 logger.exception(f"failed to delete target group {target_group_arn}")
                 pass
-    
+
     def get_listeners(self, alb_arn: str) -> dict:
         try:
             response = self.elbv2_client.describe_listeners(LoadBalancerArn=alb_arn)
@@ -72,7 +78,7 @@ class ElasticLoadBalancingV2:
             logger.exception(f"Failed to get listeners for load balancer {self.name}")
         else:
             return response["Listeners"]
-    
+
     def delete_listeners(self, listeners):
         for listener in listeners:
             listener_arn = listener["ListenerArn"]

--- a/distributions/aws/test/e2e/utils/cognito_bootstrap/aws/route53.py
+++ b/distributions/aws/test/e2e/utils/cognito_bootstrap/aws/route53.py
@@ -41,7 +41,8 @@ class Route53HostedZone:
         )
         try:
             response = self.route53_client.create_hosted_zone(
-                Name=self.domain, CallerReference=f"{self.domain}-{randstr}",
+                Name=self.domain,
+                CallerReference=f"{self.domain}-{randstr}",
             )
         except ClientError:
             logger.exception(

--- a/distributions/aws/test/e2e/utils/cognito_bootstrap/cognito_post_deployment.py
+++ b/distributions/aws/test/e2e/utils/cognito_bootstrap/cognito_post_deployment.py
@@ -37,15 +37,21 @@ def update_hosted_zone_with_alb(
     # dual stack prefix is needed when creating an alias dns record for ELB
     alb = ElasticLoadBalancingV2(dns=alb_dns, region=deployment_region)
     alb_details = alb.describe()
-    updated_subdomain_A_record = subdomain_hosted_zone.generate_change_record_type_alias_target(
-        record_name=subdomain_name,
-        record_type="A",
-        hosted_zone_id=alb_details["CanonicalHostedZoneId"],
-        dns_name="dualstack." + alb_dns,
+    updated_subdomain_A_record = (
+        subdomain_hosted_zone.generate_change_record_type_alias_target(
+            record_name=subdomain_name,
+            record_type="A",
+            hosted_zone_id=alb_details["CanonicalHostedZoneId"],
+            dns_name="dualstack." + alb_dns,
+        )
     )
 
     subdomain_hosted_zone.change_record_set(
-        [_platform_record, _default_platform_record, updated_subdomain_A_record,]
+        [
+            _platform_record,
+            _default_platform_record,
+            updated_subdomain_A_record,
+        ]
     )
 
 

--- a/distributions/aws/test/e2e/utils/cognito_bootstrap/cognito_pre_deployment.py
+++ b/distributions/aws/test/e2e/utils/cognito_bootstrap/cognito_pre_deployment.py
@@ -152,7 +152,10 @@ if __name__ == "__main__":
 
     utils.print_banner("Creating Subdomain in Route 53")
     root_hosted_zone, subdomain_hosted_zone = create_subdomain_hosted_zone(
-        subdomain_name, root_domain_name, deployment_region, root_domain_hosted_zone_id,
+        subdomain_name,
+        root_domain_name,
+        deployment_region,
+        root_domain_hosted_zone_id,
     )
     cfg["route53"]["subDomain"]["hostedZoneId"] = subdomain_hosted_zone.id
     utils.write_cfg(cfg)

--- a/distributions/aws/test/e2e/utils/cognito_bootstrap/cognito_pre_deployment_cleanup.py
+++ b/distributions/aws/test/e2e/utils/cognito_bootstrap/cognito_pre_deployment_cleanup.py
@@ -45,7 +45,10 @@ def delete_cert(acm_certificate):
 
 
 def clean_root_domain(domain_name, hosted_zone_id, subdomain_hosted_zone):
-    root_hosted_zone = Route53HostedZone(domain=domain_name, id=hosted_zone_id,)
+    root_hosted_zone = Route53HostedZone(
+        domain=domain_name,
+        id=hosted_zone_id,
+    )
 
     try:
         # delete the subdomain entry from the root domain
@@ -59,12 +62,14 @@ def clean_root_domain(domain_name, hosted_zone_id, subdomain_hosted_zone):
     except Exception:
         pass
 
+
 def delete_alb(dns: str, region: str):
     try:
         alb = ElasticLoadBalancingV2(dns=dns, region=region)
         alb.delete()
     except Exception:
         pass
+
 
 def delete_cognito_dependency_resources(cfg: dict):
     deployment_region = cfg["kubeflow"]["region"]
@@ -77,7 +82,8 @@ def delete_cognito_dependency_resources(cfg: dict):
     if subdomain_hosted_zone_id:
         subdomain_name = cfg["route53"]["subDomain"]["name"]
         subdomain_hosted_zone = Route53HostedZone(
-            domain=subdomain_name, id=subdomain_hosted_zone_id,
+            domain=subdomain_name,
+            id=subdomain_hosted_zone_id,
         )
 
         if root_domain_hosted_zone_id:
@@ -117,7 +123,7 @@ def delete_cognito_dependency_resources(cfg: dict):
                 domain_cert_arn=subdomain_cert_deployment_region.arn,
                 region=deployment_region,
             )
-        
+
         # delete ALB
         alb_dns = cfg["kubeflow"].get("ALBDNS", None)
         if alb_dns:
@@ -130,6 +136,7 @@ def delete_cognito_dependency_resources(cfg: dict):
 
         # delete hosted zone
         subdomain_hosted_zone.delete_hosted_zone()
+
 
 if __name__ == "__main__":
     utils.print_banner("Reading Config")

--- a/distributions/aws/test/e2e/utils/config.py
+++ b/distributions/aws/test/e2e/utils/config.py
@@ -75,7 +75,7 @@ def metadata(request):
 
 
 def configure_resource_fixture(
-    metadata, request, resource_id, metadata_key, on_create, on_delete
+    metadata, request, resource_details, metadata_key, on_create, on_delete
 ):
     """
     Helper method to create resources if required and configure them for teardown.
@@ -99,7 +99,7 @@ def configure_resource_fixture(
 
     if not metadata.get(metadata_key):
         on_create()
-        metadata.save(metadata_key, resource_id)
+        metadata.save(metadata_key, resource_details)
 
     successful_creation = True
     return metadata.get(metadata_key)

--- a/distributions/aws/test/e2e/utils/constants.py
+++ b/distributions/aws/test/e2e/utils/constants.py
@@ -2,8 +2,19 @@
 Global constants module
 """
 
+# Generic
+
 DEFAULT_HOST = "http://localhost:8080/"
 DEFAULT_USER_NAMESPACE = "kubeflow-user-example-com"
 DEFAULT_USERNAME = "user@example.com"
 DEFAULT_PASSWORD = "12341234"
 KUBEFLOW_GROUP = "kubeflow.org"
+KUBEFLOW_NAMESPACE = "kubeflow"
+KUBEFLOW_SERVICE_ACCOUNT_NAME = "kubeflow-secrets-manager-sa"
+
+# IAM
+
+IAM_AWS_SSM_READ_ONLY_POLICY = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+IAM_SECRETS_MANAGER_READ_WRITE_POLICY = (
+    "arn:aws:iam::aws:policy/SecretsManagerReadWrite"
+)

--- a/distributions/aws/test/e2e/utils/constants.py
+++ b/distributions/aws/test/e2e/utils/constants.py
@@ -2,19 +2,9 @@
 Global constants module
 """
 
-# Generic
-
 DEFAULT_HOST = "http://localhost:8080/"
 DEFAULT_USER_NAMESPACE = "kubeflow-user-example-com"
 DEFAULT_USERNAME = "user@example.com"
 DEFAULT_PASSWORD = "12341234"
 KUBEFLOW_GROUP = "kubeflow.org"
 KUBEFLOW_NAMESPACE = "kubeflow"
-KUBEFLOW_SERVICE_ACCOUNT_NAME = "kubeflow-secrets-manager-sa"
-
-# IAM
-
-IAM_AWS_SSM_READ_ONLY_POLICY = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
-IAM_SECRETS_MANAGER_READ_WRITE_POLICY = (
-    "arn:aws:iam::aws:policy/SecretsManagerReadWrite"
-)

--- a/distributions/aws/test/e2e/utils/custom_resources.py
+++ b/distributions/aws/test/e2e/utils/custom_resources.py
@@ -3,7 +3,7 @@ Module for helper methods to create and delete kubernetes custom resources (e.g.
 """
 
 from e2e.utils.utils import unmarshal_yaml
-from e2e.fixtures.clients import k8s_custom_objects_api_client
+from e2e.fixtures.clients import create_k8s_custom_objects_api_client
 
 from e2e.utils.constants import KUBEFLOW_GROUP
 
@@ -12,7 +12,7 @@ def create_namespaced_resource_from_yaml(
     cluster, region, yaml_file, group, version, plural, namespace, replacements={}
 ):
     body = unmarshal_yaml(yaml_file, replacements)
-    client = k8s_custom_objects_api_client(cluster, region)
+    client = create_k8s_custom_objects_api_client(cluster, region)
 
     return client.create_namespaced_custom_object(
         group=group, version=version, namespace=namespace, plural=plural, body=body
@@ -20,7 +20,7 @@ def create_namespaced_resource_from_yaml(
 
 
 def get_namespaced_resource(cluster, region, group, version, plural, namespace, name):
-    client = k8s_custom_objects_api_client(cluster, region)
+    client = create_k8s_custom_objects_api_client(cluster, region)
 
     return client.get_namespaced_custom_object(
         group=group, version=version, namespace=namespace, plural=plural, name=name
@@ -30,7 +30,7 @@ def get_namespaced_resource(cluster, region, group, version, plural, namespace, 
 def delete_namespaced_resource(
     cluster, region, group, version, plural, namespace, name
 ):
-    client = k8s_custom_objects_api_client(cluster, region)
+    client = create_k8s_custom_objects_api_client(cluster, region)
     return client.delete_namespaced_custom_object(
         group=group, version=version, namespace=namespace, plural=plural, name=name
     )

--- a/distributions/aws/test/e2e/utils/k8s_core_api.py
+++ b/distributions/aws/test/e2e/utils/k8s_core_api.py
@@ -15,4 +15,3 @@ def create_namespace(cluster, region, namespace_name):
     except ApiException as e:
         if "Conflict" != e.reason:
             raise e
-

--- a/distributions/aws/test/e2e/utils/k8s_core_api.py
+++ b/distributions/aws/test/e2e/utils/k8s_core_api.py
@@ -1,0 +1,18 @@
+"""
+Module for helper methods to create and delete kubernetes core api resources (e.g. pods, namespaces, etc.)
+"""
+
+from kubernetes.client import V1Namespace
+from kubernetes.client.exceptions import ApiException
+
+from e2e.fixtures.clients import create_k8s_core_api_client
+
+
+def create_namespace(cluster, region, namespace_name):
+    client = create_k8s_core_api_client(cluster, region)
+    try:
+        client.create_namespace(V1Namespace(metadata=dict(name=namespace_name)))
+    except ApiException as e:
+        if "Conflict" != e.reason:
+            raise e
+

--- a/distributions/aws/test/e2e/utils/mysql.py
+++ b/distributions/aws/test/e2e/utils/mysql.py
@@ -1,0 +1,19 @@
+import mysql.connector
+
+def query(mysql_client: mysql.connector.MySQLConnection, query):
+    """
+    Query a mysql database using SQL syntax
+    """
+
+    cursor = mysql_client.cursor(dictionary=True)
+
+    cursor.execute(query)
+
+    results = []
+    for row in cursor:
+        results.append(row)
+
+    cursor.close()
+    mysql_client.commit()
+
+    return results

--- a/distributions/aws/test/e2e/utils/mysql.py
+++ b/distributions/aws/test/e2e/utils/mysql.py
@@ -1,5 +1,6 @@
 import mysql.connector
 
+
 def query(mysql_client: mysql.connector.MySQLConnection, query):
     """
     Query a mysql database using SQL syntax

--- a/distributions/aws/test/e2e/utils/utils.py
+++ b/distributions/aws/test/e2e/utils/utils.py
@@ -49,6 +49,14 @@ def unmarshal_yaml(yaml_file, replacements={}):
 
     return yaml.safe_load(contents)
 
+class WaitForCircuitBreakerError(Exception):
+    """
+    When this exception is thrown, the below wait_for function
+    will exit immediately. Useful to escape a retry loop in failure scenarios
+    where the only other option would be to wait for an eventual timeout. 
+    """
+
+    pass
 
 def wait_for(callback, timeout=300, interval=10):
     """
@@ -64,6 +72,8 @@ def wait_for(callback, timeout=300, interval=10):
     while True:
         try:
             return callback()
+        except WaitForCircuitBreakerError as we:
+            raise we
         except Exception as e:
             if time.time() - start >= timeout:
                 raise e

--- a/distributions/aws/test/e2e/utils/utils.py
+++ b/distributions/aws/test/e2e/utils/utils.py
@@ -4,6 +4,7 @@ Generic helper methods module
 
 import json
 import os
+import subprocess
 import time
 import random
 import string
@@ -107,3 +108,7 @@ def get_iam_client(region):
 
 def get_ec2_client(region):
     return boto3.client("ec2", region_name=region)
+
+def kubectl_apply(path):
+    cmd = f"kubectl apply -f {path}".split()
+    subprocess.call(cmd)

--- a/distributions/aws/test/e2e/utils/utils.py
+++ b/distributions/aws/test/e2e/utils/utils.py
@@ -49,14 +49,16 @@ def unmarshal_yaml(yaml_file, replacements={}):
 
     return yaml.safe_load(contents)
 
+
 class WaitForCircuitBreakerError(Exception):
     """
     When this exception is thrown, the below wait_for function
     will exit immediately. Useful to escape a retry loop in failure scenarios
-    where the only other option would be to wait for an eventual timeout. 
+    where the only other option would be to wait for an eventual timeout.
     """
 
     pass
+
 
 def wait_for(callback, timeout=300, interval=10):
     """

--- a/distributions/aws/test/e2e/utils/utils.py
+++ b/distributions/aws/test/e2e/utils/utils.py
@@ -10,6 +10,7 @@ import random
 import string
 import yaml
 import boto3
+import mysql.connector
 
 
 def safe_open(filepath, mode="r"):
@@ -61,7 +62,7 @@ class WaitForCircuitBreakerError(Exception):
     pass
 
 
-def wait_for(callback, timeout=300, interval=10):
+def wait_for(callback, timeout=300, interval=30):
     """
     Provide a function with no arguments as a callback.
 
@@ -108,6 +109,25 @@ def get_iam_client(region):
 
 def get_ec2_client(region):
     return boto3.client("ec2", region_name=region)
+
+
+def get_cfn_client(region):
+    return boto3.client("cloudformation", region_name=region)
+
+
+def get_s3_client(region):
+    return boto3.client("s3", region_name=region)
+
+
+def get_secrets_manager_client(region):
+    return boto3.client("secretsmanager", region_name=region)
+
+
+def get_mysql_client(user, password, host, database) -> mysql.connector.MySQLConnection:
+    return mysql.connector.connect(
+        user=user, password=password, host=host, database=database
+    )
+
 
 def kubectl_apply(path):
     cmd = f"kubectl apply -f {path}".split()


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #30 #40 

**Description of your changes:**
Add testing for KFP and Katib components when KF is configured to use AWS RDS and AWS S3.

KFP testing:
- Verifies `mlpipeline` database is created
- Verifies KFP experiments show up in the `experiments` table with the correct input values and are deleted when experiments are deleted
- Verifies KFP runs show up in the `run_details` table with correct input values including s3 bucket URIs
- Verifies a sample pipeline is present in S3 after KF installation
- Verifies the S3 buckets with the run artifacts are present

Katib testing:
- Verifies the RDS database configured for Katib (usually `kubeflow`) is present
- Verifies the `observations_logs` table is present in the `kubeflow` database
- Verifies the observations logs are stored in the `observations_log` table when a Katib experiment is running


**Testing**
```
~/kf-e2e-tests/distributions/aws/test/e2e v1.3-branch-e2e-rds-s3
kf-e2e-test-env ❯ pytest tests/test_rds_s3.py -s -q --region ap-northeast-1 --keepsuccess --metadata .metadata/metadata-1639682815356347000 --accesskey HIDDEN --secretkey HIDDEN
Forwarding from 127.0.0.1:8080 -> 8080
Forwarding from [::1]:8080 -> 8080
{'region': 'ap-northeast-1', 'cluster_name': 'e2e-test-cluster-dk7mb74fb8', 'test_rds_s3_cfn_stack': {'stack_name': 'test-e2e-rds-stack-o3l8t6mjsh', 'params': {'VpcId': 'vpc-0a6335934b70eedbf', 'Subnets': 'subnet-0d7b109c23835c826,subnet-06865157fe00fd829,subnet-048cdbb3389efafa0', 'SecurityGroupId': 'sg-0d4c3402d7a509646', 'DBUsername': HIDDEN, 'DBPassword': HIDDEN}}, 'kustomize_path': '../../examples/rds-s3/'}
Created metadata file for TestRDSS3 /Users/rkharse/kf-e2e-tests/distributions/aws/test/e2e/.metadata/metadata-1639684349773910000
Handling connection for 8080
Handling connection for 8080
...
3 passed in 285.73s (0:04:45)
```

