### PR TITLE
[WIP] Enhance EFS Tests: Dynamic Provisioning and validate using KFP

### DIFF
--- a/distributions/aws/examples/storage/efs/auto-efs-setup.py
+++ b/distributions/aws/examples/storage/efs/auto-efs-setup.py
@@ -5,7 +5,7 @@ import string
 import random
 import yaml
 import urllib.request
-
+import random
 from shutil import which
 from time import sleep
 
@@ -206,7 +206,8 @@ def kubectl_apply(file_name: str):
         "kubectl",
         "apply",
         "-f",
-        file_name
+        file_name, 
+        "--force"
     ])
 
 
@@ -537,6 +538,14 @@ def footer():
     print("                      EFS Setup Complete")
     print("=================================================================")
 
+def rand_name(prefix):
+    """
+    Returns a random string of 10 ascii lowercase characters appended to the prefix
+    """
+    suffix = "".join(
+        random.choice(string.ascii_lowercase + string.digits) for _ in range(10)
+    )
+    return prefix + suffix
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -553,7 +562,7 @@ parser.add_argument(
     help='Your cluster name (eg: mycluster-1)',
     required=True
 )
-EFS_FILE_SYSTEM_NAME_DEFAULT = "KubeflowEfs"
+EFS_FILE_SYSTEM_NAME_DEFAULT = rand_name("Kubeflow-efs")
 parser.add_argument(
     '--efs_file_system_name',
     type=str,

--- a/distributions/aws/examples/storage/efs/auto-efs-setup.py
+++ b/distributions/aws/examples/storage/efs/auto-efs-setup.py
@@ -5,7 +5,6 @@ import string
 import random
 import yaml
 import urllib.request
-import random
 from shutil import which
 from time import sleep
 
@@ -44,12 +43,16 @@ def verify_oidc_provider_prerequisite():
     if is_oidc_provider_present():
         print("OIDC provider found")
     else:
-        raise Exception(f"Prerequisite not met : No OIDC provider found for cluster '{CLUSTER_NAME}'!")
+        raise Exception(
+            f"Prerequisite not met : No OIDC provider found for cluster '{CLUSTER_NAME}'!"
+        )
 
 
 def is_oidc_provider_present() -> bool:
     iam_client = get_iam_client()
-    oidc_providers = iam_client.list_open_id_connect_providers()["OpenIDConnectProviderList"]
+    oidc_providers = iam_client.list_open_id_connect_providers()[
+        "OpenIDConnectProviderList"
+    ]
 
     if len(oidc_providers) == 0:
         return False
@@ -59,19 +62,18 @@ def is_oidc_provider_present() -> bool:
             OpenIDConnectProviderArn=oidc_provider["Arn"]
         )["Tags"]
 
-        if any(tag["Key"] == "alpha.eksctl.io/cluster-name" and \
-               tag["Value"] == CLUSTER_NAME \
-               for tag in oidc_provider_tags):
+        if any(
+            tag["Key"] == "alpha.eksctl.io/cluster-name"
+            and tag["Value"] == CLUSTER_NAME
+            for tag in oidc_provider_tags
+        ):
             return True
 
     return False
 
 
 def get_iam_client():
-    return boto3.client(
-        "iam",
-        region_name=CLUSTER_REGION
-    )
+    return boto3.client("iam", region_name=CLUSTER_REGION)
 
 
 def verify_eksctl_is_installed():
@@ -82,7 +84,9 @@ def verify_eksctl_is_installed():
     if is_prerequisite_met:
         print("eksctl found!")
     else:
-        raise Exception("Prerequisite not met : eksctl could not be found, make sure it is installed or in your PATH!")
+        raise Exception(
+            "Prerequisite not met : eksctl could not be found, make sure it is installed or in your PATH!"
+        )
 
 
 def verify_kubectl_is_installed():
@@ -93,7 +97,9 @@ def verify_kubectl_is_installed():
     if is_prerequisite_met:
         print("kubectl found!")
     else:
-        raise Exception("Prerequisite not met : kubectl could not be found, make sure it is installed or in your PATH!")
+        raise Exception(
+            "Prerequisite not met : kubectl could not be found, make sure it is installed or in your PATH!"
+        )
 
 
 def setup_iam_authorization():
@@ -109,7 +115,9 @@ def setup_efs_iam_policy():
     if does_need_to_create_efs_iam_policy():
         create_efs_iam_policy()
     else:
-        print(f"Skipping EFS IAM policy creation, '{EFS_IAM_POLICY_NAME}' already exists!")
+        print(
+            f"Skipping EFS IAM policy creation, '{EFS_IAM_POLICY_NAME}' already exists!"
+        )
 
 
 def does_need_to_create_efs_iam_policy():
