### PR TITLE
Test for EFS CSI Driver installation; Volume, PV and PVC creation on Kubeflow deployment

### DIFF
--- a/distributions/aws/test/e2e/fixtures/cluster.py
+++ b/distributions/aws/test/e2e/fixtures/cluster.py
@@ -87,3 +87,23 @@ def cluster(metadata, region, request):
     return configure_resource_fixture(
         metadata, request, cluster_name, "cluster_name", on_create, on_delete
     )
+
+
+def create_iam_service_account(
+    service_account_name, namespace, cluster_name, region, iam_policy_arns
+):
+    cmd = []
+    cmd += "eksctl create iamserviceaccount".split()
+    cmd += f"--name {service_account_name}".split()
+    cmd += f"--namespace {namespace}".split()
+    cmd += f"--cluster {cluster_name}".split()
+    cmd += f"--region {region}".split()
+
+    for arn in iam_policy_arns:
+        cmd += f"--attach-policy-arn {arn}".split()
+
+    cmd += "--override-existing-serviceaccounts".split()
+    cmd += "--approve".split()
+
+    retcode = subprocess.call(cmd)
+    assert retcode == 0

--- a/distributions/aws/test/e2e/fixtures/cluster.py
+++ b/distributions/aws/test/e2e/fixtures/cluster.py
@@ -61,7 +61,8 @@ def create_iam_service_account(
     cmd += "--override-existing-serviceaccounts".split()
     cmd += "--approve".split()
 
-    subprocess.call(cmd)
+    retcode = subprocess.call(cmd)
+    assert retcode == 0
 
 
 @pytest.fixture(scope="class")
@@ -87,23 +88,4 @@ def cluster(metadata, region, request):
     return configure_resource_fixture(
         metadata, request, cluster_name, "cluster_name", on_create, on_delete
     )
-
-
-def create_iam_service_account(
-    service_account_name, namespace, cluster_name, region, iam_policy_arns
-):
-    cmd = []
-    cmd += "eksctl create iamserviceaccount".split()
-    cmd += f"--name {service_account_name}".split()
-    cmd += f"--namespace {namespace}".split()
-    cmd += f"--cluster {cluster_name}".split()
-    cmd += f"--region {region}".split()
-
-    for arn in iam_policy_arns:
-        cmd += f"--attach-policy-arn {arn}".split()
-
-    cmd += "--override-existing-serviceaccounts".split()
-    cmd += "--approve".split()
-
-    retcode = subprocess.call(cmd)
-    assert retcode == 0
+    

--- a/distributions/aws/test/e2e/fixtures/storage_efs_dependencies.py
+++ b/distributions/aws/test/e2e/fixtures/storage_efs_dependencies.py
@@ -12,6 +12,7 @@ from e2e.utils.config import configure_resource_fixture
 from e2e.fixtures.cluster import associate_iam_oidc_provider, create_iam_service_account
 from e2e.utils.utils import (
     rand_name,
+    wait_for,
     get_iam_client,
     get_eks_client,
     get_ec2_client,
@@ -28,14 +29,16 @@ DEFAULT_NAMESPACE = "kube-system"
 
 
 def wait_on_efs_status(desired_status, efs_client, file_system_id):
-    filesystem_status = ""
-    while filesystem_status != desired_status:
+
+    def callback():
         response = efs_client.describe_file_systems(
             FileSystemId=file_system_id,
         )
         filesystem_status = response["FileSystems"][0]["LifeCycleState"]
         print(f"{file_system_id} {filesystem_status} .... waiting")
-        time.sleep(10)
+        assert filesystem_status == desired_status
+        
+    wait_for(callback)
 
 
 @pytest.fixture(scope="class")

--- a/distributions/aws/test/e2e/fixtures/storage_efs_dependencies.py
+++ b/distributions/aws/test/e2e/fixtures/storage_efs_dependencies.py
@@ -1,20 +1,13 @@
-import os
-
 import time
 import pytest
 import subprocess
-import boto3, urllib
+import boto3
 
 from e2e.utils.config import metadata
 from e2e.utils.cognito_bootstrap.common import load_cfg, write_cfg
-
 from e2e.conftest import region
-
-from e2e.utils.utils import kubectl_apply, kubectl_delete
 from e2e.fixtures.cluster import cluster
-
 from e2e.utils.utils import rand_name
-
 from e2e.utils.config import configure_resource_fixture
 from e2e.fixtures.cluster import associate_iam_oidc_provider, create_iam_service_account
 from e2e.utils.utils import (
@@ -25,91 +18,104 @@ from e2e.utils.utils import (
     get_efs_client,
     curl_file_to_path,
     get_aws_account_id,
+    kubectl_apply,
+    kubectl_delete,
+    kubectl_apply_kustomize,
+    kubectl_delete_kustomize,
 )
+
+DEFAULT_NAMESPACE = "kube-system"
 
 
 def wait_on_efs_status(desired_status, efs_client, file_system_id):
     filesystem_status = ""
     while filesystem_status != desired_status:
-            response = efs_client.describe_file_systems(
+        response = efs_client.describe_file_systems(
             FileSystemId=file_system_id,
-            )
-            filesystem_status=response["FileSystems"][0]["LifeCycleState"]
-            print(f"{file_system_id} {filesystem_status} .... waiting")
-            time.sleep(10)
+        )
+        filesystem_status = response["FileSystems"][0]["LifeCycleState"]
+        print(f"{file_system_id} {filesystem_status} .... waiting")
+        time.sleep(10)
+
 
 @pytest.fixture(scope="class")
 def install_efs_csi_driver(metadata, region, request, cluster):
     EFS_CSI_DRIVER = "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v1.3.4"
 
     def on_create():
-        apply_retcode = subprocess.call(f"kubectl apply -k {EFS_CSI_DRIVER}".split())
-        assert apply_retcode == 0
+        kubectl_apply_kustomize(EFS_CSI_DRIVER)
 
     def on_delete():
-        apply_retcode = subprocess.call(f"kubectl delete -k {EFS_CSI_DRIVER}".split())
-        assert apply_retcode == 0
+        kubectl_delete_kustomize(EFS_CSI_DRIVER)
 
 
 @pytest.fixture(scope="class")
 def create_iam_policy(metadata, region, request, cluster):
-    # Existing IAM Client with Region does not work.
-    policy_name = rand_name("efs-iam-policy-")
-    iam_client = boto3.client('iam')
-    EFS_IAM_POLICY = "https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v1.3.4/docs/iam-policy-example.json"
-    aws_account_id = get_aws_account_id
+    # TODO: Existing IAM Client with Region does not seem to work.
     efs_deps = {}
+    iam_client = boto3.client("iam")
+
+    EFS_IAM_POLICY = "https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v1.3.4/docs/iam-policy-example.json"
+    policy_name = rand_name("efs-iam-policy-")
+    aws_account_id = get_aws_account_id()
     policy_arn = [f"arn:aws:iam::{aws_account_id}:policy/{policy_name}"]
 
     def on_create():
         associate_iam_oidc_provider(cluster, region)
         curl_file_to_path(EFS_IAM_POLICY, "iam-policy-example.json")
-        with open('iam-policy-example.json', 'r') as myfile:
-            policy=myfile.read()
+        with open("iam-policy-example.json", "r") as myfile:
+            policy = myfile.read()
 
         response = iam_client.create_policy(
             PolicyName=policy_name,
             PolicyDocument=policy,
-            )
-        # TODO: Why is this failing ?!
-        #create_iam_service_account("efs-csi-controller-sa", "kube-system", cluster, region, policy_arn)
+        )
+
+        create_iam_service_account(
+            "efs-csi-controller-sa", DEFAULT_NAMESPACE, cluster, region, policy_arn
+        )
         efs_deps["efs_iam_policy_name"] = policy_name
 
     def on_delete():
-        pass
+        details_efs_deps = metadata.get("efs_deps")
+        policy_name = details_efs_deps["efs_iam_policy_name"]
+        response = iam_client.delete_policy(
+            PolicyName=policy_name,
+        )
 
     return configure_resource_fixture(
         metadata, request, efs_deps, "efs_deps", on_create, on_delete
     )
-        
+
 
 @pytest.fixture(scope="class")
 def create_efs_volume(metadata, region, request, cluster):
     efs_volume = {}
+    eks_client = get_eks_client(region)
+    ec2_client = get_ec2_client(region)
+    efs_client = get_efs_client(region)
+
     def on_create():
         # Get VPC ID
-        eks_client = get_eks_client(region)
         response = eks_client.describe_cluster(name=cluster)
         vpc_id = response["cluster"]["resourcesVpcConfig"]["vpcId"]
 
         # Get CIDR Range
-        ec2_client = get_ec2_client(region)
         response = ec2_client.describe_vpcs(
             VpcIds=[
                 vpc_id,
-                ]
-            )
-        cidr_ip=response["Vpcs"][0]["CidrBlock"]
+            ]
+        )
+        cidr_ip = response["Vpcs"][0]["CidrBlock"]
 
         # Create Security Group
         security_group_name = rand_name("efs-security-group-")
         response = ec2_client.create_security_group(
             VpcId=vpc_id,
             GroupName=security_group_name,
-            Description="My EFS security group"
-            )
-        security_group_id=response["GroupId"]
-
+            Description="My EFS security group",
+        )
+        security_group_id = response["GroupId"]
         efs_volume["security_group_id"] = security_group_id
 
         # Open Port for CIDR Range
