### PR TITLE
Configurable rds and s3 secrets

### DIFF
--- a/awsconfigs/common/aws-secrets-manager/base/deployment.yaml
+++ b/awsconfigs/common/aws-secrets-manager/base/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubeflow-secrets-pod
+  namespace: kubeflow
+  annotations:
+    sidecar.istio.io/inject: "false"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubeflow-secrets-pod
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubeflow-secrets-pod
+    spec:
+      containers:
+        - name: secrets
+          image: public.ecr.aws/xray/aws-xray-daemon:latest
+          volumeMounts:
+          - name: rds-secret
+            mountPath: "/mnt/rds-store"
+            readOnly: true
+          - name: s3-secret
+            mountPath: "/mnt/aws-store"
+            readOnly: true
+      volumes:
+        - name: rds-secret
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "aws-secrets"
+        - name: s3-secret
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "aws-secrets"
+      serviceAccountName: kubeflow-secrets-manager-sa

--- a/awsconfigs/common/aws-secrets-manager/base/kustomization.yaml
+++ b/awsconfigs/common/aws-secrets-manager/base/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
 resources:
-- secrets-mount.yaml
+- deployment.yaml
 - secrets-manager.yaml

--- a/awsconfigs/common/aws-secrets-manager/overlays/configurable-secrets/deployment_patch.yaml
+++ b/awsconfigs/common/aws-secrets-manager/overlays/configurable-secrets/deployment_patch.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubeflow-secrets-pod
+  namespace: kubeflow
+spec:
+  template:
+    spec:
+      containers:
+        - name: secrets
+          volumeMounts:
+          - name: rds-secret # rename secret
+            mountPath: "/mnt/rds-store"
+            readOnly: true
+          - name: s3-secret # rename secret
+            mountPath: "/mnt/aws-store"
+            readOnly: true
+      volumes:
+        - name: rds-secret # rename secret
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "aws-secrets"
+        - name: s3-secret # rename secret
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "aws-secrets"

--- a/awsconfigs/common/aws-secrets-manager/overlays/configurable-secrets/kustomization.yaml
+++ b/awsconfigs/common/aws-secrets-manager/overlays/configurable-secrets/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- deployment_patch.yaml
+- secrets_manager_patch.yaml

--- a/awsconfigs/common/aws-secrets-manager/overlays/configurable-secrets/secrets_manager_patch.yaml
+++ b/awsconfigs/common/aws-secrets-manager/overlays/configurable-secrets/secrets_manager_patch.yaml
@@ -1,0 +1,28 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: aws-secrets
+  namespace: kubeflow
+spec:
+  parameters:
+    objects: | 
+      - objectName: "rds-secret"  # rename secret
+        objectType: "secretsmanager"
+        jmesPath:
+            - path: "username"
+              objectAlias: "user"
+            - path: "password"
+              objectAlias: "pass"
+            - path: "host"
+              objectAlias: "host"
+            - path: "database"
+              objectAlias: "database"
+            - path: "port"
+              objectAlias: "port"
+      - objectName: "s3-secret" # rename secret
+        objectType: "secretsmanager"
+        jmesPath:
+            - path: "accesskey"
+              objectAlias: "access"
+            - path: "secretkey"
+              objectAlias: "secret"           

--- a/docs/deployment/rds-s3/kustomization.yaml
+++ b/docs/deployment/rds-s3/kustomization.yaml
@@ -55,7 +55,7 @@ resources:
 # Configured for AWS RDS and AWS S3
 
 # AWS Secret Manager
-- ../../../awsconfigs/common/aws-secrets-manager/base
+- ../../../awsconfigs/common/aws-secrets-manager/overlays/configurable-secrets
 # Kubeflow Pipelines
 - ../../../awsconfigs/apps/pipeline
 # Katib

--- a/tests/e2e/resources/cloudformation-templates/rds-s3.yaml
+++ b/tests/e2e/resources/cloudformation-templates/rds-s3.yaml
@@ -67,10 +67,6 @@ Parameters:
     Default: "false"
     AllowedValues: ["true", "false"]
     ConstraintDescription: must be true or false.
-  # See MyRDSSecret and MyS3Secret below
-  # S3SecretString:
-  #   Description: Secret string for S3 secrets
-  #   Type: String
 Resources:
   MySQLSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -119,19 +115,6 @@ Resources:
       PubliclyAccessible: True
     DeletionPolicy: Snapshot
 
-  # Currently the secret names must be rds-secret and s3-secret, however SecretsManager in CFN appends a random string to the end of a provided name
-  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secret.html
-  # Uncomment this section when we make secret names a configurable parameter for our secrets manager implementation
-  # MyRDSSecret:
-  #   Type: "AWS::SecretsManager::Secret"
-  #   Properties:
-  #     Name: rds-secret
-  #     SecretString: !Sub '{"username":${DBUsername},"password":${DBPassword},"database":${DBName},"host":${MyDB.Endpoint.Address},"port":${MyDB.Endpoint.Port}}'
-  # MyS3Secret:
-  #   Type: "AWS::SecretsManager::Secret"
-  #   Properties:
-  #     Name: s3-secret
-  #     SecretString: !Sub S3SecretString # This doesn't depend on any resource outputs so lets pass it in directly
 Outputs:
   RDSEndpoint:
     Description: RDS Endpoint


### PR DESCRIPTION
**Description of your changes:**
- Made `kubeflow-secrets` a deployment instead of a pod #83 
- Allows secret names for rds and s3 to be user configurable #74 
- Updated `tests/test_rds_s3.py ` to provide custom secret names

**Testing**
Passing RDS S3 tests `tests/test_rds_s3.py`
```
pytest tests/test_rds_s3.py -s -q --region eu-west-2 --accesskey <redacted> --secretkey <redacted>

...
3 passed in 1699.30s (0:28:19)
```
  