@@ -122,10 +130,7 @@ def does_need_to_create_efs_iam_policy():
 
 
 def get_iam_resource():
-    return boto3.resource(
-        "iam",
-        region_name=CLUSTER_REGION
-    )
+    return boto3.resource("iam", region_name=CLUSTER_REGION)
 
 
 def create_efs_iam_policy():
@@ -137,7 +142,7 @@ def create_efs_iam_policy():
     iam_client.create_policy(
         PolicyName=EFS_IAM_POLICY_NAME,
         PolicyDocument=policy_document,
-        Description="EFS CSI Driver Policy"
+        Description="EFS CSI Driver Policy",
     )
 
     print("EFS IAM policy created!")
@@ -147,7 +152,7 @@ def get_efs_iam_policy_document():
     url = "https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v1.3.6/docs/iam-policy-example.json"
     response = urllib.request.urlopen(url)
     data = response.read()
-    return data.decode('utf-8')
+    return data.decode("utf-8")
 
 
 def setup_efs_iam_service_account():
@@ -157,23 +162,25 @@ def setup_efs_iam_service_account():
 def create_efs_iam_service_account():
     print("Creating EFS IAM service account...")
 
-    subprocess.run([
-        "eksctl",
-        "create",
-        "iamserviceaccount",
-        "--name",
-        "efs-csi-controller-sa",
-        "--namespace",
-        "kube-system",
-        "--cluster",
-        CLUSTER_NAME,
-        "--attach-policy-arn",
-        EFS_IAM_POLICY_ARN,
-        "--approve",
-        "--override-existing-serviceaccounts",
-        "--region",
-        CLUSTER_REGION
-    ])
+    subprocess.run(
+        [
+            "eksctl",
+            "create",
+            "iamserviceaccount",
+            "--name",
+            "efs-csi-controller-sa",
+            "--namespace",
+            "kube-system",
+            "--cluster",
+            CLUSTER_NAME,
+            "--attach-policy-arn",
+            EFS_IAM_POLICY_ARN,
+            "--approve",
+            "--override-existing-serviceaccounts",
+            "--region",
+            CLUSTER_REGION,
+        ]
+    )
 
     print("EFS IAM service account created!")
 
@@ -189,26 +196,19 @@ def setup_efs_driver():
 def install_efs_driver():
     print("Installing EFS driver...")
 
-    kubectl_kustomize_apply("https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v1.3.6")
+    kubectl_kustomize_apply(
+        "https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v1.3.6"
+    )
 
     print("EFS driver installed!")
 
+
 def kubectl_kustomize_apply(file_name: str):
-    subprocess.run([
-        "kubectl",
-        "apply",
-        "-k",
-        file_name
-    ])
+    subprocess.run(["kubectl", "apply", "-k", file_name])
+
 
 def kubectl_apply(file_name: str):
-    subprocess.run([
-        "kubectl",
-        "apply",
-        "-f",
-        file_name, 
-        "--force"
-    ])
+    subprocess.run(["kubectl", "apply", "-f", file_name, "--force"])
 
 
 def setup_efs_file_system():
@@ -220,48 +220,42 @@ def setup_efs_file_system():
         if does_need_to_create_efs_security_group():
             create_efs_security_group()
         else:
-            print(f"Skipping EFS security group creation, security group '{EFS_SECURITY_GROUP_NAME}' already exists!")
+            print(
+                f"Skipping EFS security group creation, security group '{EFS_SECURITY_GROUP_NAME}' already exists!"
+            )
 
         create_efs_file_system()
     else:
-        print(f"Skipping EFS file system creation, file system '{EFS_FILE_SYSTEM_NAME}' already exists!")
+        print(
+            f"Skipping EFS file system creation, file system '{EFS_FILE_SYSTEM_NAME}' already exists!"
+        )
 
 
 def does_need_to_create_efs_file_system() -> bool:
     efs_client = get_efs_client()
     efs_file_systems = efs_client.describe_file_systems()["FileSystems"]
 
-    return not any(file_system.get("Name", "") == EFS_FILE_SYSTEM_NAME for file_system in efs_file_systems)
+    return not any(
+        file_system.get("Name", "") == EFS_FILE_SYSTEM_NAME
+        for file_system in efs_file_systems
+    )
 
 
 def get_efs_client():