@@ -119,23 +125,13 @@ def create_efs_volume(metadata, region, request, cluster):
             ToPort=2049,
             CidrIp=cidr_ip,
             IpProtocol="tcp",
-            )
-
-        # Open Port for same security group
-        # response = ec2_client.authorize_security_group_ingress(
-        #     GroupId=security_group_id,
-        #     FromPort=2049,
-        #     ToPort=2049,
-        #     SourceSecurityGroupName=security_group_name,
-        #     IpProtocol="tcp",
-        #     )
+        )
 
         # Create an Amazon EFS FileSystem for your EKS Cluster
-        efs_client = get_efs_client(region)
         response = efs_client.create_file_system(
             PerformanceMode="generalPurpose",
-            )
-        file_system_id=response["FileSystemId"]
+        )
+        file_system_id = response["FileSystemId"]
 
         # Check for status of filesystem to be "available" before creating mount targets
         wait_on_efs_status("available", efs_client, file_system_id)
@@ -152,10 +148,10 @@ def create_efs_volume(metadata, region, request, cluster):
             ]
         )
 
-        # Create Mount Targets for each subnet - TODO: Check how many subnets this needs to be added to. 
+        # Create Mount Targets for each subnet - TODO: Check how many subnets this needs to be added to.
         subnets = response["Subnets"]
         for subnet in subnets:
