### PR TITLE
Add CloudWatch/ContainerInsights to documentation

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -24,6 +24,10 @@ Installation steps can be found [here](add-ons/storage/efs)
 ### Using FSx for Lustre with Kubeflow
 Installation steps can be found [here](add-ons/storage/fsx-for-lustre)
 
+
+### CloudWatch Logging and Container Insights
+Amazon EKS offers Container Insights using Amazon CloudWatch which monitors your Amazon Web Services (AWS) resources and the applications you run on AWS in real time. You can use CloudWatch to collect and track metrics, which are variables you can measure for your resources and applications. FluentBit is used as the DaemonSet to send logs to CloudWatch Logs. Install AWS CloudWatch by following their [documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-EKS.html).
+
 ## Security
 
 The scripts in this repository are meant to be used for development/testing purposes. We highly recommend to follow AWS security best practice documentation while provisioning AWS resources. We have added few references below.
@@ -36,14 +40,6 @@ The scripts in this repository are meant to be used for development/testing purp
 [Security in Amazon Certificate Manager (ACM)](https://docs.aws.amazon.com/acm/latest/userguide/security.html)  
 [Security best practices for Amazon Cognito user pools](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html)  
 [Security in Amazon Elastic Load Balancing (ELB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/security.html)
-
-## CloudWatch Logging and Container Insights
-Amazon EKS offers Container Insights using Amazon CloudWatch which monitors your Amazon Web Services (AWS) resources and the applications you run on AWS in real time. You can use CloudWatch to collect and track metrics, which are variables you can measure for your resources and applications. FluentBit can be used as the DaemonSet to send logs to CloudWatch Logs, and will send the following logs which contain metrics such as individual pod logs. Install AWS CloudWatch by following their [documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-EKS.html).
-   - /aws/containerinsights/Cluster_Name/application
-
-   - /aws/containerinsights/Cluster_Name/host
-
-   - /aws/containerinsights/Cluster_Name/dataplane
 
 ## Usage Tracking
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -37,6 +37,14 @@ The scripts in this repository are meant to be used for development/testing purp
 [Security best practices for Amazon Cognito user pools](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html)  
 [Security in Amazon Elastic Load Balancing (ELB)](https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/security.html)
 
+## CloudWatch Logging and Container Insights
+Amazon EKS offers Container Insights using Amazon CloudWatch which monitors your Amazon Web Services (AWS) resources and the applications you run on AWS in real time. You can use CloudWatch to collect and track metrics, which are variables you can measure for your resources and applications. FluentBit can be used as the DaemonSet to send logs to CloudWatch Logs, and will send the following logs which contain metrics such as individual pod logs. Install AWS CloudWatch by following their [documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-EKS.html).
+   - /aws/containerinsights/Cluster_Name/application
+
+   - /aws/containerinsights/Cluster_Name/host
+
+   - /aws/containerinsights/Cluster_Name/dataplane
+
 ## Usage Tracking
 
 AWS uses customer feedback and usage information to improve the quality of the services and software we offer to customers. We have added usage data collection to the AWS Kubeflow distribution in order to better understand customer usage and guide future improvements. Usage tracking for Kubeflow is activated by default, but is entirely voluntary and can be deactivated at any time. 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #59 

**Description of your changes:**
Adds description of AWS Cloudwatch from their documentation and also provides a link to their setup guide.
Integration is supported by default on Amazon EKS Clusters so no special instructions or work is necessary from our end.

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.