### PR TITLE
[main-branch] Enhance FSx test using KFP Components with volume mounts

### DIFF
--- a/docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/pv.yaml
+++ b/docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/pv.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolume
 metadata:
   name: fsx-pv
 spec:
+  storageClassName: fsx-sc
   capacity:
     storage: 1200Gi
   volumeMode: Filesystem

--- a/docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/pvc.yaml
+++ b/docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/pvc.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: <namespace>
 spec:
   accessModes:
-    - ReadWriteMany
-  storageClassName: ""
+  - ReadWriteMany
   resources:
     requests:
       storage: 1200Gi
+  storageClassName: fsx-sc
   volumeName: fsx-pv

--- a/docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/sc.yaml
+++ b/docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/sc.yaml
@@ -1,0 +1,5 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fsx-sc
+provisioner: fsx.csi.aws.com

--- a/docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/sc.yaml
+++ b/docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/sc.yaml
@@ -1,5 +1,5 @@
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: fsx-sc
 provisioner: fsx.csi.aws.com

--- a/tests/e2e/fixtures/storage_fsx_dependencies.py
+++ b/tests/e2e/fixtures/storage_fsx_dependencies.py
@@ -30,6 +30,7 @@ from e2e.utils.constants import (
     DEFAULT_SYSTEM_NAMESPACE,
 )
 
+
 def wait_on_fsx_status(desired_status, fsx_client, file_system_id):
     def callback():
         response = fsx_client.describe_file_systems(FileSystemIds=[file_system_id])
