### PR TITLE
Test for FSx CSI Driver installation; Volume, PV and PVC creation on Kubeflow deployment

### DIFF
--- a/distributions/aws/test/e2e/fixtures/storage_efs_dependencies.py
+++ b/distributions/aws/test/e2e/fixtures/storage_efs_dependencies.py
@@ -4,9 +4,11 @@ import subprocess
 import boto3
 
 from e2e.utils.config import metadata
+from e2e.fixtures.kustomize import kustomize, configure_manifests
 from e2e.utils.cognito_bootstrap.common import load_cfg, write_cfg
 from e2e.conftest import region
 from e2e.fixtures.cluster import cluster
+from e2e.fixtures.clients import account_id
 from e2e.utils.utils import rand_name
 from e2e.utils.config import configure_resource_fixture
 from e2e.fixtures.cluster import associate_iam_oidc_provider, create_iam_service_account
@@ -18,7 +20,6 @@ from e2e.utils.utils import (
     get_ec2_client,
     get_efs_client,
     curl_file_to_path,
-    get_aws_account_id,
     kubectl_apply,
     kubectl_delete,
     kubectl_apply_kustomize,
@@ -29,7 +30,6 @@ DEFAULT_NAMESPACE = "kube-system"
 
 
 def wait_on_efs_status(desired_status, efs_client, file_system_id):
-
     def callback():
         response = efs_client.describe_file_systems(
             FileSystemId=file_system_id,
@@ -37,21 +37,18 @@ def wait_on_efs_status(desired_status, efs_client, file_system_id):
         filesystem_status = response["FileSystems"][0]["LifeCycleState"]
         print(f"{file_system_id} {filesystem_status} .... waiting")
         assert filesystem_status == desired_status
-        
+
     wait_for(callback)
 
 
 @pytest.fixture(scope="class")
-def install_efs_csi_driver(metadata, region, request, cluster):
+def install_efs_csi_driver(metadata, region, request, cluster, kustomize):
     efs_driver = {}
     EFS_DRIVER_VERSION = "v1.3.4"
     EFS_CSI_DRIVER = f"github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/{EFS_DRIVER_VERSION}"
 
     def on_create():
         kubectl_apply_kustomize(EFS_CSI_DRIVER)
-        # cmd = f"kubectl apply -k {EFS_CSI_DRIVER}".split()
-        # subprocess.call(cmd)
-
         efs_driver["driver_version"] = EFS_DRIVER_VERSION
 
     def on_delete():
@@ -61,16 +58,18 @@ def install_efs_csi_driver(metadata, region, request, cluster):
         metadata, request, efs_driver, "efs_driver", on_create, on_delete
     )
 
+
 @pytest.fixture(scope="class")
-def create_iam_policy(metadata, region, request, cluster):
+def create_efs_driver_sa(
+    metadata, region, request, cluster, account_id, install_efs_csi_driver
+):
     # TODO: Existing IAM Client with Region does not seem to work.
     efs_deps = {}
     iam_client = boto3.client("iam")
 
     EFS_IAM_POLICY = "https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v1.3.4/docs/iam-policy-example.json"
     policy_name = rand_name("efs-iam-policy-")
-    aws_account_id = get_aws_account_id()
-    policy_arn = [f"arn:aws:iam::{aws_account_id}:policy/{policy_name}"]
+    policy_arn = [f"arn:aws:iam::{account_id}:policy/{policy_name}"]
 
     def on_create():
         associate_iam_oidc_provider(cluster, region)
@@ -88,10 +87,9 @@ def create_iam_policy(metadata, region, request, cluster):
             "efs-csi-controller-sa", DEFAULT_NAMESPACE, cluster, region, policy_arn
         )
         efs_deps["efs_iam_policy_name"] = policy_name
-        efs_deps["aws_account_id"] = aws_account_id
 
     def on_delete():
