### PR TITLE
[WIP] Enhance FSx test using KFP Components with volume mounts

### DIFF
--- a/distributions/aws/test/e2e/tests/test_storage_fsx.py
+++ b/distributions/aws/test/e2e/tests/test_storage_fsx.py
@@ -15,7 +15,17 @@ from e2e.utils.config import metadata
 from e2e.conftest import region
 
 from e2e.fixtures.cluster import cluster
-from e2e.fixtures.clients import account_id
+from e2e.fixtures.clients import (
+    account_id,
+    create_k8s_admission_registration_api_client,
+    port_forward,
+    kfp_client,
+    host,
+    client_namespace,
+    session_cookie,
+    login,
+    password,
+)
 
 from e2e.fixtures.kustomize import kustomize, configure_manifests
 
@@ -25,8 +35,24 @@ from e2e.fixtures.storage_fsx_dependencies import (
     create_fsx_volume,
     static_provisioning,
 )
+from e2e.utils.constants import (
+    DEFAULT_USER_NAMESPACE,
+    DEFAULT_NAMESPACE,
+)
+from e2e.utils.utils import (
+    unmarshal_yaml,
+    rand_name,
+    wait_for_kfp_run_succeeded_from_run_id,
+)
+from e2e.resources.piplines.pipeline_read_from_volume import read_from_volume_pipeline
+from e2e.resources.piplines.pipeline_write_to_volume import write_to_volume_pipeline
 
 GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../../../example"
+GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../../../example"
+DISABLE_PIPELINE_CACHING_PATCH_FILE = (
+    "./resources/custom-resource-templates/patch-disable-pipeline-caching.yaml"
+)
+MOUNT_PATH = "/home/jovyan/"
 
 
 @pytest.fixture(scope="class")
@@ -36,16 +62,29 @@ def kustomize_path():
 
 class TestFSx:
     @pytest.fixture(scope="class")
-    def setup(self, metadata, static_provisioning):
-        metadata_file = metadata.to_file()
-        print(metadata.params)  # These needed to be logged
-        print("Created metadata file for TestSanity", metadata_file)
+    def setup(self, metadata, kustomize, port_forward, static_provisioning):
+        def setup(self, metadata, kustomize, port_forward, static_provisioning):
+            # Disable caching in KFP
+            # By default KFP will cache previous pipeline runs and subsequent runs will skip cached steps
+            # This prevents artifacts from being uploaded to s3 for subsequent runs
+            patch_body = unmarshal_yaml(DISABLE_PIPELINE_CACHING_PATCH_FILE)
+            k8s_admission_registration_api_client = (
+                create_k8s_admission_registration_api_client(cluster, region)
+            )
+            k8s_admission_registration_api_client.patch_mutating_webhook_configuration(
+                "cache-webhook-kubeflow", patch_body
+            )
+
+            metadata_file = metadata.to_file()
+            print(metadata.params)  # These needed to be logged
+            print("Created metadata file for TestFSx_Static", metadata_file)
 
     def test_pvc_with_volume(
         self,
         metadata,
         account_id,
         setup,
+        kfp_client,
         create_fsx_volume,
         static_provisioning,
     ):
@@ -63,6 +102,44 @@ class TestFSx:
         fs_id = create_fsx_volume["file_system_id"]
         assert "fs-" in fs_id
 
-        claim_name = static_provisioning["claim_name"]
+        CLAIM_NAME = static_provisioning["claim_name"]
         claim_list = subprocess.check_output("kubectl get pvc -A".split()).decode()
-        assert claim_name in claim_list
+        assert CLAIM_NAME in claim_list
+
+        claim_entry = subprocess.check_output(
+            f"kubectl get pvc -n {DEFAULT_USER_NAMESPACE} {CLAIM_NAME} -o=jsonpath='{{.status.phase}}'".split()
+        ).decode()
+        assert "Pending" in claim_entry
+
+        # TODO: The following can be put into a method or split this into different tests
+        # TODO: The following section needs more assertions
+        # Create two Pipelines both mounted with the same EFS volume claim.
+        # The first one writes a file to the volume, the second one reads it and verifies content.
+        experiment_name = rand_name("fsx-static-experiment-")
+        experiment_description = rand_name("fsx-description-")
+        experiment = kfp_client.create_experiment(
+            experiment_name,
+            description=experiment_description,
+            namespace=DEFAULT_USER_NAMESPACE,
+        )
+        arguments = {"mount_path": MOUNT_PATH, "claim_name": CLAIM_NAME}
+
+        # Write Pipeline Run
+        write_run_id = kfp_client.create_run_from_pipeline_func(
+            write_to_volume_pipeline,
+            experiment_name=experiment_name,
+            namespace=DEFAULT_USER_NAMESPACE,
+            arguments=arguments,
+        ).run_id
+        print(f"write_pipeline run id is {write_run_id}")
+        wait_for_kfp_run_succeeded_from_run_id(kfp_client, write_run_id)
+
+        # Read Pipeline Run
+        read_run_id = kfp_client.create_run_from_pipeline_func(
+            read_from_volume_pipeline,
+            experiment_name=experiment_name,
+            namespace=DEFAULT_USER_NAMESPACE,
+            arguments=arguments,
+        ).run_id
+        print(f"read_pipeline run id is {read_run_id}")
+        wait_for_kfp_run_succeeded_from_run_id(kfp_client, read_run_id)


### PR DESCRIPTION
#### [WIP] This PR is complete in functionality but needs some code cleanup

**Description of your changes:**
 - [x]  Enhance the FSx tests to also test the volume usage using 2 KFP pipelines - one writes to the volume and other reads from it. 
 
**TODO:**
- [ ] Add Automated script. 

**Testing:** - 
Tested the change manually at every step to ensure it is doing what is expected and also ran the suite multiple times locally. 


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
