### PR TITLE
add relative path for dex configmap

### DIFF
--- a/distributions/aws/examples/vanilla/README.md
+++ b/distributions/aws/examples/vanilla/README.md
@@ -361,7 +361,7 @@ For security reasons, we don't want to use the default password for the default 
     python3 -c 'from passlib.hash import bcrypt; import getpass; print(bcrypt.using(rounds=12, ident="2y").hash(getpass.getpass()))'
     ```
 
-2. Edit `../../../../common/dex/base/config-map.yaml` and fill the relevant field with the hash of the password you chose:
+2. Edit `common/dex/base/config-map.yaml` and fill the relevant field with the hash of the password you chose:
 
     ```yaml
     ...


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
In #146 I added path from vanilla directory but all other commands refer to path from root directory. Changing it to relative path from package root

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.