### PR TITLE
Fix cognito logout automation and readme steps

### DIFF
--- a/docs/deployment/cognito/README.md
+++ b/docs/deployment/cognito/README.md
@@ -104,7 +104,7 @@ From this point onwards, we will be creating/updating the DNS records **only in 
           export CognitoUserPoolDomain=<>
           export certArn=<>
           export signOutURL=<>
-          export CognitoLogoutURL=$CognitoUserPoolDomain/logout?client_id=$CognitoAppClientId&logout_uri=$signOutURL
+          export CognitoLogoutURL=https://$CognitoUserPoolDomain/logout?client_id=$CognitoAppClientId&logout_uri=$signOutURL
           ```
 1. Substitute values for setting up Ingress.
     1. ```

--- a/tests/e2e/utils/cognito_bootstrap/cognito_pre_deployment.py
+++ b/tests/e2e/utils/cognito_bootstrap/cognito_pre_deployment.py
@@ -117,7 +117,7 @@ def configure_aws_authservice(
     configure_env_file(
         env_file_path="../../awsconfigs/common/aws-authservice/base/params.env",
         env_dict={
-            "LOGOUT_URL": f"{cognito_userpool.userpool_domain}/logout?client_id={cognito_userpool.client_id}&logout_uri=https://kubeflow.{subdomain_name}",
+            "LOGOUT_URL": f"https://{cognito_userpool.userpool_domain}/logout?client_id={cognito_userpool.client_id}&logout_uri=https://kubeflow.{subdomain_name}",
         },
     )
 


### PR DESCRIPTION
**Description of your changes:**

- Automation script doesn't pass https:// as part of the string format for the logout url and the userpool_domain doesn't have https:// as part of it so this will/may cause logout to fail as this prevents the browser from doing a full redirect.

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.