### PR TITLE
Remove loadBalancerScheme from Cognito params

### DIFF
--- a/distributions/aws/examples/cognito/README.md
+++ b/distributions/aws/examples/cognito/README.md
@@ -134,7 +134,6 @@ In this section, we will be creating certificate to enable TLS authentication at
         CognitoAppClientId='$CognitoAppClientId'
         CognitoUserPoolDomain='$CognitoUserPoolDomain'
         certArn='$certArn'
-        loadBalancerScheme=internet-facing
         ' > distributions/aws/istio-ingress/overlays/cognito/params.env
         ```
 1. Setup resources required for the application load balancer controller

--- a/distributions/aws/istio-ingress/overlays/cognito/params.env
+++ b/distributions/aws/istio-ingress/overlays/cognito/params.env
@@ -2,4 +2,3 @@ CognitoUserPoolArn=
 CognitoAppClientId=
 CognitoUserPoolDomain=
 certArn=
-loadBalancerScheme=internet-facing


### PR DESCRIPTION
Customer can just use the loadBalancerScheme param in the base : https://github.com/awslabs/kubeflow-manifests/blob/v1.3-branch/distributions/aws/istio-ingress/base/params.env

If we do want to keep the parameter in Cognito folder then for it to work we have to change the parameter name `loadBalancerScheme` and edit other files in the folder. 