@@ -76,7 +77,9 @@ def create_fsx_driver_sa(
     fsx_deps = {}
     iam_client = boto3.client("iam")
 
-    FSx_POLICY_DOCUMENT = "../../docs/deployment/add-ons/storage/fsx-for-lustre/fsx-csi-driver-policy.json"
+    FSx_POLICY_DOCUMENT = (
+        "../../docs/deployment/add-ons/storage/fsx-for-lustre/fsx-csi-driver-policy.json"
+    )
     policy_name = rand_name("fsx-iam-policy-")
     policy_arn = [f"arn:aws:iam::{account_id}:policy/{policy_name}"]
 
@@ -203,8 +206,18 @@ def static_provisioning(metadata, region, request, cluster, create_fsx_volume):
     dns_name = details_fsx_volume["dns_name"]
     mount_name = details_fsx_volume["mount_name"]
     claim_name = rand_name("fsx-claim-")
-    fsx_pv_filepath = "../../docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/pv.yaml"
-    fsx_pvc_filepath = "../../docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/pvc.yaml"
+    fsx_sc_filepath = (
+        "../../docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/sc.yaml"
+    )
+    fsx_pv_filepath = (
+        "../../docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/pv.yaml"
+    )
+    fsx_pvc_filepath = (
+        "../../docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/pvc.yaml"
+    )
+    fsx_permissions_filepath = (
+        "../../docs/deployment/add-ons/storage/notebook-sample/set-permission-job.yaml"
+    )
     fsx_claim = {}
 
     def on_create():
@@ -216,12 +229,14 @@ def static_provisioning(metadata, region, request, cluster, create_fsx_volume):
         fsx_pv["spec"]["csi"]["volumeAttributes"]["mountname"] = mount_name
         write_cfg(fsx_pv, fsx_pv_filepath)
 
-        # Add the namespace to the pvc.yaml file
+        # Update the values in the pvc.yaml file
         fsx_pvc = load_cfg(fsx_pvc_filepath)
-        fsx_pvc["metadata"]["namespace"] = DEFAULT_SYSTEM_NAMESPACE
+        fsx_pvc["metadata"]["namespace"] = DEFAULT_USER_NAMESPACE
         fsx_pvc["metadata"]["name"] = claim_name
+        fsx_pvc["spec"]["volumeName"] = claim_name
         write_cfg(fsx_pvc, fsx_pvc_filepath)
 
+        kubectl_apply(fsx_sc_filepath)
         kubectl_apply(fsx_pv_filepath)
         kubectl_apply(fsx_pvc_filepath)
 

--- a/tests/e2e/tests/test_storage_efs.py
+++ b/tests/e2e/tests/test_storage_efs.py
@@ -95,7 +95,6 @@ class TestEFS_Static:
         assert "efs-csi-controller" in name
         assert status == "Running"
 
-        get_service_account
         sa_account = get_service_account(
             cluster, region, DEFAULT_SYSTEM_NAMESPACE, "efs-csi-controller-sa"
         )

--- a/tests/e2e/tests/test_storage_fsx.py
+++ b/tests/e2e/tests/test_storage_fsx.py
@@ -9,13 +9,22 @@ Installs the vanilla distribution of kubeflow and validates FSx for Lustre integ
 import pytest
 import subprocess
 
-from e2e.utils.constants import DEFAULT_USER_NAMESPACE
 from e2e.utils.config import metadata
 
 from e2e.conftest import region
 
 from e2e.fixtures.cluster import cluster
-from e2e.fixtures.clients import account_id
+from e2e.fixtures.clients import (
+    account_id,
+    create_k8s_admission_registration_api_client,
+    port_forward,
+    kfp_client,
+    host,
+    client_namespace,
+    session_cookie,
+    login,
+    password,
+)
 
 from e2e.fixtures.kustomize import kustomize, configure_manifests, clone_upstream
 
@@ -25,8 +34,23 @@ from e2e.fixtures.storage_fsx_dependencies import (
     create_fsx_volume,
     static_provisioning,
 )
+from e2e.utils.constants import (
+    DEFAULT_USER_NAMESPACE,
+    DEFAULT_SYSTEM_NAMESPACE,
+)
+from e2e.utils.utils import (
+    unmarshal_yaml,
+    rand_name,
+    wait_for_kfp_run_succeeded_from_run_id,
+)
+from e2e.resources.pipelines.pipeline_read_from_volume import read_from_volume_pipeline
+from e2e.resources.pipelines.pipeline_write_to_volume import write_to_volume_pipeline
 
 GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../docs/deployment/vanilla"
+DISABLE_PIPELINE_CACHING_PATCH_FILE = (
+    "./resources/custom-resource-templates/patch-disable-pipeline-caching.yaml"
+)
+MOUNT_PATH = "/home/jovyan/"
 
 
 @pytest.fixture(scope="class")
@@ -36,16 +60,29 @@ def kustomize_path():
 
 class TestFSx:
     @pytest.fixture(scope="class")
-    def setup(self, metadata, static_provisioning):
-        metadata_file = metadata.to_file()
-        print(metadata.params)  # These needed to be logged
-        print("Created metadata file for TestSanity", metadata_file)
+    def setup(self, metadata, kustomize, port_forward, static_provisioning):
+        def setup(self, metadata, kustomize, port_forward, static_provisioning):
+            # Disable caching in KFP
+            # By default KFP will cache previous pipeline runs and subsequent runs will skip cached steps
+            # This prevents artifacts from being uploaded to s3 for subsequent runs
+            patch_body = unmarshal_yaml(DISABLE_PIPELINE_CACHING_PATCH_FILE)
+            k8s_admission_registration_api_client = (
+                create_k8s_admission_registration_api_client(cluster, region)
+            )
+            k8s_admission_registration_api_client.patch_mutating_webhook_configuration(
+                "cache-webhook-kubeflow", patch_body
+            )
+
+            metadata_file = metadata.to_file()
+            print(metadata.params)  # These needed to be logged
+            print("Created metadata file for TestFSx_Static", metadata_file)
 
     def test_pvc_with_volume(
         self,
         metadata,
         account_id,
         setup,
+        kfp_client,
         create_fsx_volume,
         static_provisioning,
     ):
@@ -63,6 +100,45 @@ class TestFSx:
         fs_id = create_fsx_volume["file_system_id"]
         assert "fs-" in fs_id
 
-        claim_name = static_provisioning["claim_name"]
+        CLAIM_NAME = static_provisioning["claim_name"]
         claim_list = subprocess.check_output("kubectl get pvc -A".split()).decode()
-        assert claim_name in claim_list
+        assert CLAIM_NAME in claim_list
+
+        claim_entry = subprocess.check_output(
+            f"kubectl get pvc -n {DEFAULT_USER_NAMESPACE} {CLAIM_NAME} -o=jsonpath='{{.status.phase}}'".split()
+        ).decode()
+        # Claim is already bound at this point
+        assert "Bound" in claim_entry
+
+        # TODO: The following can be put into a method or split this into different tests
+        # TODO: The following section needs more assertions
+        # Create two Pipelines both mounted with the same EFS volume claim.
+        # The first one writes a file to the volume, the second one reads it and verifies content.
+        experiment_name = rand_name("fsx-static-experiment-")
+        experiment_description = rand_name("fsx-description-")
+        experiment = kfp_client.create_experiment(
+            experiment_name,
+            description=experiment_description,
+            namespace=DEFAULT_USER_NAMESPACE,
+        )
+        arguments = {"mount_path": MOUNT_PATH, "claim_name": CLAIM_NAME}
+
+        # Write Pipeline Run
+        write_run_id = kfp_client.create_run_from_pipeline_func(
+            write_to_volume_pipeline,
+            experiment_name=experiment_name,
+            namespace=DEFAULT_USER_NAMESPACE,
+            arguments=arguments,
+        ).run_id
+        print(f"write_pipeline run id is {write_run_id}")
+        wait_for_kfp_run_succeeded_from_run_id(kfp_client, write_run_id)
+
+        # Read Pipeline Run
+        read_run_id = kfp_client.create_run_from_pipeline_func(
+            read_from_volume_pipeline,
+            experiment_name=experiment_name,
+            namespace=DEFAULT_USER_NAMESPACE,
+            arguments=arguments,
+        ).run_id
+        print(f"read_pipeline run id is {read_run_id}")
+        wait_for_kfp_run_succeeded_from_run_id(kfp_client, read_run_id)


### PR DESCRIPTION
**Description of your changes:**
 - [x]  Enhance the FSx tests to also test the volume usage using 2 KFP pipelines - one writes to the volume and other reads from it. 
 
**TODO:**
- [ ] Add Automated script (separate PR)

**Testing:** - 
Tested the change manually at every step to ensure it is doing what is expected and also ran the suite multiple times locally. 

Link to testing logs - https://gist.github.com/mbaijal/b24ac6c349a1ee6c620d292897d4494a

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