-            subnet_id=subnet["SubnetId"]
+            subnet_id = subnet["SubnetId"]
             response = efs_client.create_mount_target(
                 FileSystemId=file_system_id,
                 SecurityGroups=[
@@ -169,69 +165,68 @@ def create_efs_volume(metadata, region, request, cluster):
 
     def on_delete():
         # Get FileSystem_ID
-        efs_client = get_efs_client(region)
-        ec2_client = get_ec2_client(region)
         details_efs_volume = metadata.get("efs_volume")
         fs_id = details_efs_volume["file_system_id"]
         sg_id = details_efs_volume["security_group_id"]
 
-        # Delete Any Existing Mount Targets
+        # Delete the Mount Targets
         response = efs_client.describe_mount_targets(
             FileSystemId=fs_id,
-            )
+        )
         existing_mount_targets = response["MountTargets"]
         for mount_target in existing_mount_targets:
-            mount_target_id=mount_target["MountTargetId"]
+            mount_target_id = mount_target["MountTargetId"]
             response = efs_client.delete_mount_target(
                 MountTargetId=mount_target_id,
             )
 
-        #Delete the Filesystem
+        # Delete the Filesystem
         response = efs_client.delete_file_system(
             FileSystemId=fs_id,
-            )
+        )
         wait_on_efs_status("deleted", efs_client, fs_id)
 
         # Delete the Security Group
-        response = ec2_client.delete_security_group(
-            GroupId=sg_id
-        )
+        response = ec2_client.delete_security_group(GroupId=sg_id)
 
     return configure_resource_fixture(
         metadata, request, efs_volume, "efs_volume", on_create, on_delete
     )
 
+
 @pytest.fixture(scope="class")
 def static_provisioning(metadata, region, request, cluster):
     details_efs_volume = metadata.get("efs_volume")
     fs_id = details_efs_volume["file_system_id"]
