### PR TITLE
[WIP] Storage Options: FSx, Dynamic Provisioning on Kubeflow 1.3

### DIFF
--- a/distributions/aws/examples/storage/fsx-for-lustre/README.md
+++ b/distributions/aws/examples/storage/fsx-for-lustre/README.md
@@ -103,6 +103,8 @@ kubectl apply -f fsx-for-lustre/static-provisioning/pvc.yaml
 ```
 
 ## 5.2 Provisioning Option 2: Dynamic Provisioning
+Note: There are some known issues when using Dynamic Provisioning for FSx on Kubernetes v1.20. Refer to this [Github Issue](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/183).
+
 The Dynamic Provisioning does not require you to create an FSx Volume upfront but instead deploys based on the configuration in the storageClass spec. We have provided one specific example here but for more details and configuration options refer to the [upstream documentation here](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/tree/master/examples/kubernetes/dynamic_provisioning).
 
 1. Determine the IDs of the subnets in your VPC and which Availability Zone the subnet is in. Use one public subnet while creating the filesystem

--- a/distributions/aws/examples/storage/fsx-for-lustre/dynamic-provisioning/pvc.yaml
+++ b/distributions/aws/examples/storage/fsx-for-lustre/dynamic-provisioning/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fsx-claim-dynamic
+  namespace: <namespace>
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: fsx-sc-dynamic
+  resources:
+    requests:
+      storage: 1200Gi

--- a/distributions/aws/examples/storage/fsx-for-lustre/dynamic-provisioning/sc.yaml
+++ b/distributions/aws/examples/storage/fsx-for-lustre/dynamic-provisioning/sc.yaml
@@ -1,0 +1,18 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fsx-sc-dynamic
+provisioner: fsx.csi.aws.com
+parameters:
+  subnetId: <subnet-idxxx>
+  securityGroupIds: <sg-idxxx>
+  deploymentType: PERSISTENT_1
+  automaticBackupRetentionDays: "1"
+  dailyAutomaticBackupStartTime: "00:00"
+  copyTagsToBackups: "true"
+  perUnitStorageThroughput: "200"
+  dataCompressionType: "NONE"
+  weeklyMaintenanceStartTime: "7:09:00"
+  fileSystemTypeVersion: "2.12"
+mountOptions:
+  - flock

--- a/distributions/aws/examples/storage/notebook-sample/set-permission-job.yaml
+++ b/distributions/aws/examples/storage/notebook-sample/set-permission-job.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: set-permission-fsx
+  namespace: kubeflow-user-example-com
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: app
+        image: centos
+        command: ["/bin/sh"]
+        args:
+        - "-c"
+        - "chmod 2775 /data && chown root:users /data"
+        volumeMounts:
+        - name: persistent-storage
+          mountPath: /data
+      volumes:
+      - name: persistent-storage
+        persistentVolumeClaim:
+          claimName: 	fsx-claim


### PR DESCRIPTION
**Description of your changes:**
Storage Options: FSx, Dynamic Provisioning on Kubeflow 1.3 includes - 
- [x] Updates to the README to add dynamic provisioning for FSX
- [x] Required storageClass and PersistentVolumeClaim Spec files
- [x] Minor file restructuring. 

Testing
- [x] Tested that I could follow the README to provision an instance of FSx filesystem and use it to load a Kubeflow Notebook Server. 

TODO: 
- [ ] Manual addition of the IAM Policy to worker node should not be needed, needs to be fixed. 
- [ ] Rebase on PR #35 once merged


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
