### PR TITLE
telemetry cronjob k8s v1.19 and v1.20 compatibility

### DIFF
--- a/distributions/aws/aws-telemetry/cronjob.yaml
+++ b/distributions/aws/aws-telemetry/cronjob.yaml
@@ -1,11 +1,11 @@
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: aws-kubeflow-telemetry
 spec:
   schedule: "0 0 * * *"
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 0
   jobTemplate:
     spec:

--- a/distributions/aws/aws-telemetry/job.yaml
+++ b/distributions/aws/aws-telemetry/job.yaml
@@ -1,3 +1,4 @@
+# Since CronJob operates on fix schedule, this job is in place for one off tracking at the time Kubeflow is deployed.
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
**Description of your changes:**
- v1 api of CronJob is supported starting 1.21. `vbeta1` is supported in 1.19, 1.20 and deprecated in v1.21+ but is available in 1.21. 
- CronJob history limit set to 0. This was missed in #92. Jobs are cleaned up as soon as they are finished because of `ttlSecondsAfterFinished` set to 0 in job spec(this takes precedence).

**Testing**
Tested on:
- [x] 1.21
- [x] 1.20
- [x] 1.19