-    return boto3.client(
-        "efs",
-        region_name=CLUSTER_REGION
-    )
+    return boto3.client("efs", region_name=CLUSTER_REGION)
 
 
 def does_need_to_create_efs_security_group() -> bool:
     ec2_client = get_ec2_client()
     efs_security_groups_with_matching_name = ec2_client.describe_security_groups(
-        Filters=[
-            {
-                "Name": "group-name",
-                "Values": [
-                    EFS_SECURITY_GROUP_NAME
-                ]
-            }
-        ]
+        Filters=[{"Name": "group-name", "Values": [EFS_SECURITY_GROUP_NAME]}]
     )["SecurityGroups"]
 
     return len(efs_security_groups_with_matching_name) == 0
 
 
 def get_ec2_client():
-    return boto3.client(
-        "ec2",
-        region_name=CLUSTER_REGION
-    )
+    return boto3.client("ec2", region_name=CLUSTER_REGION)
 
 
 def create_efs_security_group():
@@ -281,16 +275,11 @@ def create_efs_security_group():
 
 
 def get_eks_client():
-    return boto3.client(
-        "eks",
-        region_name=CLUSTER_REGION
-    )
+    return boto3.client("eks", region_name=CLUSTER_REGION)
 
 
 def get_cluster_info(eks_client):
-    return eks_client.describe_cluster(
-        name=CLUSTER_NAME
-    )["cluster"]
+    return eks_client.describe_cluster(name=CLUSTER_NAME)["cluster"]
 
 
 def get_vpc_id(cluster_info):
@@ -300,12 +289,9 @@ def get_vpc_id(cluster_info):
 def get_cidr_block_ip(ec2_client, vpc_id):
     return ec2_client.describe_vpcs(
         Filters=[
-            {
-                "Name": "tag:alpha.eksctl.io/cluster-name",
-                "Values": [CLUSTER_NAME]
-            },
+            {"Name": "tag:alpha.eksctl.io/cluster-name", "Values": [CLUSTER_NAME]},
         ],
-        VpcIds=[vpc_id]
+        VpcIds=[vpc_id],
     )["Vpcs"][0]["CidrBlock"]
 
 
@@ -342,11 +328,8 @@ def create_efs_file_system():
         ThroughputMode=EFS_FILE_SYSTEM_THROUGHPUT_MODE,
         Backup=False,
         Tags=[
-            {
-                "Key": "Name",
-                "Value": EFS_FILE_SYSTEM_NAME
-            },
-        ]
+            {"Key": "Name", "Value": EFS_FILE_SYSTEM_NAME},
+        ],
     )
     print("EFS file system created!")
     wait_for_efs_file_system_to_become_available(efs_file_system_creation_token)
@@ -355,7 +338,7 @@ def create_efs_file_system():
 
 
 def generate_creation_token(size=64, chars=string.ascii_uppercase) -> str:
-    return ''.join(random.choice(chars) for _ in range(size))
+    return "".join(random.choice(chars) for _ in range(size))
 
 
 def wait_for_efs_file_system_to_become_available(efs_file_system_creation_token):
@@ -372,7 +355,9 @@ def wait_for_efs_file_system_to_become_available(efs_file_system_creation_token)
         )["FileSystems"][0]["LifeCycleState"]
 
         if status == "error":
-            raise Exception("An unexpected error occurred while waiting for the EFS file system to become available!")
+            raise Exception(
+                "An unexpected error occurred while waiting for the EFS file system to become available!"
+            )
 
         sleep(1)
 
@@ -381,13 +366,17 @@ def wait_for_efs_file_system_to_become_available(efs_file_system_creation_token)
 
 def create_efs_mount_targets(efs_file_system_creation_token):
     efs_client = get_efs_client()
-    file_system_id = get_file_system_id_from_creation_token(efs_client, efs_file_system_creation_token)
+    file_system_id = get_file_system_id_from_creation_token(
+        efs_client, efs_file_system_creation_token
+    )
 
     ec2_client = get_ec2_client()
     efs_security_group_id = get_efs_security_group_id(ec2_client)
     subnet_ids = get_cluster_public_subnet_ids(ec2_client)
 
-    mount_target_ids = create_mount_targets(efs_client, efs_security_group_id, file_system_id, subnet_ids)
+    mount_target_ids = create_mount_targets(
+        efs_client, efs_security_group_id, file_system_id, subnet_ids
+    )
     wait_for_mount_target_to_become_available(efs_client, mount_target_ids)
 
 