-        details_efs_deps = metadata.get("efs_deps")
+        details_efs_deps = metadata.get("efs_deps") or efs_deps
         policy_name = details_efs_deps["efs_iam_policy_name"]
         iam_client.delete_policy(
             PolicyName=policy_name,
@@ -103,7 +101,7 @@ def create_iam_policy(metadata, region, request, cluster):
 
 
 @pytest.fixture(scope="class")
-def create_efs_volume(metadata, region, request, cluster):
+def create_efs_volume(metadata, region, request, cluster, create_efs_driver_sa):
     efs_volume = {}
     eks_client = get_eks_client(region)
     ec2_client = get_ec2_client(region)
@@ -179,7 +177,7 @@ def create_efs_volume(metadata, region, request, cluster):
 
     def on_delete():
         # Get FileSystem_ID
-        details_efs_volume = metadata.get("efs_volume")
+        details_efs_volume = metadata.get("efs_volume") or efs_volume
         fs_id = details_efs_volume["file_system_id"]
         sg_id = details_efs_volume["security_group_id"]
 
@@ -209,7 +207,7 @@ def create_efs_volume(metadata, region, request, cluster):
 
 
 @pytest.fixture(scope="class")
-def static_provisioning(metadata, region, request, cluster):
+def static_provisioning(metadata, region, request, cluster, create_efs_volume):
     details_efs_volume = metadata.get("efs_volume")
     fs_id = details_efs_volume["file_system_id"]
     claim_name = rand_name("efs-claim-")

--- a/distributions/aws/test/e2e/fixtures/storage_efs_dependencies.py
+++ b/distributions/aws/test/e2e/fixtures/storage_efs_dependencies.py
@@ -49,8 +49,8 @@ def install_efs_csi_driver(metadata, region, request, cluster):
 
     def on_create():
         kubectl_apply_kustomize(EFS_CSI_DRIVER)
-        cmd = f"kubectl apply -k {EFS_CSI_DRIVER}".split()
-        subprocess.call(cmd)
+        # cmd = f"kubectl apply -k {EFS_CSI_DRIVER}".split()
+        # subprocess.call(cmd)
 
         efs_driver["driver_version"] = EFS_DRIVER_VERSION
 

--- a/distributions/aws/test/e2e/fixtures/storage_fsx_dependencies.py
+++ b/distributions/aws/test/e2e/fixtures/storage_fsx_dependencies.py
@@ -1,0 +1,249 @@
+import time
+import pytest
+import subprocess
+import boto3
+
+from e2e.utils.config import metadata
+from e2e.utils.cognito_bootstrap.common import load_cfg, write_cfg
+from e2e.conftest import region
+from e2e.fixtures.cluster import cluster
+from e2e.utils.utils import rand_name
+from e2e.utils.config import configure_resource_fixture
+from e2e.fixtures.cluster import associate_iam_oidc_provider, create_iam_service_account
+from e2e.utils.utils import (
+    rand_name,
+    wait_for,
+    get_iam_client,
+    get_eks_client,
+    get_ec2_client,
+    get_fsx_client,
+    curl_file_to_path,
+    get_aws_account_id,
+    kubectl_apply,
+    kubectl_delete,
+    kubectl_apply_kustomize,
+    kubectl_delete_kustomize,
+)
+
+DEFAULT_NAMESPACE = "kube-system"
+
+
+def wait_on_fsx_status(desired_status, fsx_client, file_system_id):
+
+    def callback():
+        response = fsx_client.describe_file_systems(
+            FileSystemIds=[
+                file_system_id
+            ]
+        )
+        filesystem_status = response["FileSystems"][0]["Lifecycle"]
+        print(f"{file_system_id} {filesystem_status} .... waiting")
+        assert filesystem_status == desired_status
+        
+    wait_for(callback, 600)
+
+def get_fsx_dns_name(fsx_client, file_system_id):
+    response = fsx_client.describe_file_systems(
+            FileSystemIds=[
+                file_system_id
+            ]
+        )
+    return response["FileSystems"][0]["DNSName"]
+
+def get_fsx_mount_name(fsx_client, file_system_id):
+    response = fsx_client.describe_file_systems(
+            FileSystemIds=[
+                file_system_id
+            ]
+        )
+    return response["FileSystems"][0]["LustreConfiguration"]["MountName"]
+
+@pytest.fixture(scope="class")
+def install_fsx_csi_driver(metadata, region, request, cluster):
+    fsx_driver = {}
+    FSx_DRIVER_VERSION = "v0.7.1"
+    FSx_CSI_DRIVER = f"github.com/kubernetes-sigs/aws-fsx-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/{FSx_DRIVER_VERSION}"
+
+    def on_create():
+        kubectl_apply_kustomize(FSx_CSI_DRIVER)
+        # cmd = f"kubectl apply -k {FSx_CSI_DRIVER}".split()
+        # subprocess.call(cmd)
+
+        fsx_driver["driver_version"] = FSx_DRIVER_VERSION
+
+    def on_delete():
+        kubectl_delete_kustomize(FSx_CSI_DRIVER)
+
+    return configure_resource_fixture(
+        metadata, request, fsx_driver, "fsx_driver", on_create, on_delete
+    )
+
+@pytest.fixture(scope="class")
+def create_iam_policy(metadata, region, request, cluster):
+    # TODO: Existing IAM Client with Region does not seem to work.
+    fsx_deps = {}
+    iam_client = boto3.client("iam")
+
+    FSx_POLICY_DOCUMENT = "../../examples/storage/fsx-for-lustre/fsx-csi-driver-policy.json"
+    policy_name = rand_name("fsx-iam-policy-")
+    aws_account_id = get_aws_account_id()
+    policy_arn = [f"arn:aws:iam::{aws_account_id}:policy/{policy_name}"]
+
+    def on_create():
+        associate_iam_oidc_provider(cluster, region)
+
+        with open(FSx_POLICY_DOCUMENT, "r") as myfile:
+            policy = myfile.read()
+
+        response = iam_client.create_policy(
+            PolicyName=policy_name,
+            PolicyDocument=policy,
+        )
+        assert response["Policy"]["Arn"] is not None
+
+        create_iam_service_account(
+            "fsx-csi-controller-sa", DEFAULT_NAMESPACE, cluster, region, policy_arn
+        )
+        fsx_deps["fsx_iam_policy_name"] = policy_name
+        fsx_deps["aws_account_id"] = aws_account_id
+
+    def on_delete():
+        details_fsx_deps = metadata.get("fsx_deps")
+        policy_name = details_fsx_deps["fsx_iam_policy_name"]
+        iam_client.delete_policy(
+            PolicyName=policy_name,
+        )
+
+    return configure_resource_fixture(
+        metadata, request, fsx_deps, "fsx_deps", on_create, on_delete
+    )
+
+
+@pytest.fixture(scope="class")
+def create_fsx_volume(metadata, region, request, cluster):
+    fsx_volume = {}
+    eks_client = get_eks_client(region)
+    ec2_client = get_ec2_client(region)
+    fsx_client = get_fsx_client(region)
+
+    def on_create():
+        # Get VPC ID, Cluster security group
+        response = eks_client.describe_cluster(name=cluster)
+        vpc_id = response["cluster"]["resourcesVpcConfig"]["vpcId"]
+        cluster_security_group = response["cluster"]["resourcesVpcConfig"]["clusterSecurityGroupId"]
+        subnet_id = response["cluster"]["resourcesVpcConfig"]["subnetIds"][0]
+
+        # Create Security Group
+        security_group_name = rand_name("fsx-security-group-")
+        response = ec2_client.create_security_group(
+            VpcId=vpc_id,
+            GroupName=security_group_name,
+            Description="My fsx security group",
+        )
+        security_group_id = response["GroupId"]
+        fsx_volume["security_group_id"] = security_group_id
+
+        # Open Port for CIDR Range
+        ec2_client.authorize_security_group_ingress(
+            GroupId=security_group_id,
+            IpPermissions=[
+                {
+                    'FromPort': 988,
+                    'ToPort': 988,
+                    'IpProtocol': 'tcp',
+                    'UserIdGroupPairs': [{ 'GroupId': security_group_id }]
+                },
+                ],
+        )
+
+        ec2_client.authorize_security_group_ingress(
+            GroupId=security_group_id,
+            IpPermissions=[
+                {
+                    'FromPort': 988,
+                    'ToPort': 988,
+                    'IpProtocol': 'tcp',
+                    'UserIdGroupPairs': [{ 'GroupId': cluster_security_group }]
+                },
+                ],
+        )
+
+        # Create an Amazon fsx FileSystem for your EKS Cluster
+        response = fsx_client.create_file_system(
+            FileSystemType="LUSTRE",
+            SubnetIds=[
+                subnet_id
+            ],
+            SecurityGroupIds=[
+                security_group_id
+            ],
+            StorageCapacity=1200,
+        )
+        file_system_id = response["FileSystem"]["FileSystemId"]
+
+        # Check for status of filesystem to be "available" before creating mount targets
+        wait_on_fsx_status("AVAILABLE", fsx_client, file_system_id)
+
+        # Write the FileSystemDetails to the metadata file
+        fsx_volume["file_system_id"] = file_system_id
+        fsx_volume["dns_name"] = get_fsx_dns_name(fsx_client, file_system_id)
+        fsx_volume["mount_name"] = get_fsx_mount_name(fsx_client, file_system_id)
+
+    def on_delete():
+        # Get FileSystem_ID
+        details_fsx_volume = metadata.get("fsx_volume")
+        fs_id = details_fsx_volume["file_system_id"]
+        sg_id = details_fsx_volume["security_group_id"]
+
+
+        # Delete the Filesystem, does not provide a deleted status hence can't check delete status
+        fsx_client.delete_file_system(
+            FileSystemId=fs_id,
+        )
+
+        # Delete the Security Group
+        ec2_client.delete_security_group(GroupId=sg_id)
+
+    return configure_resource_fixture(
+        metadata, request, fsx_volume, "fsx_volume", on_create, on_delete
+    )
+
+
+@pytest.fixture(scope="class")
+def static_provisioning(metadata, region, request, cluster):
+    details_fsx_volume = metadata.get("fsx_volume")
+    fs_id = details_fsx_volume["file_system_id"]
+    dns_name = details_fsx_volume["dns_name"]
+    mount_name = details_fsx_volume["mount_name"]
+    claim_name = rand_name("fsx-claim-")
+    fsx_pv_filepath = "../../examples/storage/fsx-for-lustre/static-provisioning/pv.yaml"
+    fsx_pvc_filepath = "../../examples/storage/fsx-for-lustre/static-provisioning/pvc.yaml"
+    fsx_claim = {}
+
+    def on_create():
+        # Add the filesystem_id to the pv.yaml file
+        fsx_pv = load_cfg(fsx_pv_filepath)
+        fsx_pv["spec"]["csi"]["volumeHandle"] = fs_id
+        fsx_pv["metadata"]["name"] = claim_name
+        fsx_pv["spec"]["csi"]["volumeAttributes"]["dnsname"] = dns_name
+        fsx_pv["spec"]["csi"]["volumeAttributes"]["mountname"] = mount_name
+        write_cfg(fsx_pv, fsx_pv_filepath)
+
+        # Add the namespace to the pvc.yaml file
+        fsx_pvc = load_cfg(fsx_pvc_filepath)
+        fsx_pvc["metadata"]["namespace"] = DEFAULT_NAMESPACE
+        fsx_pvc["metadata"]["name"] = claim_name
+        write_cfg(fsx_pvc, fsx_pvc_filepath)
+
+        kubectl_apply(fsx_pv_filepath)
+        kubectl_apply(fsx_pvc_filepath)
+
+        fsx_claim["claim_name"] = claim_name
+
+    def on_delete():
+        kubectl_delete(fsx_pvc_filepath)
+        kubectl_delete(fsx_pv_filepath)
+
+    return configure_resource_fixture(
+        metadata, request, fsx_claim, "fsx_claim", on_create, on_delete
+    )

--- a/distributions/aws/test/e2e/tests/test_storage_fsx.py
+++ b/distributions/aws/test/e2e/tests/test_storage_fsx.py
@@ -1,0 +1,73 @@
+"""
+Installs the vanilla distribution of kubeflow and validates FSx for Lustre integration by:
+    - Installing the FSx CSI Driver from upstream
+    - Creating the required IAM Policy, Role and Service Account
+    - Creating the FSx for Lustre Volume 
+    - Creating a StorageClass, PersistentVolume and PersistentVolumeClaim using Static Provisioning
+"""
+
+import pytest
+import subprocess
+
+from e2e.utils.constants import DEFAULT_USER_NAMESPACE
+from e2e.utils.config import metadata
+
+from e2e.conftest import region
+
+from e2e.fixtures.cluster import cluster
+
+from e2e.fixtures.kustomize import kustomize, configure_manifests
+
+from e2e.fixtures.storage_fsx_dependencies import (
+    install_fsx_csi_driver,
+    create_iam_policy,
+    create_fsx_volume,
+    static_provisioning,
+)
+
+GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../../../example"
+
+
+@pytest.fixture(scope="class")
+def kustomize_path():
+    return GENERIC_KUSTOMIZE_MANIFEST_PATH
+
+
+class TestFSx:
+    @pytest.fixture(scope="class")
+    def setup(self, metadata, kustomize):
+        metadata_file = metadata.to_file()
+        print(metadata.params)  # These needed to be logged
+        print("Created metadata file for TestSanity", metadata_file)
+
+    def test_pvc_with_volume(
+        self,
+        metadata,
+        setup,
+        install_fsx_csi_driver,
+        create_iam_policy,
+        create_fsx_volume,
+        static_provisioning,
+    ):
+        details_fsx_deps = metadata.get("fsx_deps")
+        details_fsx_volume = metadata.get("fsx_volume")
+        details_fsx_claim = metadata.get("fsx_claim")
+
+        driver_list = subprocess.check_output("kubectl get csidriver".split()).decode()
+        assert "fsx.csi.aws.com" in driver_list
+
+        pod_list = subprocess.check_output("kubectl get pods -A".split()).decode()
+        assert "fsx-csi-controller" in pod_list
+
+        sa_account = subprocess.check_output(
+            "kubectl describe -n kube-system serviceaccount fsx-csi-controller-sa".split()
+        ).decode()
+        aws_account_id = details_fsx_deps["aws_account_id"]
+        assert f"arn:aws:iam::{aws_account_id}:role" in sa_account
+
+        fs_id = details_fsx_volume["file_system_id"]
+        assert "fs-" in fs_id
+
+        claim_name = details_fsx_claim["claim_name"]
+        claim_list = subprocess.check_output("kubectl get pvc -A".split()).decode()
+        assert claim_name in claim_list

--- a/distributions/aws/test/e2e/utils/utils.py
+++ b/distributions/aws/test/e2e/utils/utils.py
@@ -129,33 +129,35 @@ def get_mysql_client(user, password, host, database) -> mysql.connector.MySQLCon
         user=user, password=password, host=host, database=database
     )
 
