### PR TITLE
Fixed metadata db name hard coded to metadb

### DIFF
--- a/awsconfigs/apps/pipeline/params.env
+++ b/awsconfigs/apps/pipeline/params.env
@@ -1,5 +1,5 @@
 dbHost=YOUR_RDS_ENDPOINT
-
+mlmdDb=YOUR_METADATA_DB_NAME
 bucketName=YOUR_S3_BUCKET_NAME
 minioServiceHost=s3.amazonaws.com
 minioServiceRegion=YOUR_AWS_REGION

--- a/docs/deployment/rds-s3/README.md
+++ b/docs/deployment/rds-s3/README.md
@@ -171,10 +171,10 @@ Resources:
 
    1. Configure `awsconfigs/apps/pipeline/params.env` file with the RDS endpoint URL, S3 bucket name, and S3 bucket region that were configured when following the steps in Create RDS Instance and Create S3 Bucket steps in prerequisites(#1-prerequisites).
 
-      - For example, if your RDS endpoint URL is `rm12abc4krxxxxx.xxxxxxxxxxxx.us-west-2.rds.amazonaws.com`, S3 bucket name is `kf-aws-demo-bucket`, and s3 bucket region is `us-west-2` your `params.env` file should look like:
+      - For example, if your RDS endpoint URL is `rm12abc4krxxxxx.xxxxxxxxxxxx.us-west-2.rds.amazonaws.com`, metadata db name is `kubeflow`, S3 bucket name is `kf-aws-demo-bucket`, and s3 bucket region is `us-west-2` your `params.env` file should look like:
       - ```
         dbHost=rm12abc4krxxxxx.xxxxxxxxxxxx.us-west-2.rds.amazonaws.com
-
+        mlmdDb=kubeflow
         bucketName=kf-aws-demo-bucket
         minioServiceHost=s3.amazonaws.com
         minioServiceRegion=us-west-2

--- a/docs/deployment/rds-s3/auto-rds-s3-setup.py
+++ b/docs/deployment/rds-s3/auto-rds-s3-setup.py
@@ -564,6 +564,9 @@ def get_updated_pipeline_params_env_lines(db_instance_info, pipeline_params_env_
     db_host_pattern = "dbHost="
     db_host_new_line = db_host_pattern + db_instance_info["Endpoint"]["Address"] + "\n"
 
+    db_mlmd_db_pattern = "mlmdDb="
+    db_mlmd_db_new_line = db_mlmd_db_pattern + db_instance_info["DBName"] + "\n"
+
     bucket_name_pattern = "bucketName="
     bucket_name_new_line = bucket_name_pattern + S3_BUCKET_NAME + "\n"
 
@@ -574,6 +577,7 @@ def get_updated_pipeline_params_env_lines(db_instance_info, pipeline_params_env_
 
     for line in pipeline_params_env_lines:
         line = replace_line(line, db_host_pattern, db_host_new_line)
+        line = replace_line(line, db_mlmd_db_pattern, db_mlmd_db_new_line)
         line = replace_line(line, bucket_name_pattern, bucket_name_new_line)
         line = replace_line(line, minio_service_region_pattern, minio_service_region_new_line)
         new_pipeline_params_env_lines.append(line)
@@ -645,12 +649,12 @@ parser.add_argument(
     help=f"Unique identifier for the RDS database instance. Default is set to {DB_INSTANCE_NAME_DEFAULT}",
     required=False
 )
-DB_NAME_DEFAULT = "kubeflow"
+DB_NAME_DEFAULT = "metadb"
 parser.add_argument(
     '--db_name',
     type=str,
     default=DB_NAME_DEFAULT,
-    help=f"Default is set to {DB_NAME_DEFAULT}",
+    help=f"Name of the metadata database. Default is set to {DB_NAME_DEFAULT}",
     required=False
 )
 DB_INSTANCE_TYPE_DEFAULT = "db.m5.large"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #110  

**Description of your changes:**
Tested using custom db name `ml_metadata_db`   
<img src="https://user-images.githubusercontent.com/26939775/156201001-306e8b56-6097-4387-bf37-c7d09e77c11b.png" width="300" height="400" />
<img src="https://user-images.githubusercontent.com/26939775/156201317-2495580c-c7b2-4027-8678-6f261c8bc065.png" width="300" height="400" />
<img src="https://user-images.githubusercontent.com/26939775/156201437-37c6afef-27d6-4648-a9fa-04b38ffa7261.png" width="800" height="400" />

Verified every databases and every tables content after executing a pipeline run with artifacts.  

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
- [x] end-to-end test (new cluster, setup rds using automated script, create pipeline with artifacts, verify db and tables) 