+    claim_name = rand_name("efs-claim-")
     efs_sc_filepath = "../../examples/storage/efs/static-provisioning/sc.yaml"
     efs_pv_filepath = "../../examples/storage/efs/static-provisioning/pv.yaml"
     efs_pvc_filepath = "../../examples/storage/efs/static-provisioning/pvc.yaml"
-    PVC_NAMESPACE="kubeflow-user-example-com"
     efs_claim = {}
 
     def on_create():
         # Add the filesystem_id to the pv.yaml file
         efs_pv = load_cfg(efs_pv_filepath)
         efs_pv["spec"]["csi"]["volumeHandle"] = fs_id
+        efs_pv["metadata"]["name"] = claim_name
         write_cfg(efs_pv, efs_pv_filepath)
 
         # Add the namespace to the pvc.yaml file
         efs_pvc = load_cfg(efs_pvc_filepath)
-        efs_pvc["metadata"]["namespace"] = PVC_NAMESPACE
+        efs_pvc["metadata"]["namespace"] = DEFAULT_NAMESPACE
+        efs_pvc["metadata"]["name"] = claim_name
         write_cfg(efs_pvc, efs_pvc_filepath)
 
         kubectl_apply(efs_sc_filepath)
         kubectl_apply(efs_pv_filepath)
         kubectl_apply(efs_pvc_filepath)
 
-        efs_claim["claim_name"] = "efs_claim"
-        
+        efs_claim["claim_name"] = claim_name
+
     def on_delete():
-        kubectl_delete(efs_sc_filepath)
-        kubectl_delete(efs_pv_filepath)
         kubectl_delete(efs_pvc_filepath)