+
 def get_efs_client(region):
     return boto3.client("efs", region_name=region)
 
+
 def get_fsx_client(region):
     return boto3.client("fsx", region_name=region)
+
 
 def curl_file_to_path(file, path):
     cmd = f"curl -o {path} {file}".split()
     subprocess.call(cmd)
 
+
 def kubectl_apply(path):
     cmd = f"kubectl apply -f {path}".split()
     subprocess.call(cmd)
+
 
 def kubectl_delete(path):
     cmd = f"kubectl delete -f {path}".split()
     subprocess.call(cmd)
 
+
 def kubectl_apply_kustomize(path):
     cmd = f"kubectl apply -k {path}".split()
     subprocess.call(cmd)
 
+
 def kubectl_delete_kustomize(path):
     cmd = f"kubectl delete -k {path}".split()
     subprocess.call(cmd)
-
-def get_aws_account_id():
-    client = boto3.client('sts')
-    response = client.get_caller_identity()
-    return response["Account"]

--- a/distributions/aws/test/e2e/utils/utils.py
+++ b/distributions/aws/test/e2e/utils/utils.py
@@ -132,6 +132,9 @@ def get_mysql_client(user, password, host, database) -> mysql.connector.MySQLCon
 def get_efs_client(region):
     return boto3.client("efs", region_name=region)
 
+def get_fsx_client(region):
+    return boto3.client("fsx", region_name=region)
+
 def curl_file_to_path(file, path):
     cmd = f"curl -o {path} {file}".split()
     subprocess.call(cmd)


### PR DESCRIPTION
**Description of your changes:**
Installs the vanilla distribution of kubeflow and validates FSx integration by:
- [x] Installing the FSx Driver from upstream
- [x] Creating the required IAM Policy, Role and Service Account
- [x] Creating the FSx Volume 
- [x] Creating a PersistentVolume and PersistentVolumeClaim using Static Provisioning

Tested using the following commands - 
- [x] `pytest -s -q tests/test_storage_fsx.py --keepsuccess --region eu-north-1 --metadata .metadata/metadata-xxx.json` on existing cluster
- [x] `pytest -s -q tests/test_storage_fsx.py --keepsuccess --region eu-north-1` to test on a new cluster
- [x] `pytest -s -q tests/test_storage_fsx.py --region eu-north-1` to test deletion of all resources.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
