### PR TITLE
Add telemetry component

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,14 @@ Install the XGBoost Operator official Kubeflow component:
 kustomize build apps/xgboost-job/upstream/overlays/kubeflow | kubectl apply -f -
 ```
 
+#### AWS Telemetry
+
+Install the AWS Kubeflow telemetry component. This is an optional component. See the [usage tracking documentation](TBD) for more information
+
+```sh
+kustomize build distributions/aws/aws-telemetry | kubectl apply -f -
+```
+
 #### User Namespace
 
 Finally, create a new namespace for the the default user (named `kubeflow-user-example-com`).

--- a/distributions/aws/aws-telemetry/cronjob.yaml
+++ b/distributions/aws/aws-telemetry/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
       template:
         metadata:
           annotations:
+            # istio sidecar is not neeeded since there is no inbound or outbound traffic from the service mesh
             sidecar.istio.io/inject: "false"
         spec:
           restartPolicy: Never
@@ -24,12 +25,16 @@ spec:
               - /bin/sh
               - -c
               - |
+                # Following code uses IMDS service. See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+
                 get_instance_id() {
+                  # use IMDSv2 if enabled else fallback to IMDSv1
                   local _token
                   _token=$(curl -s --retry 3 --max-time 3 -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
                   if [[ -n ${_token+x} ]]; then
                     IMDSV2_HEADER=(-H "X-aws-ec2-metadata-token: ${_token}")
                   fi
+                  
                   INSTANCE_ID=$(curl -s --retry 3 "${IMDSV2_HEADER[@]}" http://169.254.169.254/latest/meta-data/instance-id)
 
                   local _instance_id_regex="^(i-\S{17})"
@@ -39,6 +44,7 @@ spec:
                 }
 
                 get_region() {
+                  # regions where S3 buckets have been created
                   local _valid_regions=(
                     "us-east-1"
                     "us-east-2"
@@ -74,4 +80,5 @@ spec:
                 get_instance_id
                 get_region
 
+                # send a GET request to S3 access point
                 curl -s -o /dev/null "https://kubeflow-on-aws-usage-tracking-${REGION}.s3.${REGION}.amazonaws.com/instance-${INSTANCE_ID}.log?x-instance-id=${INSTANCE_ID}"

--- a/distributions/aws/aws-telemetry/cronjob.yaml
+++ b/distributions/aws/aws-telemetry/cronjob.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: aws-kubeflow-telemetry
+spec:
+  schedule: "0 0 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 0
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 0
+      backoffLimit: 3
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: amazonlinux
+            image: public.ecr.aws/amazonlinux/amazonlinux:2
+            command:
+              - /bin/sh
+              - -c
+              - |
+                get_instance_id() {
+                  local _token
+                  _token=$(curl -s --retry 3 --max-time 3 -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+                  if [[ -n ${_token+x} ]]; then
+                    IMDSV2_HEADER=(-H "X-aws-ec2-metadata-token: ${_token}")
+                  fi
+                  INSTANCE_ID=$(curl -s --retry 3 "${IMDSV2_HEADER[@]}" http://169.254.169.254/latest/meta-data/instance-id)
+
+                  local _instance_id_regex="^(i-\S{17})"
+                  if [[ -z ${INSTANCE_ID+x} || ! ${INSTANCE_ID} =~ ${_instance_id_regex} ]]; then
+                    exit 0
+                  fi
+                }
+
+                get_region() {
+                  local _valid_regions=(
+                    "us-east-1"
+                    "us-east-2"
+                    "us-west-1"
+                    "us-west-2"
+                    "af-south-1"
+                    "ap-east-1"
+                    "ap-southeast-1"
+                    "ap-southeast-2"
+                    "ap-southeast-3"
+                    "ap-south-1"
+                    "ap-northeast-1"
+                    "ap-northeast-2"
+                    "ap-northeast-3"
+                    "ca-central-1"
+                    "eu-central-1"
+                    "eu-north-1"
+                    "eu-west-1"
+                    "eu-west-2"
+                    "eu-west-3"
+                    "eu-south-1"
+                    "me-south-1"
+                    "sa-east-1"
+                  )
+                  REGION=$(curl -s --retry 3 "${IMDSV2_HEADER[@]}" http://169.254.169.254/latest/meta-data/placement/availability-zone | awk '{print substr($1, 1, length($1)-1)}')
+
+                  if [[ -z ${REGION+x} || ! ${_valid_regions[${REGION}]+x} ]]; then
+                    exit 0
+                  fi
+                }
+
+                sleep $((1 + $RANDOM % 300))
+                get_instance_id
+                get_region
+
+                curl -s -o /dev/null "https://kubeflow-on-aws-usage-tracking-${REGION}.s3.${REGION}.amazonaws.com/instance-${INSTANCE_ID}.log?x-instance-id=${INSTANCE_ID}"

--- a/distributions/aws/aws-telemetry/job.yaml
+++ b/distributions/aws/aws-telemetry/job.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: aws-kubelow-telemetry
+spec:
+  ttlSecondsAfterFinished: 0
+  backoffLimit: 3
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: amazonlinux
+        image: public.ecr.aws/amazonlinux/amazonlinux:2
+        command:
+          - /bin/sh
+          - -c
+          - |
+            get_instance_id() {
+              local _token
+              _token=$(curl -s --retry 3 --max-time 3 -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+              if [[ -n ${_token+x} ]]; then
+                IMDSV2_HEADER=(-H "X-aws-ec2-metadata-token: ${_token}")
+              fi
+              INSTANCE_ID=$(curl -s --retry 3 "${IMDSV2_HEADER[@]}" http://169.254.169.254/latest/meta-data/instance-id)
+
+              local _instance_id_regex="^(i-\S{17})"
+              if [[ -z ${INSTANCE_ID+x} || ! ${INSTANCE_ID} =~ ${_instance_id_regex} ]]; then
+                exit 0
+              fi
+            }
+
+            get_region() {
+              local _valid_regions=(
+                "us-east-1"
+                "us-east-2"
+                "us-west-1"
+                "us-west-2"
+                "af-south-1"
+                "ap-east-1"
+                "ap-southeast-1"
+                "ap-southeast-2"
+                "ap-southeast-3"
+                "ap-south-1"
+                "ap-northeast-1"
+                "ap-northeast-2"
+                "ap-northeast-3"
+                "ca-central-1"
+                "eu-central-1"
+                "eu-north-1"
+                "eu-west-1"
+                "eu-west-2"
+                "eu-west-3"
+                "eu-south-1"
+                "me-south-1"
+                "sa-east-1"
+              )
+              REGION=$(curl -s --retry 3 "${IMDSV2_HEADER[@]}" http://169.254.169.254/latest/meta-data/placement/availability-zone | awk '{print substr($1, 1, length($1)-1)}')
+
+              if [[ -z ${REGION+x} || ! ${_valid_regions[${REGION}]+x} ]]; then
+                exit 0
+              fi
+            }
+
+            get_instance_id
+            get_region
+
+            curl -s -o /dev/null "https://kubeflow-on-aws-usage-tracking-${REGION}.s3.${REGION}.amazonaws.com/instance-${INSTANCE_ID}.log?x-instance-id=${INSTANCE_ID}"

--- a/distributions/aws/aws-telemetry/job.yaml
+++ b/distributions/aws/aws-telemetry/job.yaml
@@ -8,6 +8,7 @@ spec:
   template:
     metadata:
       annotations:
+        # istio sidecar is not neeeded since there is no inbound or outbound traffic from the service mesh
         sidecar.istio.io/inject: "false"
     spec:
       restartPolicy: Never
@@ -18,12 +19,16 @@ spec:
           - /bin/sh
           - -c
           - |
+            # Following code uses IMDS service. See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+
             get_instance_id() {
+              # use IMDSv2 if enabled else fallback to IMDSv1
               local _token
               _token=$(curl -s --retry 3 --max-time 3 -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
               if [[ -n ${_token+x} ]]; then
                 IMDSV2_HEADER=(-H "X-aws-ec2-metadata-token: ${_token}")
               fi
+
               INSTANCE_ID=$(curl -s --retry 3 "${IMDSV2_HEADER[@]}" http://169.254.169.254/latest/meta-data/instance-id)
 
               local _instance_id_regex="^(i-\S{17})"
@@ -33,6 +38,7 @@ spec:
             }
 
             get_region() {
+              # regions where S3 buckets have been created
               local _valid_regions=(
                 "us-east-1"
                 "us-east-2"
@@ -67,4 +73,5 @@ spec:
             get_instance_id
             get_region
 
+            # send a GET request to S3 access point
             curl -s -o /dev/null "https://kubeflow-on-aws-usage-tracking-${REGION}.s3.${REGION}.amazonaws.com/instance-${INSTANCE_ID}.log?x-instance-id=${INSTANCE_ID}"

--- a/distributions/aws/aws-telemetry/kustomization.yaml
+++ b/distributions/aws/aws-telemetry/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+commonLabels:
+  app: aws-telemetry
+resources:
+- cronjob.yaml
+- job.yaml

--- a/distributions/aws/examples/cognito-rds-s3/README.md
+++ b/distributions/aws/examples/cognito-rds-s3/README.md
@@ -98,6 +98,9 @@ Follow the pre-requisites section from [this guide](../rds-s3/README.md#1-prereq
         # Katib
         kustomize build apps/katib/upstream/installs/katib-external-db-with-kubeflow | kubectl apply -f -
 
+        # AWS Telemetry
+        kustomize build distributions/aws/aws-telemetry | kubectl apply -f -
+
         # Configured for AWS Cognito
         
         # Ingress

--- a/distributions/aws/examples/cognito-rds-s3/README.md
+++ b/distributions/aws/examples/cognito-rds-s3/README.md
@@ -98,7 +98,7 @@ Follow the pre-requisites section from [this guide](../rds-s3/README.md#1-prereq
         # Katib
         kustomize build apps/katib/upstream/installs/katib-external-db-with-kubeflow | kubectl apply -f -
 
-        # AWS Telemetry
+        # AWS Telemetry - This is an optional component. See usage tracking documentation for more information
         kustomize build distributions/aws/aws-telemetry | kubectl apply -f -
 
         # Configured for AWS Cognito

--- a/distributions/aws/examples/cognito-rds-s3/kustomization.yaml
+++ b/distributions/aws/examples/cognito-rds-s3/kustomization.yaml
@@ -55,6 +55,8 @@ resources:
 - ../../aws-alb-ingress-controller/base
 # Envoy filter
 - ../../aws-istio-envoy-filter/base
+# Telemetry
+- ../../aws-telemetry
 
 # Configured for AWS RDS and AWS S3
 

--- a/distributions/aws/examples/cognito-rds-s3/kustomization.yaml
+++ b/distributions/aws/examples/cognito-rds-s3/kustomization.yaml
@@ -55,7 +55,7 @@ resources:
 - ../../aws-alb-ingress-controller/base
 # Envoy filter
 - ../../aws-istio-envoy-filter/base
-# Telemetry
+# AWS Telemetry - This is an optional component. See usage tracking documentation for more information
 - ../../aws-telemetry
 
 # Configured for AWS RDS and AWS S3

--- a/distributions/aws/examples/cognito/README.md
+++ b/distributions/aws/examples/cognito/README.md
@@ -282,7 +282,7 @@ In this section, we will be creating certificate to enable TLS authentication at
         # XGBoost Operator
         kustomize build apps/xgboost-job/upstream/overlays/kubeflow | kubectl apply -f -
 
-        # AWS Telemetry
+        # AWS Telemetry - This is an optional component. See usage tracking documentation for more information
         kustomize build distributions/aws/aws-telemetry | kubectl apply -f -
 
         # Ingress

--- a/distributions/aws/examples/cognito/README.md
+++ b/distributions/aws/examples/cognito/README.md
@@ -282,6 +282,9 @@ In this section, we will be creating certificate to enable TLS authentication at
         # XGBoost Operator
         kustomize build apps/xgboost-job/upstream/overlays/kubeflow | kubectl apply -f -
 
+        # AWS Telemetry
+        kustomize build distributions/aws/aws-telemetry | kubectl apply -f -
+
         # Ingress
         kustomize build distributions/aws/istio-ingress/overlays/cognito | kubectl apply -f -
 

--- a/distributions/aws/examples/cognito/kustomization.yaml
+++ b/distributions/aws/examples/cognito/kustomization.yaml
@@ -50,6 +50,8 @@ resources:
 - ../../../../apps/mxnet-job/upstream/overlays/kubeflow
 # XGBoost Operator
 - ../../../../apps/xgboost-job/upstream/overlays/kubeflow
+# Telemetry
+- ../../aws-telemetry
 
 # Configured for AWS Cognito
 

--- a/distributions/aws/examples/cognito/kustomization.yaml
+++ b/distributions/aws/examples/cognito/kustomization.yaml
@@ -50,7 +50,7 @@ resources:
 - ../../../../apps/mxnet-job/upstream/overlays/kubeflow
 # XGBoost Operator
 - ../../../../apps/xgboost-job/upstream/overlays/kubeflow
-# Telemetry
+# AWS Telemetry - This is an optional component. See usage tracking documentation for more information
 - ../../aws-telemetry
 
 # Configured for AWS Cognito

--- a/distributions/aws/examples/rds-s3/kustomization.yaml
+++ b/distributions/aws/examples/rds-s3/kustomization.yaml
@@ -53,6 +53,8 @@ resources:
 - ../../../../apps/mxnet-job/upstream/overlays/kubeflow
 # XGBoost Operator
 - ../../../../apps/xgboost-job/upstream/overlays/kubeflow
+# AWS Telemetry - This is an optional component. See usage tracking documentation for more information
+- ../../aws-telemetry
 
 # User namespace
 - ../../../../common/user-namespace/base
@@ -66,5 +68,3 @@ resources:
 - ../../../../apps/pipeline/upstream/env/aws
 # Katib
 - ../../../../apps/katib/upstream/installs/katib-external-db-with-kubeflow
-# Telemetry
-- ../../aws-telemetry

--- a/distributions/aws/examples/rds-s3/kustomization.yaml
+++ b/distributions/aws/examples/rds-s3/kustomization.yaml
@@ -66,3 +66,5 @@ resources:
 - ../../../../apps/pipeline/upstream/env/aws
 # Katib
 - ../../../../apps/katib/upstream/installs/katib-external-db-with-kubeflow
+# Telemetry
+- ../../aws-telemetry

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -57,6 +57,8 @@ resources:
 - ../apps/mxnet-job/upstream/overlays/kubeflow
 # XGBoost Operator
 - ../apps/xgboost-job/upstream/overlays/kubeflow
+# Telemetry
+- ../distributions/aws/aws-telemetry
 
 # User namespace
 - ../common/user-namespace/base

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -57,7 +57,7 @@ resources:
 - ../apps/mxnet-job/upstream/overlays/kubeflow
 # XGBoost Operator
 - ../apps/xgboost-job/upstream/overlays/kubeflow
-# Telemetry
+# AWS Telemetry - This is an optional component. See usage tracking documentation for more information
 - ../distributions/aws/aws-telemetry
 
 # User namespace


### PR DESCRIPTION
**Description of your changes:**
Add an optional `aws-kubeflow-telemetry` component to collect instance-id information from Kubeflow deployments.

Detailed documentation will be in a follow up PR allowing customer to activate/deactivate it per their requirement

**Testing:**
- Manual by changing cronjob to run very minute, removing the ttlSecondsAfterFinish and changing curl command to print the output
- ensure job does not hang and exists gracefully with imdsv2/imdsv2 disabled or imds disabled completely