### PR TITLE
Documentation updates: usage tracking, link and manifest fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS Distribution of Kubeflow
+# Kubeflow on AWS
 
 ## Overview
 
@@ -12,7 +12,7 @@ There are a number of deployment options for installing Kubeflow with AWS servic
 
 For help, please consider the following venues (in order):
 
-* Documentation: Link TBD
+* [Documentation](https://www.kubeflow.org/docs/distributions/aws/)
 * [Search open issues](https://github.com/awslabs/kubeflow-manifests/issues)
 * [File an issue](https://github.com/awslabs/kubeflow-manifests/issues/new/choose)
 * Chat with us on the `#platform-aws` channel in the [Kubeflow Slack](https://www.kubeflow.org/docs/about/community/#slack) community.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,4 +1,4 @@
-# AWS Distribution of Kubeflow
+# Kubeflow on AWS
 
 ## Deployment Options
 
@@ -26,7 +26,7 @@ Installation steps can be found [here](add-ons/storage/fsx-for-lustre)
 
 ## Security
 
-We highly recommend to follow AWS security best practice documentation while provisioning AWS resources. We have added few references below.
+The scripts in this repository are meant to be used for development/testing purposes. We highly recommend to follow AWS security best practice documentation while provisioning AWS resources. We have added few references below.
 
 [Security best practices for Amazon Elastic Kubernetes Service (EKS)](https://aws.github.io/aws-eks-best-practices/security/docs/)  
 [Security best practices for AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/best-practices.html)  
@@ -36,3 +36,51 @@ We highly recommend to follow AWS security best practice documentation while pro
 [Security in Amazon Certificate Manager (ACM)](https://docs.aws.amazon.com/acm/latest/userguide/security.html)  
 [Security best practices for Amazon Cognito user pools](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html)  
 [Security in Amazon Elastic Load Balancing (ELB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/security.html)
+
+## Usage Tracking
+
+AWS uses customer feedback and usage information to improve the quality of the services and software we offer to customers. We have added usage data collection to the AWS Kubeflow distribution in order to better understand customer usage and guide future improvements. Usage tracking for Kubeflow is activated by default, but is entirely voluntary and can be deactivated at any time. 
+
+Usage tracking for Kubeflow on AWS collects the instance ID used by one of the worker nodes in a customer’s cluster. This data is sent back to AWS once per day. Usage tracking only collects the EC2 instance ID where Kubeflow is running and does not collect or export any other data to AWS. If you wish to deactivate this tracking, instructions are below. 
+
+### How to activate usage tracking
+
+Usage tracking is activated by default. If you deactivated usage tracking for your Kubeflow deployment and would like to activate it after the fact, you can do so at any time with the following command:
+
+- ```
+  kustomize build distributions/aws/aws-telemetry | kubectl apply -f -
+  ```
+
+### How to deactivate usage tracking
+
+**Before deploying Kubeflow:** 
+
+You can deactivate usage tracking by skipping the telemetry component installation in one of two ways:
+
+1. For single line installation, comment out the `aws-telemetry` line in the `kustomization.yaml` file. e.g. in [cognito-rds-s3 kustomization.yaml](cognito-rds-s3/kustomization.yaml#L59) file:
+    ```
+    # ./../aws-telemetry
+    ```
+1. For individual component installation, **do not** install the `aws-telemetry` component: 
+    ```
+    # AWS Telemetry - This is an optional component. See usage tracking documentation for more information
+    kustomize build distributions/aws/aws-telemetry | kubectl apply -f -
+    ```
+**After deploying Kubeflow:**
+
+To deactivate usage tracking on an existing deployment, delete the `aws-kubeflow-telemetry` cronjob with the following command:
+
+```
+kubectl delete cronjob -n kubeflow aws-kubeflow-telemetry
+```
+
+### Information collected by usage tracking
+
+* **Instance ID** - We collect the instance ID used by one of the worker nodes in the customer’s EKS cluster. This collection occurs once per day.
+
+### Learn more
+
+The telemetry data we collect is in accordance with AWS data privacy policies. For more information, see the following:
+
+* [AWS Service Terms](https://aws.amazon.com/service-terms/)
+* [Data Privacy](https://aws.amazon.com/compliance/data-privacy-faq/)

--- a/docs/deployment/add-ons/storage/efs/README.md
+++ b/docs/deployment/add-ons/storage/efs/README.md
@@ -3,7 +3,7 @@
 This guide describes how to use Amazon EFS as Persistent storage on top of an existing Kubeflow deployment.  
 
 ## 1.0 Prerequisites
-1. For this README, we will assume that you already have an EKS Cluster with Kubeflow installed since the EFS CSI Driver can be installed and configured as a separate resource on top of an existing Kubeflow deployment. You can follow any of the other guides to complete these steps - choose one of the [AWS managed service integrated offering](../../README.md) or [generic distribution](../../../../../README.md).
+1. For this README, we will assume that you already have an EKS Cluster with Kubeflow installed since the EFS CSI Driver can be installed and configured as a separate resource on top of an existing Kubeflow deployment. You can follow any of the other guides to complete these steps - choose one of the [AWS managed service integrated offering](../../../README.md#deployment-options) or [vanilla distribution](../../../vanilla/README.md).
 
 **Important :**
 You must make sure you have an [OIDC provider](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) for your cluster and that it was added from `eksctl` >= `0.56` or if you already have an OIDC provider in place, then you must make sure you have the tag `alpha.eksctl.io/cluster-name` with the cluster name as its value. If you don't have the tag, you can add it via the AWS Console by navigating to IAM->Identity providers->Your OIDC->Tags.

--- a/docs/deployment/add-ons/storage/fsx-for-lustre/README.md
+++ b/docs/deployment/add-ons/storage/fsx-for-lustre/README.md
@@ -3,7 +3,7 @@
 This guide describes how to use Amazon FSx as Persistent storage on top of an existing Kubeflow deployment.  
 
 ## 1.0 Prerequisites
-1. For this README, we will assume that you already have an EKS Cluster with Kubeflow installed since the FSx CSI Driver can be installed and configured as a separate resource on top of an existing Kubeflow deployment. You can follow any of the other guides to complete these steps - choose one of the [AWS managed service integrated offering](../../README.md) or [generic distribution](../../../../../README.md).
+1. For this README, we will assume that you already have an EKS Cluster with Kubeflow installed since the FSx CSI Driver can be installed and configured as a separate resource on top of an existing Kubeflow deployment. You can follow any of the other guides to complete these steps - choose one of the [AWS managed service integrated offering](../../../README.md#deployment-options) or [vanilla distribution](../../../vanilla/README.md).
 
 2. At this point, you have likely cloned this repo and checked out the right branch. Navigate to the current directory - 
 ```

--- a/docs/deployment/cognito-rds-s3/README.md
+++ b/docs/deployment/cognito-rds-s3/README.md
@@ -43,7 +43,7 @@ Follow the pre-requisites section from [this guide](../rds-s3/README.md#1-prereq
         kustomize build upstream/common/cert-manager/kubeflow-issuer/base | kubectl apply -f -
         
         # KNative
-        kustomize build upstream/common/knative/knative-serving/base | kubectl apply -f -
+        kustomize build upstream/common/knative/knative-serving/overlays/gateways | kubectl apply -f -
         kustomize build upstream/common/knative/knative-eventing/base | kubectl apply -f -
         kustomize build upstream/common/istio-1-9/cluster-local-gateway/base | kubectl apply -f -
         

--- a/docs/deployment/cognito-rds-s3/kustomization.yaml
+++ b/docs/deployment/cognito-rds-s3/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 - ../../../upstream/common/istio-1-9/istio-namespace/base
 - ../../../upstream/common/istio-1-9/istio-install/base
 # KNative
-- ../../../upstream/common/knative/knative-serving/base
+- ../../../upstream/common/knative/knative-serving/overlays/gateways
 - ../../../upstream/common/knative/knative-eventing/base
 - ../../../upstream/common/istio-1-9/cluster-local-gateway/base
 # Kubeflow Istio Resources

--- a/docs/deployment/cognito/README.md
+++ b/docs/deployment/cognito/README.md
@@ -10,7 +10,7 @@ This guide assumes that you have:
     - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) - A command line tool for interacting with AWS services.
     - [eksctl](https://eksctl.io/introduction/#installation) - A command line tool for working with EKS clusters.
     - [kubectl](https://kubernetes.io/docs/tasks/tools) - A command line tool for working with Kubernetes clusters.
-    - [yq](https://mikefarah.gitbook.io/yq) - A command line tool for YAML processing. (For Linux environments, use the [wget plain binary installation](https://mikefarah.gitbook.io/yq/#wget))
+    - [yq](https://mikefarah.gitbook.io/yq) - A command line tool for YAML processing. (For Linux environments, use the [wget plain binary installation](https://github.com/mikefarah/yq/#install))
     - [jq](https://stedolan.github.io/jq/download/) - A command line tool for processing JSON.
     - [kustomize version 3.2.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) - A command line tool to customize Kubernetes objects through a kustomization file.
       - :warning: Kubeflow 1.3.0 is not compatible with the latest versions of of kustomize 4.x. This is due to changes in the order resources are sorted and printed. Please see [kubernetes-sigs/kustomize#3794](https://github.com/kubernetes-sigs/kustomize/issues/3794) and [kubeflow/manifests#1797](https://github.com/kubeflow/manifests/issues/1797). We know this is not ideal and are working with the upstream kustomize team to add support for the latest versions of kustomize as soon as we can.
@@ -234,7 +234,7 @@ In this section, we will be creating certificate to enable TLS authentication at
         kustomize build common/cert-manager/kubeflow-issuer/base | kubectl apply -f -
         
         # KNative
-        kustomize build common/knative/knative-serving/base | kubectl apply -f -
+        kustomize build common/knative/knative-serving/overlays/gateways | kubectl apply -f -
         kustomize build common/knative/knative-eventing/base | kubectl apply -f -
         kustomize build common/istio-1-9/cluster-local-gateway/base | kubectl apply -f -
         

--- a/docs/deployment/cognito/kustomization.yaml
+++ b/docs/deployment/cognito/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 - ../../../upstream/common/istio-1-9/istio-namespace/base
 - ../../../upstream/common/istio-1-9/istio-install/base
 # KNative
-- ../../../upstream/common/knative/knative-serving/base
+- ../../../upstream/common/knative/knative-serving/overlays/gateways
 - ../../../upstream/common/knative/knative-eventing/base
 - ../../../upstream/common/istio-1-9/cluster-local-gateway/base
 # Kubeflow Istio Resources

--- a/docs/deployment/rds-s3/README.md
+++ b/docs/deployment/rds-s3/README.md
@@ -17,7 +17,7 @@ The following steps show how to configure and deploy Kubeflow with supported AWS
    - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) - A command line tool for interacting with AWS services.
    - [eksctl >= 0.56](https://eksctl.io/introduction/#installation) - A command line tool for working with EKS clusters.
    - [kubectl](https://kubernetes.io/docs/tasks/tools) - A command line tool for working with Kubernetes clusters.
-   - [yq](https://mikefarah.gitbook.io/yq) - A command line tool for YAML processing. (For Linux environments, use the [wget plain binary installation](https://mikefarah.gitbook.io/yq/#wget))
+   - [yq](https://mikefarah.gitbook.io/yq) - A command line tool for YAML processing. (For Linux environments, use the [wget plain binary installation](https://github.com/mikefarah/yq/#install))
    - [jq](https://stedolan.github.io/jq/download/) - A command line tool for processing JSON.
    - [kustomize version 3.2.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) - A command line tool to customize Kubernetes objects through a kustomization file.
      - :warning: Kubeflow 1.3.0 is not compatible with the latest versions of of kustomize 4.x. This is due to changes in the order resources are sorted and printed. Please see [kubernetes-sigs/kustomize#3794](https://github.com/kubernetes-sigs/kustomize/issues/3794) and [kubeflow/manifests#1797](https://github.com/kubeflow/manifests/issues/1797). We know this is not ideal and are working with the upstream kustomize team to add support for the latest versions of kustomize as soon as we can.

--- a/docs/deployment/rds-s3/kustomization.yaml
+++ b/docs/deployment/rds-s3/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 # Dex
 - ../../../upstream/common/dex/overlays/istio
 # KNative
-- ../../../upstream/common/knative/knative-serving/base
+- ../../../upstream/common/knative/knative-serving/overlays/gateways
 - ../../../upstream/common/knative/knative-eventing/base
 - ../../../upstream/common/istio-1-9/cluster-local-gateway/base
 # Kubeflow namespace

--- a/docs/deployment/vanilla/README.md
+++ b/docs/deployment/vanilla/README.md
@@ -325,6 +325,10 @@ After running the command, you can access the Kubeflow Central Dashboard by doin
 1. Open your browser and visit `http://localhost:8080`. You should get the Dex login screen.
 2. Login with the default user's credential. The default email address is `user@example.com` and the default password is `12341234`.
 
+#### Exposing Kubeflow over Load Balancer
+
+In order to expose Kubeflow over an external address you can setup AWS Application Load Balancer. This feature is in active development, please take a look at the following issue: [#67](https://github.com/awslabs/kubeflow-manifests/issues/67) to stay up to date on the progress.
+
 ### Change default user password
 
 For security reasons, we don't want to use the default password for the default Kubeflow user when installing in security-sensitive environments. Instead, you should define your own password before deploying. To define a password for the default user:


### PR DESCRIPTION
**Description of your changes:**
- Bring in changes from #114:
  - TODO item from #109 regarding detailed documentation for telemetry component
  - Changed the name from AWS distribution of Kubeflow to Kubeflow on AWS to be consistent with website and usage tracking documentation
  - Added a section in vanilla Kubeflow readme: `Exposing Kubeflow over Load Balancer` to this [#67](https://github.com/awslabs/kubeflow-manifests/issues/67) to expose deployment over LoadBalancer.
- adds fixes for a few broken links
- Sync the knative manifest for other deployment options with [vanilla](https://github.com/awslabs/kubeflow-manifests/blob/14c17ff16689dbf70af7fb7971deb7da63105690/docs/deployment/vanilla/kustomization.yaml#L17) corresponding to this [change](https://github.com/kubeflow/manifests/issues/1966). This was a missed in initial PR because of looking at 2 branches to create this one

**Testing**
- links working as expected
- tested kfserving model using steps from #82 for the knative overlay change