### PR TITLE
[WIP] Storage Options: EFS, Dynamic Provisioning on Kubeflow 1.3

### DIFF
--- a/distributions/aws/examples/storage/efs/dynamic-provisioning/pvc.yaml
+++ b/distributions/aws/examples/storage/efs/dynamic-provisioning/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: efs-claim-dynamic
+  namespace: kubeflow-user-example-com
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: efs-sc-dynamic
+  resources:
+    requests:
+      storage: 5Gi

--- a/distributions/aws/examples/storage/efs/dynamic-provisioning/sc.yaml
+++ b/distributions/aws/examples/storage/efs/dynamic-provisioning/sc.yaml
@@ -1,0 +1,12 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: efs-sc-dynamic
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: <fs-xxxxx>
+  directoryPerms: "700"
+  gidRangeStart: "1000" # optional
+  gidRangeEnd: "2000" # optional
+  basePath: "/dynamic_provisioning" # optional


### PR DESCRIPTION
**Description of your changes:**
Storage Options: EFS, Dynamic Provisioning on Kubeflow 1.3 includes - 
- [x] Updates to the README to add dynamic provisioning for EFS
- [x] Required storageClass Spec file

[In-progress] Testing
- [ ] Tested that I could follow the README to provision an instance of EFS filesystem and use it to load a Kubeflow Notebook Server. 

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
