### PR TITLE
Check cluster-region before creating s3-Bucket in automated setup

### DIFF
--- a/distributions/aws/examples/rds-s3/auto-rds-s3-setup.py
+++ b/distributions/aws/examples/rds-s3/auto-rds-s3-setup.py
@@ -126,21 +126,12 @@ def does_bucket_exist(s3_client):
 def create_s3_bucket(s3_client):
     print("Creating S3 bucket...")
 
-    # CreateBucketConfiguration cannot have LocationConstraint of us-east-1 since it is the default
-    if CLUSTER_REGION == "us-east-1":
-        s3_client.create_bucket(
-        ACL="private",
-        Bucket=S3_BUCKET_NAME
-    )
-    else: 
-        s3_client.create_bucket(
-            ACL="private",
-            Bucket=S3_BUCKET_NAME,
-            CreateBucketConfiguration={
-                "LocationConstraint": CLUSTER_REGION,
-            }
-        )
-
+    args = {"ACL":"private","Bucket":S3_BUCKET_NAME}
+    # CreateBucketConfiguration is necessary to provide LocationConstraint unless using default region of us-east-1
+    if CLUSTER_REGION != "us-east-1":
+        args["CreateBucketConfiguration"] = {"LocationConstraint":CLUSTER_REGION}
+     
+    s3_client.create_bucket(**args)
     print("S3 bucket created!")
 
 

--- a/distributions/aws/examples/rds-s3/auto-rds-s3-setup.py
+++ b/distributions/aws/examples/rds-s3/auto-rds-s3-setup.py
@@ -126,13 +126,20 @@ def does_bucket_exist(s3_client):
 def create_s3_bucket(s3_client):
     print("Creating S3 bucket...")
 
-    s3_client.create_bucket(
+    # CreateBucketConfiguration cannot have LocationConstraint of us-east-1 since it is the default
+    if CLUSTER_REGION == "us-east-1":
+        s3_client.create_bucket(
         ACL="private",
-        Bucket=S3_BUCKET_NAME,
-        CreateBucketConfiguration={
-            "LocationConstraint": CLUSTER_REGION,
-        }
+        Bucket=S3_BUCKET_NAME
     )
+    else: 
+        s3_client.create_bucket(
+            ACL="private",
+            Bucket=S3_BUCKET_NAME,
+            CreateBucketConfiguration={
+                "LocationConstraint": CLUSTER_REGION,
+            }
+        )
 
     print("S3 bucket created!")
 


### PR DESCRIPTION
**Description of your changes:**
Automated setup will fail if cluster_region is set to us-east-1, since the s3-bucket creation will error out due to 

> botocore.exceptions.ClientError: An error occurred (InvalidLocationConstraint) when calling the CreateBucket operation: The specified location-constraint is not valid
thus will check if region is us-east-1 and call CreateBucket without this constraint.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