@@ -399,28 +388,15 @@ def get_file_system_id_from_creation_token(efs_client, efs_file_system_creation_
 
 def get_efs_security_group_id(ec2_client):
     return ec2_client.describe_security_groups(
-        Filters=[
-            {
-                "Name": "group-name",
-                "Values": [
-                    EFS_SECURITY_GROUP_NAME
-                ]
-            }
-        ]
+        Filters=[{"Name": "group-name", "Values": [EFS_SECURITY_GROUP_NAME]}]
     )["SecurityGroups"][0]["GroupId"]
 
 
 def get_cluster_public_subnet_ids(ec2_client):
     subnets = ec2_client.describe_subnets(
         Filters=[
-            {
-                "Name": "tag:alpha.eksctl.io/cluster-name",
-                "Values": [CLUSTER_NAME]
-            },
-            {
-                "Name": "tag:aws:cloudformation:logical-id",
-                "Values": ["SubnetPublic*"]
-            },
+            {"Name": "tag:alpha.eksctl.io/cluster-name", "Values": [CLUSTER_NAME]},
+            {"Name": "tag:aws:cloudformation:logical-id", "Values": ["SubnetPublic*"]},
         ]
     )["Subnets"]
 
@@ -439,7 +415,7 @@ def create_mount_targets(efs_client, efs_security_group_id, file_system_id, subn
         mount_target_id = efs_client.create_mount_target(
             FileSystemId=file_system_id,
             SubnetId=subnet_id,
-            SecurityGroups=[efs_security_group_id]
+            SecurityGroups=[efs_security_group_id],
         )["MountTargetId"]
 
         print(f"Mount target {mount_target_id} created!")
@@ -456,12 +432,14 @@ def wait_for_mount_target_to_become_available(efs_client, mount_target_ids):
         print(f"Waiting for EFS mount target {mount_target_id} to become available...")
 
         while status != "available":
-            status = efs_client.describe_mount_targets(
-                MountTargetId=mount_target_id
-            )["MountTargets"][0]["LifeCycleState"]
+            status = efs_client.describe_mount_targets(MountTargetId=mount_target_id)[
+                "MountTargets"
+            ][0]["LifeCycleState"]
 
             if status == "error":
-                raise Exception(f"An unexpected error occurred while waiting for the mount target {mount_target_id}!")
+                raise Exception(
+                    f"An unexpected error occurred while waiting for the mount target {mount_target_id}!"
+                )
 
             sleep(1)
 
@@ -489,11 +467,12 @@ def update_dynamic_provisioning_storage_class_file():
     efs_client = get_efs_client()
     file_system_id = get_file_system_id_from_name(efs_client)
 
-    storage_class_file_yaml_content = read_dynamic_provisioning_storage_class_file_content()
+    storage_class_file_yaml_content = (
+        read_dynamic_provisioning_storage_class_file_content()
+    )
 
     edit_dynamic_provisioning_storage_class_fields(
-        file_system_id,
-        storage_class_file_yaml_content
+        file_system_id, storage_class_file_yaml_content
     )
 
 
@@ -505,8 +484,7 @@ def read_dynamic_provisioning_storage_class_file_content():
 
 
 def edit_dynamic_provisioning_storage_class_fields(
-        file_system_id,
-        storage_class_file_yaml_content
+    file_system_id, storage_class_file_yaml_content
 ):
     print("Editing storage class with appropriate values...")
 
@@ -538,61 +516,61 @@ def footer():
     print("                      EFS Setup Complete")
     print("=================================================================")
 
-def rand_name(prefix):
-    """
-    Returns a random string of 10 ascii lowercase characters appended to the prefix
-    """
-    suffix = "".join(
-        random.choice(string.ascii_lowercase + string.digits) for _ in range(10)
-    )
-    return prefix + suffix
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    '--region',
+    "--region",
     type=str,
     metavar="CLUSTER_REGION",
-    help='Your cluster region code (eg: us-east-2)',
-    required=True
+    help="Your cluster region code (eg: us-east-2)",
+    required=True,
 )
 parser.add_argument(
-    '--cluster',
+    "--cluster",
     type=str,
     metavar="CLUSTER_NAME",
-    help='Your cluster name (eg: mycluster-1)',
-    required=True
+    help="Your cluster name (eg: mycluster-1)",
+    required=True,
 )
-EFS_FILE_SYSTEM_NAME_DEFAULT = rand_name("Kubeflow-efs")
+EFS_FILE_SYSTEM_NAME_DEFAULT = "Kubeflow-efs"
 parser.add_argument(
-    '--efs_file_system_name',
+    "--efs_file_system_name",
     type=str,
     default=EFS_FILE_SYSTEM_NAME_DEFAULT,
     help=f"Default is set to {EFS_FILE_SYSTEM_NAME_DEFAULT}",
-    required=False
+    required=False,
 )
 EFS_SECURITY_GROUP_NAME_DEFAULT = "KubeflowEfsSecurityGroup"
 parser.add_argument(
-    '--efs_security_group_name',
+    "--efs_security_group_name",
     type=str,
     default=EFS_SECURITY_GROUP_NAME_DEFAULT,
     help=f"Default is set to {EFS_SECURITY_GROUP_NAME_DEFAULT}",
-    required=False
+    required=False,
 )
 EFS_PERFORMANCE_MODE_DEFAULT = "generalPurpose"
 parser.add_argument(
-    '--efs_performance_mode',
+    "--efs_performance_mode",
     type=str,
     default=EFS_PERFORMANCE_MODE_DEFAULT,
     help=f"Default is set to {EFS_PERFORMANCE_MODE_DEFAULT}",
-    required=False
+    required=False,
 )
 EFS_THROUGHPUT_MODE_DEFAULT = "bursting"
 parser.add_argument(
-    '--efs_throughput_mode',
+    "--efs_throughput_mode",
     type=str,
     default=EFS_THROUGHPUT_MODE_DEFAULT,
     help=f"Default is set to {EFS_THROUGHPUT_MODE_DEFAULT}",
-    required=False
+    required=False,
+)
+DEFAULT_DIRECTORY_PATH = ""
+parser.add_argument(
+    "--directory",
+    type=str,
+    default=DEFAULT_DIRECTORY_PATH,
+    help=f"Specify the path to the source files if different. Default is set to empty.",
+    required=False,
 )
 
 args, _ = parser.parse_known_args()
@@ -604,10 +582,13 @@ if __name__ == "__main__":
     EFS_SECURITY_GROUP_NAME = args.efs_security_group_name
     EFS_FILE_SYSTEM_PERFORMANCE_MODE = args.efs_performance_mode
     EFS_FILE_SYSTEM_THROUGHPUT_MODE = args.efs_throughput_mode
+    DIRECTORY_PATH = args.directory
 
-    AWS_ACCOUNT_ID = boto3.client('sts').get_caller_identity()["Account"]
+    AWS_ACCOUNT_ID = boto3.client("sts").get_caller_identity()["Account"]
     EFS_IAM_POLICY_NAME = "AmazonEKS_EFS_CSI_Driver_Policy"
     EFS_IAM_POLICY_ARN = f"arn:aws:iam::{AWS_ACCOUNT_ID}:policy/{EFS_IAM_POLICY_NAME}"
-    EFS_DYNAMIC_PROVISIONING_STORAGE_CLASS_FILE_PATH = "dynamic-provisioning/sc.yaml"
+    EFS_DYNAMIC_PROVISIONING_STORAGE_CLASS_FILE_PATH = (
+        DIRECTORY_PATH + "dynamic-provisioning/sc.yaml"
+    )
 
     main()

--- a/distributions/aws/examples/storage/efs/dynamic-provisioning/pvc.yaml
+++ b/distributions/aws/examples/storage/efs/dynamic-provisioning/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: efs-claim
+  namespace: kubeflow-user-example-com
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: efs-claim

--- a/distributions/aws/examples/storage/notebook-sample/set-permission-job.yaml
+++ b/distributions/aws/examples/storage/notebook-sample/set-permission-job.yaml
@@ -23,4 +23,4 @@ spec:
       volumes:
       - name: persistent-storage
         persistentVolumeClaim:
-          claimName: 	<claim-name>
+          claimName: <claim-name>

--- a/distributions/aws/test/e2e/resources/piplines/pipeline_read_from_volume.py
+++ b/distributions/aws/test/e2e/resources/piplines/pipeline_read_from_volume.py
@@ -1,0 +1,43 @@
+"""
+A Kubeflow Pipeline Function which reads a file with dummy content at a specified path.
+The Pipeline is run with a specified PVC volume mount. 
+"""
+
+import kfp
+from kfp import components
+from kfp import dsl
+from kfp.components import create_component_from_func
+
+MOUNT_PATH = ""
+CLAIM_NAME = ""
+
+
+def read_volume(mount_path: str):
+    import os
+
+    file_name = "write-to-volume.md"
+    file_path = mount_path + file_name
+    print("Reading from volume")
+    output = os.listdir(mount_path)
+
+    assert file_name in output
+
+    with open(file_path, "r") as fp:
+        content = fp.read()
+
+    assert "dummy" in content
+
+
+read_volume_op = create_component_from_func(
+    read_volume, base_image="python", packages_to_install=["boto3"]
+)
+
+
+@dsl.pipeline(
+    name="Reading from Volume KFP Component",
+    description="Read from Volume",
+)
+def read_from_volume_pipeline(mount_path=MOUNT_PATH, claim_name=CLAIM_NAME):
+    read_volume_op(mount_path).set_display_name("Read Volume KFP Component").add_pvolumes(
+        {mount_path: dsl.PipelineVolume(pvc=claim_name)}
+    )

--- a/distributions/aws/test/e2e/resources/piplines/pipeline_write_to_volume.py
+++ b/distributions/aws/test/e2e/resources/piplines/pipeline_write_to_volume.py
@@ -1,0 +1,36 @@
+"""
+A Kubeflow Pipeline Function which creates a file with dummy content at a specified path.
+The Pipeline is run with a specified PVC volume mount. 
+"""
+
+import kfp
+from kfp import components
+from kfp import dsl
+from kfp.components import create_component_from_func
+
+MOUNT_PATH = ""
+CLAIM_NAME = ""
+
+
+def write_volume(mount_path: str):
+    import os
+
+    print("Writing a file on the Volume")
+    file_path = mount_path + "write-to-volume.md"
+    with open(file_path, "w") as fp:
+        fp.write("dummy content ! ")
+
+
+write_volume_op = create_component_from_func(
+    write_volume, base_image="python", packages_to_install=["boto3"]
+)
+
+
+@dsl.pipeline(
+    name="Writing to Volume Component",
+    description="Write to Volume",
+)
+def write_to_volume_pipeline(mount_path=MOUNT_PATH, claim_name=CLAIM_NAME):
+    write_volume_op(mount_path).set_display_name("Write KFP Component").add_pvolumes(
+        {mount_path: dsl.PipelineVolume(pvc=claim_name)}
+    )

--- a/distributions/aws/test/e2e/tests/test_rds_s3.py
+++ b/distributions/aws/test/e2e/tests/test_rds_s3.py
@@ -226,7 +226,7 @@ def delete_s3_bucket_contents(cfn_stack, request, region):
 PIPELINE_NAME = "[Demo] XGBoost - Iterative model training"
 KATIB_EXPERIMENT_FILE = "katib-experiment-random.yaml"
 
-
+# TODO: This could be moved to utils and combined with the `wait_for_kfp_run_succeeded_from_run_id`
 def wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id):
     def callback():
         resp = kfp_client.get_run(run.id)