+        kubectl_delete(efs_pv_filepath)
+        kubectl_delete(efs_sc_filepath)
 
     return configure_resource_fixture(
         metadata, request, efs_claim, "efs_claim", on_create, on_delete

--- a/distributions/aws/test/e2e/fixtures/storage_efs_dependencies.py
+++ b/distributions/aws/test/e2e/fixtures/storage_efs_dependencies.py
@@ -1,0 +1,238 @@
+import os
+
+import time
+import pytest
+import subprocess
+import boto3, urllib
+
+from e2e.utils.config import metadata
+from e2e.utils.cognito_bootstrap.common import load_cfg, write_cfg
+
+from e2e.conftest import region
+
+from e2e.utils.utils import kubectl_apply, kubectl_delete
+from e2e.fixtures.cluster import cluster
+
+from e2e.utils.utils import rand_name
+
+from e2e.utils.config import configure_resource_fixture
+from e2e.fixtures.cluster import associate_iam_oidc_provider, create_iam_service_account
+from e2e.utils.utils import (
+    rand_name,
+    get_iam_client,
+    get_eks_client,
+    get_ec2_client,
+    get_efs_client,
+    curl_file_to_path,
+    get_aws_account_id,
+)
+
+
+def wait_on_efs_status(desired_status, efs_client, file_system_id):
+    filesystem_status = ""
+    while filesystem_status != desired_status:
+            response = efs_client.describe_file_systems(
+            FileSystemId=file_system_id,
+            )
+            filesystem_status=response["FileSystems"][0]["LifeCycleState"]
+            print(f"{file_system_id} {filesystem_status} .... waiting")
+            time.sleep(10)
+
+@pytest.fixture(scope="class")
+def install_efs_csi_driver(metadata, region, request, cluster):
+    EFS_CSI_DRIVER = "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v1.3.4"
+
+    def on_create():
+        apply_retcode = subprocess.call(f"kubectl apply -k {EFS_CSI_DRIVER}".split())
+        assert apply_retcode == 0
+
+    def on_delete():
+        apply_retcode = subprocess.call(f"kubectl delete -k {EFS_CSI_DRIVER}".split())
+        assert apply_retcode == 0
+
+
+@pytest.fixture(scope="class")
+def create_iam_policy(metadata, region, request, cluster):
+    # Existing IAM Client with Region does not work.
+    policy_name = rand_name("efs-iam-policy-")
+    iam_client = boto3.client('iam')
+    EFS_IAM_POLICY = "https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v1.3.4/docs/iam-policy-example.json"
+    aws_account_id = get_aws_account_id
+    efs_deps = {}
+    policy_arn = [f"arn:aws:iam::{aws_account_id}:policy/{policy_name}"]
+
+    def on_create():
+        associate_iam_oidc_provider(cluster, region)
+        curl_file_to_path(EFS_IAM_POLICY, "iam-policy-example.json")
+        with open('iam-policy-example.json', 'r') as myfile:
+            policy=myfile.read()
+
+        response = iam_client.create_policy(
+            PolicyName=policy_name,
+            PolicyDocument=policy,
+            )
+        # TODO: Why is this failing ?!
+        #create_iam_service_account("efs-csi-controller-sa", "kube-system", cluster, region, policy_arn)
+        efs_deps["efs_iam_policy_name"] = policy_name
+
+    def on_delete():
+        pass
+
+    return configure_resource_fixture(
+        metadata, request, efs_deps, "efs_deps", on_create, on_delete
+    )
+        
+
+@pytest.fixture(scope="class")
+def create_efs_volume(metadata, region, request, cluster):
+    efs_volume = {}
+    def on_create():
+        # Get VPC ID
+        eks_client = get_eks_client(region)
+        response = eks_client.describe_cluster(name=cluster)
+        vpc_id = response["cluster"]["resourcesVpcConfig"]["vpcId"]
+
+        # Get CIDR Range
+        ec2_client = get_ec2_client(region)
+        response = ec2_client.describe_vpcs(
+            VpcIds=[
+                vpc_id,
+                ]
+            )
+        cidr_ip=response["Vpcs"][0]["CidrBlock"]
+
+        # Create Security Group
+        security_group_name = rand_name("efs-security-group-")
+        response = ec2_client.create_security_group(
+            VpcId=vpc_id,
+            GroupName=security_group_name,
+            Description="My EFS security group"
+            )
+        security_group_id=response["GroupId"]
+
+        efs_volume["security_group_id"] = security_group_id
+
+        # Open Port for CIDR Range
+        response = ec2_client.authorize_security_group_ingress(
+            GroupId=security_group_id,
+            FromPort=2049,
+            ToPort=2049,
+            CidrIp=cidr_ip,
+            IpProtocol="tcp",
+            )
+
+        # Open Port for same security group
+        # response = ec2_client.authorize_security_group_ingress(
+        #     GroupId=security_group_id,
+        #     FromPort=2049,
+        #     ToPort=2049,
+        #     SourceSecurityGroupName=security_group_name,
+        #     IpProtocol="tcp",
+        #     )
+
+        # Create an Amazon EFS FileSystem for your EKS Cluster
+        efs_client = get_efs_client(region)
+        response = efs_client.create_file_system(
+            PerformanceMode="generalPurpose",
+            )
+        file_system_id=response["FileSystemId"]
+
+        # Check for status of filesystem to be "available" before creating mount targets
+        wait_on_efs_status("available", efs_client, file_system_id)
+
+        # Get Subnet Ids
+        response = ec2_client.describe_subnets(
+            Filters=[
+                {
+                    "Name": "vpc-id",
+                    "Values": [
+                        vpc_id,
+                    ],
+                },
+            ]
+        )
+
+        # Create Mount Targets for each subnet - TODO: Check how many subnets this needs to be added to. 
+        subnets = response["Subnets"]
+        for subnet in subnets:
+            subnet_id=subnet["SubnetId"]
+            response = efs_client.create_mount_target(
+                FileSystemId=file_system_id,
+                SecurityGroups=[
+                    security_group_id,
+                ],
+                SubnetId=subnet_id,
+            )
+
+        # Write the FileSystemId to the metadata file
+        efs_volume["file_system_id"] = file_system_id
+
+    def on_delete():
+        # Get FileSystem_ID
+        efs_client = get_efs_client(region)
+        ec2_client = get_ec2_client(region)
+        details_efs_volume = metadata.get("efs_volume")
+        fs_id = details_efs_volume["file_system_id"]
+        sg_id = details_efs_volume["security_group_id"]
+
+        # Delete Any Existing Mount Targets
+        response = efs_client.describe_mount_targets(
+            FileSystemId=fs_id,
+            )
+        existing_mount_targets = response["MountTargets"]
+        for mount_target in existing_mount_targets:
+            mount_target_id=mount_target["MountTargetId"]
+            response = efs_client.delete_mount_target(
+                MountTargetId=mount_target_id,
+            )
+
+        #Delete the Filesystem
+        response = efs_client.delete_file_system(
+            FileSystemId=fs_id,
+            )
+        wait_on_efs_status("deleted", efs_client, fs_id)
+
+        # Delete the Security Group
+        response = ec2_client.delete_security_group(
+            GroupId=sg_id
+        )
+
+    return configure_resource_fixture(
+        metadata, request, efs_volume, "efs_volume", on_create, on_delete
+    )
+
+@pytest.fixture(scope="class")
+def static_provisioning(metadata, region, request, cluster):
+    details_efs_volume = metadata.get("efs_volume")
+    fs_id = details_efs_volume["file_system_id"]
+    efs_sc_filepath = "../../examples/storage/efs/static-provisioning/sc.yaml"
+    efs_pv_filepath = "../../examples/storage/efs/static-provisioning/pv.yaml"
+    efs_pvc_filepath = "../../examples/storage/efs/static-provisioning/pvc.yaml"
+    PVC_NAMESPACE="kubeflow-user-example-com"
+    efs_claim = {}
+
+    def on_create():
+        # Add the filesystem_id to the pv.yaml file
+        efs_pv = load_cfg(efs_pv_filepath)
+        efs_pv["spec"]["csi"]["volumeHandle"] = fs_id
+        write_cfg(efs_pv, efs_pv_filepath)
+
+        # Add the namespace to the pvc.yaml file
+        efs_pvc = load_cfg(efs_pvc_filepath)
+        efs_pvc["metadata"]["namespace"] = PVC_NAMESPACE
+        write_cfg(efs_pvc, efs_pvc_filepath)
+
+        kubectl_apply(efs_sc_filepath)
+        kubectl_apply(efs_pv_filepath)
+        kubectl_apply(efs_pvc_filepath)
+
+        efs_claim["claim_name"] = "efs_claim"
+        
+    def on_delete():
+        kubectl_delete(efs_sc_filepath)
+        kubectl_delete(efs_pv_filepath)
+        kubectl_delete(efs_pvc_filepath)
+
+    return configure_resource_fixture(
+        metadata, request, efs_claim, "efs_claim", on_create, on_delete
+    )

--- a/distributions/aws/test/e2e/tests/test_storage_efs.py
+++ b/distributions/aws/test/e2e/tests/test_storage_efs.py
@@ -1,13 +1,13 @@
 """
-Installs the vanilla distribution of kubeflow and validates the installation by:
-    - Creating, describing, and deleting a KFP experiment
-    - Running a pipeline that comes with the default kubeflow installation
-    - Creating, describing, and deleting a Katib experiment
+Installs the vanilla distribution of kubeflow and validates EFS integration by:
+    - Installing the EFS Driver from upstream
+    - Creating the required IAM Policy, Role and Service Account
+    - Creating the EFS Volume 
+    - Creating a StorageClass, PersistentVolume and PersistentVolumeClaim using Static Provisioning
 """
 
 import pytest
 import subprocess
-import urllib
 
 from e2e.utils.constants import DEFAULT_USER_NAMESPACE
 from e2e.utils.config import metadata
@@ -16,7 +16,7 @@ from e2e.conftest import region
 
 from e2e.fixtures.cluster import cluster
 
-from e2e.fixtures.kustomize import kustomize
+from e2e.fixtures.kustomize import kustomize, configure_manifests
 
 from e2e.fixtures.storage_efs_dependencies import (
     install_efs_csi_driver,
@@ -27,6 +27,7 @@ from e2e.fixtures.storage_efs_dependencies import (
 
 GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../../../example"
 
+
 @pytest.fixture(scope="class")
 def kustomize_path():
     return GENERIC_KUSTOMIZE_MANIFEST_PATH
@@ -34,12 +35,20 @@ def kustomize_path():
 
 class TestEFS:
     @pytest.fixture(scope="class")
-    def setup(self, metadata):
+    def setup(self, metadata, kustomize):
         metadata_file = metadata.to_file()
         print(metadata.params)  # These needed to be logged
         print("Created metadata file for TestSanity", metadata_file)
 
-    def test_pvc_with_volume(self, metadata, setup, install_efs_csi_driver, create_iam_policy, create_efs_volume, static_provisioning):
+    def test_pvc_with_volume(
+        self,
+        metadata,
+        setup,
+        install_efs_csi_driver,
+        create_iam_policy,
+        create_efs_volume,
+        static_provisioning,
+    ):
         details_efs_deps = metadata.get("efs_deps")
         details_efs_volume = metadata.get("efs_volume")
         details_efs_claim = metadata.get("efs_claim")
@@ -48,10 +57,12 @@ class TestEFS:
         assert "efs.csi.aws.com" in driver_list
 
         pod_list = subprocess.check_output("kubectl get pods -A".split()).decode()
-        #assert "efs-csi-controller" in pod_list
+        assert "efs-csi-controller" in pod_list
 
-        #sa_account = subprocess.check_output("kubectl describe -n kube-system serviceaccount efs-csi-controller-sa".split()).decode()
-        #assert details_efs_deps["efs_iam_policy_name"] in sa_account
+        sa_account = subprocess.check_output(
+            "kubectl describe -n kube-system serviceaccount efs-csi-controller-sa".split()
+        ).decode()
+        assert details_efs_deps["efs_iam_policy_name"] in sa_account
 
         fs_id = details_efs_volume["file_system_id"]
         assert "fs-" in fs_id
@@ -59,5 +70,3 @@ class TestEFS:
         claim_name = details_efs_claim["claim_name"]
         claim_list = subprocess.check_output("kubectl get pvc -A".split()).decode()
         assert claim_name in claim_list
-
-

--- a/distributions/aws/test/e2e/tests/test_storage_efs.py
+++ b/distributions/aws/test/e2e/tests/test_storage_efs.py
@@ -62,7 +62,8 @@ class TestEFS:
         sa_account = subprocess.check_output(
             "kubectl describe -n kube-system serviceaccount efs-csi-controller-sa".split()
         ).decode()
-        assert details_efs_deps["efs_iam_policy_name"] in sa_account
+        aws_account_id = details_efs_deps["aws_account_id"]
+        assert f"arn:aws:iam::{aws_account_id}:role" in sa_account
 
         fs_id = details_efs_volume["file_system_id"]
         assert "fs-" in fs_id

--- a/distributions/aws/test/e2e/tests/test_storage_efs.py
+++ b/distributions/aws/test/e2e/tests/test_storage_efs.py
@@ -1,0 +1,63 @@
+"""
+Installs the vanilla distribution of kubeflow and validates the installation by:
+    - Creating, describing, and deleting a KFP experiment
+    - Running a pipeline that comes with the default kubeflow installation
+    - Creating, describing, and deleting a Katib experiment
+"""
+
+import pytest
+import subprocess
+import urllib
+
+from e2e.utils.constants import DEFAULT_USER_NAMESPACE
+from e2e.utils.config import metadata
+
+from e2e.conftest import region
+
+from e2e.fixtures.cluster import cluster
+
+from e2e.fixtures.kustomize import kustomize
+
+from e2e.fixtures.storage_efs_dependencies import (
+    install_efs_csi_driver,
+    create_iam_policy,
+    create_efs_volume,
+    static_provisioning,
+)
+
+GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../../../example"
+
+@pytest.fixture(scope="class")
+def kustomize_path():
+    return GENERIC_KUSTOMIZE_MANIFEST_PATH
+
+
+class TestEFS:
+    @pytest.fixture(scope="class")
+    def setup(self, metadata):
+        metadata_file = metadata.to_file()
+        print(metadata.params)  # These needed to be logged
+        print("Created metadata file for TestSanity", metadata_file)
+
+    def test_pvc_with_volume(self, metadata, setup, install_efs_csi_driver, create_iam_policy, create_efs_volume, static_provisioning):
+        details_efs_deps = metadata.get("efs_deps")
+        details_efs_volume = metadata.get("efs_volume")
+        details_efs_claim = metadata.get("efs_claim")
+
+        driver_list = subprocess.check_output("kubectl get csidriver".split()).decode()
+        assert "efs.csi.aws.com" in driver_list
+
+        pod_list = subprocess.check_output("kubectl get pods -A".split()).decode()
+        #assert "efs-csi-controller" in pod_list
+
+        #sa_account = subprocess.check_output("kubectl describe -n kube-system serviceaccount efs-csi-controller-sa".split()).decode()
+        #assert details_efs_deps["efs_iam_policy_name"] in sa_account
+
+        fs_id = details_efs_volume["file_system_id"]
+        assert "fs-" in fs_id
+
+        claim_name = details_efs_claim["claim_name"]
+        claim_list = subprocess.check_output("kubectl get pvc -A".split()).decode()
+        assert claim_name in claim_list
+
+

--- a/distributions/aws/test/e2e/utils/cognito_bootstrap/common.py
+++ b/distributions/aws/test/e2e/utils/cognito_bootstrap/common.py
@@ -13,7 +13,7 @@ CONFIG_FILE = "./utils/cognito_bootstrap/config.yaml"
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html
 CLOUDFRONT_HOSTED_ZONE_ID = "Z2FDTNDATAQYW2"
 
-
+# TODO: Remove this methods from this file and move it to the utils file
 def load_cfg(file_path: str = CONFIG_FILE):
     with open(file_path, "r") as stream:
         try:

--- a/distributions/aws/test/e2e/utils/utils.py
+++ b/distributions/aws/test/e2e/utils/utils.py
@@ -147,6 +147,14 @@ def kubectl_delete(path):
     cmd = f"kubectl delete -f {path}".split()
     subprocess.call(cmd)
 
+def kubectl_apply_kustomize(path):
+    cmd = f"kubectl apply -k {path}".split()
+    subprocess.call(cmd)
+
+def kubectl_delete_kustomize(path):
+    cmd = f"kubectl delete -k {path}".split()
+    subprocess.call(cmd)
+
 def get_aws_account_id():
     client = boto3.client('sts')
     response = client.get_caller_identity()

--- a/distributions/aws/test/e2e/utils/utils.py
+++ b/distributions/aws/test/e2e/utils/utils.py
@@ -10,7 +10,11 @@ import random
 import string
 import yaml
 import boto3
+<<<<<<< HEAD
 import mysql.connector
+=======
+import subprocess
+>>>>>>> Initial Commit: EFS Test
 
 
 def safe_open(filepath, mode="r"):
@@ -128,7 +132,22 @@ def get_mysql_client(user, password, host, database) -> mysql.connector.MySQLCon
         user=user, password=password, host=host, database=database
     )
 
+def get_efs_client(region):
+    return boto3.client("efs", region_name=region)
+
+def curl_file_to_path(file, path):
+    cmd = f"curl -o {path} {file}".split()
+    subprocess.call(cmd)
 
 def kubectl_apply(path):
     cmd = f"kubectl apply -f {path}".split()
     subprocess.call(cmd)
+
+def kubectl_delete(path):
+    cmd = f"kubectl delete -f {path}".split()
+    subprocess.call(cmd)
+
+def get_aws_account_id():
+    client = boto3.client('sts')
+    response = client.get_caller_identity()
+    return response["Account"]

--- a/distributions/aws/test/e2e/utils/utils.py
+++ b/distributions/aws/test/e2e/utils/utils.py
@@ -10,11 +10,8 @@ import random
 import string
 import yaml
 import boto3
-<<<<<<< HEAD
 import mysql.connector
-=======
 import subprocess
->>>>>>> Initial Commit: EFS Test
 
 
 def safe_open(filepath, mode="r"):


### PR DESCRIPTION
**Description of your changes:**
Installs the vanilla distribution of kubeflow and validates EFS integration by:
- [x] Installing the EFS Driver from upstream
- [x] Creating the required IAM Policy, Role and Service Account
- [x] Creating the EFS Volume 
- [x] Creating a StorageClass, PersistentVolume and PersistentVolumeClaim using Static Provisioning

Tested using the following commands - 
- [x] `pytest -s -q tests/test_storage_efs.py --keepsuccess --region eu-north-1 --metadata .metadata/metadata-xxx.json` on existing cluster
- [x] `pytest -s -q tests/test_storage_efs.py --keepsuccess --region eu-north-1` to test on a new cluster
- [x] `pytest -s -q tests/test_storage_efs.py --region eu-north-1` to test deletion of all resources.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
