### PR TITLE
Fix dex for Kubernetes 1.21

### DIFF
--- a/common/dex/base/deployment.yaml
+++ b/common/dex/base/deployment.yaml
@@ -28,6 +28,11 @@ spec:
         envFrom:
           - secretRef:
               name: dex-oidc-client
+        env:
+          - name: KUBERNETES_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Pulling fix from https://github.com/kubeflow/manifests/pull/1883 regarding an issue where dex pods were not getting creating the kubeflow namespace for EKS cluster running version 1.21.

**Description of your changes:**
Update dex deployment.yaml

**Checklist:**

CLI verifcation:
```
❮ kbl get pods -n auth
NAME                   READY   STATUS    RESTARTS   AGE
dex-5ddf47d88d-fh29t   1/1     Running   1          6m21s
```

- [x] Manual testing EKS v1.21 (verify fix)
  - [x] Verify pod in CLI
  - [x] Connect to central dashboard and run an experiment
- [x] Manual testing EKS v1.19 (verify fix doesn't break previous versions)
  - [x] Verify pod in CLI
  - [x] Connect to central dashboard and run an experiment