--- a/distributions/aws/test/e2e/tests/test_storage_efs.py
+++ b/distributions/aws/test/e2e/tests/test_storage_efs.py
@@ -4,9 +4,13 @@ Installs the vanilla distribution of kubeflow and validates EFS integration by:
     - Creating the required IAM Policy, Role and Service Account
     - Creating the EFS Volume 
     - Creating a StorageClass, PersistentVolume and PersistentVolumeClaim using Static Provisioning
+    - Using KFP to check that the EFS can be accessed
 """
 
 import pytest
+import json
+import os
+import time
 import subprocess
 
 from e2e.utils.constants import DEFAULT_USER_NAMESPACE
@@ -15,7 +19,17 @@ from e2e.utils.config import metadata
 from e2e.conftest import region
 
 from e2e.fixtures.cluster import cluster
-from e2e.fixtures.clients import account_id
+from e2e.fixtures.clients import (
+    account_id,
+    create_k8s_admission_registration_api_client,
+    port_forward,
+    kfp_client,
+    host,
+    client_namespace,
+    session_cookie,
+    login,
+    password,
+)
 
 from e2e.fixtures.kustomize import kustomize, configure_manifests
 
@@ -30,8 +44,19 @@ from e2e.utils.constants import (
     DEFAULT_USER_NAMESPACE,
     DEFAULT_NAMESPACE,
 )
+from e2e.utils.utils import (
+    unmarshal_yaml,
+    rand_name,
+    wait_for_kfp_run_succeeded_from_run_id,
+)
+from e2e.resources.piplines.pipeline_read_from_volume import read_from_volume_pipeline
+from e2e.resources.piplines.pipeline_write_to_volume import write_to_volume_pipeline
 
 GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../../../example"
+DISABLE_PIPELINE_CACHING_PATCH_FILE = (
+    "./resources/custom-resource-templates/patch-disable-pipeline-caching.yaml"
+)
+MOUNT_PATH = "/home/jovyan/"
 
 
 @pytest.fixture(scope="class")
@@ -41,15 +66,27 @@ def kustomize_path():
 
 class TestEFS_Static:
     @pytest.fixture(scope="class")
-    def setup(self, metadata, kustomize, static_provisioning):
+    def setup(self, metadata, kustomize, port_forward, static_provisioning):
+        # Disable caching in KFP
+        # By default KFP will cache previous pipeline runs and subsequent runs will skip cached steps
+        # This prevents artifacts from being uploaded to s3 for subsequent runs
+        patch_body = unmarshal_yaml(DISABLE_PIPELINE_CACHING_PATCH_FILE)
+        k8s_admission_registration_api_client = (
+            create_k8s_admission_registration_api_client(cluster, region)
+        )
+        k8s_admission_registration_api_client.patch_mutating_webhook_configuration(
+            "cache-webhook-kubeflow", patch_body
+        )
+
         metadata_file = metadata.to_file()
         print(metadata.params)  # These needed to be logged
-        print("Created metadata file for TestSanity", metadata_file)
+        print("Created metadata file for TestEFS_Static", metadata_file)
 
     def test_pvc_with_volume(
         self,
         metadata,
         setup,
+        kfp_client,
         account_id,
         create_efs_volume,
         static_provisioning,
@@ -68,22 +105,64 @@ class TestEFS_Static:
         fs_id = create_efs_volume["file_system_id"]
         assert "fs-" in fs_id
 
-        claim_name = static_provisioning["claim_name"]
+        CLAIM_NAME = static_provisioning["claim_name"]
+        print(f"static claim name is {CLAIM_NAME}")
         claim_list = subprocess.check_output("kubectl get pvc -A".split()).decode()
-        assert claim_name in claim_list
+        assert CLAIM_NAME in claim_list
+
+
+        claim_entry = subprocess.check_output(
+            f"kubectl get pvc -n {DEFAULT_USER_NAMESPACE} {CLAIM_NAME} -o=jsonpath='{{.status.phase}}'".split()
+        ).decode()
+        assert "Bound" in claim_entry
+        
+        # TODO: The following can be put into a method or split this into different tests
+        # TODO: The following section needs more assertions
+        # Create two Pipelines both mounted with the same EFS volume claim. 
+        # The first one writes a file to the volume, the second one reads it and verifies content.
+        experiment_name = rand_name("static-experiment-")
+        experiment_description = rand_name("description-")
+        experiment = kfp_client.create_experiment(
+            experiment_name,
+            description=experiment_description,
+            namespace=DEFAULT_USER_NAMESPACE,
+        )
+        arguments = {'mount_path': MOUNT_PATH, 'claim_name': CLAIM_NAME}
+
+        #Write Pipeline Run
+        write_run_id = kfp_client.create_run_from_pipeline_func(write_to_volume_pipeline, experiment_name=experiment_name, namespace=DEFAULT_USER_NAMESPACE, arguments=arguments).run_id
+        print(f"write_pipeline run id is {write_run_id}")
+        wait_for_kfp_run_succeeded_from_run_id(kfp_client, write_run_id)
+
+        #Read Pipeline Run
+        read_run_id = kfp_client.create_run_from_pipeline_func(read_from_volume_pipeline, experiment_name=experiment_name, namespace=DEFAULT_USER_NAMESPACE, arguments=arguments).run_id
+        print(f"read_pipeline run id is {read_run_id}")
+        wait_for_kfp_run_succeeded_from_run_id(kfp_client, read_run_id)
 
 
 class TestEFS_Dynamic:
     @pytest.fixture(scope="class")
-    def setup_dynamic(self, metadata, kustomize, dynamic_provisioning):
+    def setup_dynamic(self, metadata, kustomize, port_forward, dynamic_provisioning):
+        # Disable caching in KFP
+        # By default KFP will cache previous pipeline runs and subsequent runs will skip cached steps
+        # This prevents artifacts from being uploaded to s3 for subsequent runs
+        patch_body = unmarshal_yaml(DISABLE_PIPELINE_CACHING_PATCH_FILE)
+        k8s_admission_registration_api_client = (
+            create_k8s_admission_registration_api_client(cluster, region)
+        )
+        k8s_admission_registration_api_client.patch_mutating_webhook_configuration(
+            "cache-webhook-kubeflow", patch_body
+        )
+
         metadata_file = metadata.to_file()
         print(metadata.params)  # These needed to be logged
-        print("Created metadata file for TestSanity", metadata_file)
+        print("Created metadata file for TestEFS_Dynamic", metadata_file)
 
     def test_pvc_with_volume_dynamic(
         self,
         metadata,
         setup_dynamic,
+        kfp_client,
         account_id,
         create_efs_volume,
         dynamic_provisioning,
@@ -102,12 +181,50 @@ class TestEFS_Dynamic:
         fs_id = create_efs_volume["file_system_id"]
         assert "fs-" in fs_id
 
-        efs_claim_dyn = dynamic_provisioning["efs_claim_dyn"]
+        CLAIM_NAME = dynamic_provisioning["efs_claim_dyn"]
         claim_list = subprocess.check_output("kubectl get pvc -A".split()).decode()
-        assert efs_claim_dyn in claim_list
+        assert CLAIM_NAME in claim_list
 
-        # TODO: Add this check to static provisioning as well
-        # TODO: Status is currently pending but we should also be testing for this to reach bound state
-        claim_entry = subprocess.check_output(f"kubectl get pvc -n {DEFAULT_USER_NAMESPACE} {efs_claim_dyn} -o=jsonpath='{{.status.phase}}'".split()).decode()
+        claim_entry = subprocess.check_output(
+            f"kubectl get pvc -n {DEFAULT_USER_NAMESPACE} {CLAIM_NAME} -o=jsonpath='{{.status.phase}}'".split()
+        ).decode()
         assert "Pending" in claim_entry
-        
+
+        # TODO: The following can be put into a method or split this into different tests
+        # TODO: The following section needs more assertions
+        # Create two Pipelines both mounted with the same EFS volume claim. 
+        # The first one writes a file to the volume, the second one reads it and verifies content.
+        experiment_name = rand_name("dyn-experiment-")
+        experiment_description = rand_name("description-")
+        experiment = kfp_client.create_experiment(
+            experiment_name,
+            description=experiment_description,
+            namespace=DEFAULT_USER_NAMESPACE,
+        )
+        arguments = {"mount_path": MOUNT_PATH, "claim_name": CLAIM_NAME}
+
+        # Write Pipeline Run 
+        write_run_id = kfp_client.create_run_from_pipeline_func(
+            write_to_volume_pipeline,
+            experiment_name=experiment_name,
+            namespace=DEFAULT_USER_NAMESPACE,
+            arguments=arguments,
+        ).run_id
+        print(f"write_pipeline run id is {write_run_id}")
+        wait_for_kfp_run_succeeded_from_run_id(kfp_client, write_run_id)
+
+        # Read Pipeline Run
+        read_run_id = kfp_client.create_run_from_pipeline_func(
+            read_from_volume_pipeline,
+            experiment_name=experiment_name,
+            namespace=DEFAULT_USER_NAMESPACE,
+            arguments=arguments,
+        ).run_id
+        print(f"read_pipeline run id is {read_run_id}")
+        wait_for_kfp_run_succeeded_from_run_id(kfp_client, read_run_id)
+
+        # PVC should now be bound
+        claim_entry_after = subprocess.check_output(
+            f"kubectl get pvc -n {DEFAULT_USER_NAMESPACE} {CLAIM_NAME} -o=jsonpath='{{.status.phase}}'".split()
+        ).decode()
+        assert "Bound" in claim_entry_after

--- a/distributions/aws/test/e2e/utils/constants.py
+++ b/distributions/aws/test/e2e/utils/constants.py
@@ -4,6 +4,7 @@ Global constants module
 
 DEFAULT_HOST = "http://localhost:8080/"
 DEFAULT_USER_NAMESPACE = "kubeflow-user-example-com"
+DEFAULT_NAMESPACE = "kube-system"
 DEFAULT_USERNAME = "user@example.com"
 DEFAULT_PASSWORD = "12341234"
 KUBEFLOW_GROUP = "kubeflow.org"

--- a/distributions/aws/test/e2e/utils/utils.py
+++ b/distributions/aws/test/e2e/utils/utils.py
@@ -85,6 +85,22 @@ def wait_for(callback, timeout=300, interval=30):
             time.sleep(interval)
 
 
+def wait_for_kfp_run_succeeded_from_run_id(kfp_client, run_id):
+    def callback():
+        resp = kfp_client.get_run(run_id)
+        status = resp.run.status
+
+        if "Failed" == status:
+            print(resp.run)
+            raise WaitForCircuitBreakerError("Pipeline run Failed")
+
+        print(f"{run_id} {status} .... waiting")
+        assert status == "Succeeded"
+
+    # TODO: These Pipeline runs are taking longer than expected, needs investigation
+    return wait_for(callback, 1200)
+
+
 def rand_name(prefix):
     """
     Returns a random string of 10 ascii lowercase characters appended to the prefix


### PR DESCRIPTION
#### [WIP] This PR is complete in functionality but needs some code cleanup

**Description of your changes:**
 - [x] Adds a test for EFS dynamic provisioning using the automated script, `auto-efs-setup.py`
 - [x] added a parameter to the auto-install script to specify a path to the `sc.yaml` file since the path requirements change when running from tests - this can be customized a bit more so that I can use it for static provisioning as well. 
 - [x]  Enhance the EFS static and dynamic provisioning tests to also test the volume usage using 2 KFP pipelines - one writes to the volume and other reads from it. 
 
**TODO:**
- [ ] Static Provisioning also needs an automated script. 
- [ ] The KFP test is currently taking very long to run on my cluster - about 40minutes sometimes - this has increased with the number of runs on my cluster so possibly a resource limitation - I need to debug this.

**Testing:** - 
Tested the change manually at every step to ensure it is doing what is expected and also ran the suite multiple times locally. 


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
