### PR TITLE
Fix for EFS auto-script for clusters with shared VPC

### DIFF
--- a/docs/deployment/add-ons/storage/efs/README.md
+++ b/docs/deployment/add-ons/storage/efs/README.md
@@ -56,7 +56,7 @@ python utils/auto-efs-setup.py --region $CLUSTER_REGION --cluster $CLUSTER_NAME 
 ```
 
 4. The script above takes care of creating the `StorageClass (SC)` which is a cluster scoped resource. In order to create the `PersistentVolumeClaim (PVC)` you can either use the yaml file provided in this directory or use the Kubeflow UI directly. 
-The PVC needs to be in the namespace you will be accessing it from. Replace the `kubeflow-user-example-com` namespace specified the below with the namespace for your kubeflow user and edit the `fsx-for-lustre/static-provisioning/pvc.yaml` file accordingly. 
+The PVC needs to be in the namespace you will be accessing it from. Replace the `kubeflow-user-example-com` namespace specified the below with the namespace for your kubeflow user and edit the `efs/dynamic-provisioning/pvc.yaml` file accordingly. 
 ```
 yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i $GITHUB_STORAGE_DIR/efs/dynamic-provisioning/pvc.yaml
 yq e '.metadata.name = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/efs/dynamic-provisioning/pvc.yaml
@@ -224,11 +224,11 @@ Note: As mentioned, make sure to change your default storage class only after yo
 This step may not be necessary but you might need to specify some additional directory permissions on your worker node before you can use these as mount points. By default, new Amazon EFS file systems are owned by root:root, and only the root user (UID 0) has read-write-execute permissions. If your containers are not running as root, you must change the Amazon EFS file system permissions to allow other users to modify the file system. The set-permission-job.yaml is an example of how you could set these permissions to be able to use the efs as your workspace in your kubeflow notebook. Modify it accordingly if you run into similar permission issues with any other job pod. 
 
 ```
-yq e '.metadata.name = env(CLAIM_NAME)' -i notebook-sample/set-permission-job.yaml
-yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i notebook-sample/set-permission-job.yaml
-yq e '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName = env(CLAIM_NAME)' -i notebook-sample/set-permission-job.yaml
+yq e '.metadata.name = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
+yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
+yq e '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
 
-kubectl apply -f notebook-sample/set-permission-job.yaml
+kubectl apply -f $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
 ```
 
 ### 3.4 Using existing EFS volume as workspace or data volume for a notebook

--- a/docs/deployment/add-ons/storage/efs/README.md
+++ b/docs/deployment/add-ons/storage/efs/README.md
@@ -21,10 +21,10 @@ export CLUSTER_REGION=<clusterregion>
 
 ## 2.0 Setup EFS
 
-You can either use Automated or Manual setup to set up the resources required. If you choose the manual route, you get another choice between static and dynamic provisioning, so pick whichever suits you. On the other hand, for the automated script we currently only support dynamic provisioning. Whichever combination you pick, be sure to continue picking the appropriate sections through the rest of this guide. 
+You can either use Automated or Manual setup to set up the resources required. If you choose the manual route, you get another choice between **static and dynamic provisioning**, so pick whichever suits you. On the other hand, for the automated script we currently only support **dynamic provisioning**. Whichever combination you pick, be sure to continue picking the appropriate sections through the rest of this guide. 
 
 ### 2.1 [Option 1] Automated setup
-The script automates all the manual resource creation steps but is currently only available for Dynamic Provisioning option.  
+The script automates all the manual resource creation steps but is currently only available for **Dynamic Provisioning** option.  
 It performs the required cluster configuration, creates an EFS file system and it also takes care of creating a storage class for dynamic provisioning. Once done, move to section 3.0. 
 1. Run the following commands from the `tests/e2e` directory as - 
 ```
@@ -35,8 +35,12 @@ cd $GITHUB_ROOT/tests/e2e
 pip install -r requirements.txt
 ```
 
-3. Run the automated script as follows. You can skip specifying the `efs_file_system_name` and `efs_security_group_name` if you are running the command for the first time in your account and want to use default values - 
+3. Run the automated script as follows. You can skip specifying the `efs_file_system_name` and `efs_security_group_name` if you are running the command for the first time in your account and want to use default values as in option 1 below - 
 ```
+# Option 1:
+python utils/auto-efs-setup.py --region $CLUSTER_REGION --cluster $CLUSTER_NAME
+
+# Option 2:
 export FILESYSTEM_NAME=<fs_name>
 export SG_NAME=<sg_name>
 
@@ -46,7 +50,7 @@ python utils/auto-efs-setup.py --region $CLUSTER_REGION --cluster $CLUSTER_NAME 
 The script applies some default values for the file system name, performance mode etc. If you know what you are doing, you can see which options are customizable by executing `python utils/auto-efs-setup.py --help`.
 
 ### 2.2 [Option 2] Manual setup
-If you prefer to manually setup each components then you can follow this manual guide.  As mentioned, it you have two options between Static and Dynamic provisioing later in step 4 of this section.  
+If you prefer to manually setup each component then you can follow this manual guide.  As mentioned, it you have two options between **Static and Dynamic provisioing** later in step 4 of this section.  
 
 ```
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
@@ -208,7 +212,6 @@ Note: As mentioned, make sure to change your default storage class only after yo
 This step may not be necessary but you might need to specify some additional directory permissions on your worker node before you can use these as mount points. By default, new Amazon EFS file systems are owned by root:root, and only the root user (UID 0) has read-write-execute permissions. If your containers are not running as root, you must change the Amazon EFS file system permissions to allow other users to modify the file system. The set-permission-job.yaml is an example of how you could set these permissions to be able to use the efs as your workspace in your kubeflow notebook. Modify it accordingly if you run into similar permission issues with any other job pod. 
 
 ```
-export CLAIM_NAME=efs-claim
 yq e '.metadata.name = env(CLAIM_NAME)' -i notebook-sample/set-permission-job.yaml
 yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i notebook-sample/set-permission-job.yaml
 yq e '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName = env(CLAIM_NAME)' -i notebook-sample/set-permission-job.yaml
@@ -274,7 +277,6 @@ yq e '.spec.tfReplicaSpecs.Worker.template.spec.containers[0].image = env(IMAGE_
 ```
 Also, specify the name of the PVC you created - 
 ```
-export CLAIM_NAME=efs-claim
 yq e '.spec.tfReplicaSpecs.Worker.template.spec.volumes[0].persistentVolumeClaim.claimName = env(CLAIM_NAME)' -i training-sample/tfjob.yaml
 ```
 Make sure to run it in the same namespace as the claim - 
@@ -326,5 +328,3 @@ Use the steps in this [AWS Guide](https://docs.aws.amazon.com/efs/latest/ug/dele
 1. When you rerun the `eksctl create iamserviceaccount` to create and annotate the same service account multiple times, sometimes the role does not get overwritten. In such a case you may need to do one or both of the following - 
     a. Delete the cloudformation stack associated with this add-on role.
     b. Delete the `efs-csi-controller-sa` service account and then re-run the required steps. If you used the auto-script, you can rerun it by specifying the same `filesystem-name` such that a new one is not created. 
-
-2. We have seen some issues when running these steps on multiple clusters sharing the same VPC.

--- a/tests/e2e/fixtures/storage_efs_dependencies.py
+++ b/tests/e2e/fixtures/storage_efs_dependencies.py
@@ -7,7 +7,6 @@ import sys
 
 from e2e.utils.config import metadata
 from e2e.fixtures.kustomize import kustomize, configure_manifests
-from e2e.utils.cognito_bootstrap.common import load_cfg, write_cfg
 from e2e.conftest import region
 from e2e.fixtures.cluster import cluster
 from e2e.utils.utils import rand_name
@@ -25,6 +24,8 @@ from e2e.utils.utils import (
     kubectl_delete,
     kubectl_apply_kustomize,
     kubectl_delete_kustomize,
+    load_cfg,
+    write_cfg,
 )
 from e2e.utils.constants import (
     DEFAULT_USER_NAMESPACE,

--- a/tests/e2e/fixtures/storage_efs_dependencies.py
+++ b/tests/e2e/fixtures/storage_efs_dependencies.py
@@ -24,8 +24,8 @@ from e2e.utils.utils import (
     kubectl_delete,
     kubectl_apply_kustomize,
     kubectl_delete_kustomize,
-    load_cfg,
-    write_cfg,
+    load_yaml_file,
+    write_yaml_file,
 )
 from e2e.utils.constants import (
     DEFAULT_USER_NAMESPACE,
@@ -246,26 +246,26 @@ def static_provisioning(metadata, region, request, cluster, create_efs_volume):
 
     def on_create():
         # Add the filesystem_id to the pv.yaml file
-        efs_pv = load_cfg(efs_pv_filepath)
+        efs_pv = load_yaml_file(efs_pv_filepath)
         efs_pv["spec"]["csi"]["volumeHandle"] = fs_id
         efs_pv["metadata"]["name"] = claim_name
-        write_cfg(efs_pv, efs_pv_filepath)
+        write_yaml_file(efs_pv, efs_pv_filepath)
 
         # Update the values in the pvc.yaml file
-        efs_pvc = load_cfg(efs_pvc_filepath)
+        efs_pvc = load_yaml_file(efs_pvc_filepath)
         efs_pvc["metadata"]["namespace"] = DEFAULT_USER_NAMESPACE
         efs_pvc["metadata"]["name"] = claim_name
-        write_cfg(efs_pvc, efs_pvc_filepath)
+        write_yaml_file(efs_pvc, efs_pvc_filepath)
 
         # Update the values in the permissions file
         # Statically provisioned volume needs extra permissions
-        efs_permission = load_cfg(efs_permissions_filepath)
+        efs_permission = load_yaml_file(efs_permissions_filepath)
         efs_permission["metadata"]["namespace"] = DEFAULT_USER_NAMESPACE
         efs_permission["metadata"]["name"] = "permissions" + claim_name
         efs_permission["spec"]["template"]["spec"]["volumes"][0][
             "persistentVolumeClaim"
         ]["claimName"] = claim_name
-        write_cfg(efs_permission, efs_permissions_filepath)
+        write_yaml_file(efs_permission, efs_permissions_filepath)
 
         kubectl_apply(efs_sc_filepath)
         kubectl_apply(efs_pv_filepath)
@@ -328,10 +328,10 @@ def dynamic_provisioning(metadata, region, request, cluster):
 
         # PVC creation is not a part of the script
         # Update the values in the pvc.yaml file
-        efs_pvc = load_cfg(efs_pvc_filepath)
+        efs_pvc = load_yaml_file(efs_pvc_filepath)
         efs_pvc["metadata"]["namespace"] = DEFAULT_USER_NAMESPACE
         efs_pvc["metadata"]["name"] = claim_name
-        write_cfg(efs_pvc, efs_pvc_filepath)
+        write_yaml_file(efs_pvc, efs_pvc_filepath)
 
         kubectl_apply(efs_pvc_filepath)
 

--- a/tests/e2e/fixtures/storage_fsx_dependencies.py
+++ b/tests/e2e/fixtures/storage_fsx_dependencies.py
@@ -5,7 +5,6 @@ import boto3
 import os, stat, sys
 
 from e2e.utils.config import metadata
-from e2e.utils.cognito_bootstrap.common import load_cfg, write_cfg
 from e2e.fixtures.kustomize import kustomize, configure_manifests
 from e2e.conftest import region
 from e2e.fixtures.cluster import cluster
@@ -19,6 +18,8 @@ from e2e.utils.utils import (
     kubectl_apply,
     kubectl_delete,
     load_json_file,
+    load_cfg,
+    write_cfg,
 )
 
 from e2e.utils.constants import (

--- a/tests/e2e/fixtures/storage_fsx_dependencies.py
+++ b/tests/e2e/fixtures/storage_fsx_dependencies.py
@@ -18,8 +18,8 @@ from e2e.utils.utils import (
     kubectl_apply,
     kubectl_delete,
     load_json_file,
-    load_cfg,
-    write_cfg,
+    load_yaml_file,
+    write_yaml_file,
 )
 
 from e2e.utils.constants import (
@@ -82,19 +82,19 @@ def static_provisioning(metadata, region, request, cluster):
         mount_name = get_fsx_mount_name(fsx_client, file_system_id)
 
         # Add the filesystem_id to the pv.yaml file
-        fsx_pv = load_cfg(fsx_pv_filepath)
+        fsx_pv = load_yaml_file(fsx_pv_filepath)
         fsx_pv["spec"]["csi"]["volumeHandle"] = file_system_id
         fsx_pv["metadata"]["name"] = claim_name
         fsx_pv["spec"]["csi"]["volumeAttributes"]["dnsname"] = dns_name
         fsx_pv["spec"]["csi"]["volumeAttributes"]["mountname"] = mount_name
-        write_cfg(fsx_pv, fsx_pv_filepath)
+        write_yaml_file(fsx_pv, fsx_pv_filepath)
 
         # Update the values in the pvc.yaml file
-        fsx_pvc = load_cfg(fsx_pvc_filepath)
+        fsx_pvc = load_yaml_file(fsx_pvc_filepath)
         fsx_pvc["metadata"]["namespace"] = DEFAULT_USER_NAMESPACE
         fsx_pvc["metadata"]["name"] = claim_name
         fsx_pvc["spec"]["volumeName"] = claim_name
-        write_cfg(fsx_pvc, fsx_pvc_filepath)
+        write_yaml_file(fsx_pvc, fsx_pvc_filepath)
 
         kubectl_apply(fsx_pv_filepath)
         kubectl_apply(fsx_pvc_filepath)

--- a/tests/e2e/utils/auto-efs-setup.py
+++ b/tests/e2e/utils/auto-efs-setup.py
@@ -264,10 +264,10 @@ def create_efs_security_group():
     eks_client = get_eks_client()
     ec2_client = get_ec2_client()
 
-    cluster_info = get_cluster_info(eks_client)
-
-    vpc_id = get_vpc_id(cluster_info)
+    vpc_id = get_vpc_id(eks_client)
+    print("VPC_ID:  ", vpc_id)
     cidr_block_ip = get_cidr_block_ip(ec2_client, vpc_id)
+    print("CIDR: ", cidr_block_ip)
     security_group_id = create_security_group_resource(ec2_client, vpc_id)
     authorize_security_group_ingress(cidr_block_ip, ec2_client, security_group_id)
 
@@ -282,17 +282,19 @@ def get_cluster_info(eks_client):
     return eks_client.describe_cluster(name=CLUSTER_NAME)["cluster"]
 
 
-def get_vpc_id(cluster_info):
-    return cluster_info["resourcesVpcConfig"]["vpcId"]
+def get_vpc_id(eks_client):
+    response = eks_client.describe_cluster(name=CLUSTER_NAME)
+    return response["cluster"]["resourcesVpcConfig"]["vpcId"]
 
 
 def get_cidr_block_ip(ec2_client, vpc_id):
-    return ec2_client.describe_vpcs(
-        Filters=[
-            {"Name": "tag:alpha.eksctl.io/cluster-name", "Values": [CLUSTER_NAME]},
-        ],
-        VpcIds=[vpc_id],
-    )["Vpcs"][0]["CidrBlock"]
+    # Get CIDR Range
+    response = ec2_client.describe_vpcs(
+        VpcIds=[
+            vpc_id,
+        ]
+    )
+    return response["Vpcs"][0]["CidrBlock"]
 
 
 def create_security_group_resource(ec2_client, vpc_id):
@@ -301,7 +303,6 @@ def create_security_group_resource(ec2_client, vpc_id):
         GroupName=EFS_SECURITY_GROUP_NAME,
         VpcId=vpc_id,
     )["GroupId"]
-
 
 def authorize_security_group_ingress(cidr_block_ip, ec2_client, security_group_id):
     tcp_port = 2049
@@ -331,10 +332,10 @@ def create_efs_file_system():
             {"Key": "Name", "Value": EFS_FILE_SYSTEM_NAME},
         ],
     )
-    print("EFS file system created!")
     wait_for_efs_file_system_to_become_available(efs_file_system_creation_token)
-
-    create_efs_mount_targets(efs_file_system_creation_token)
+    file_system_id = get_file_system_id_from_name(efs_client)
+    print(f"EFS filesystem {EFS_FILE_SYSTEM_NAME} created! filesystem id: {file_system_id}")
+    create_efs_mount_targets(file_system_id)
 
 
 def generate_creation_token(size=64, chars=string.ascii_uppercase) -> str:
@@ -364,15 +365,13 @@ def wait_for_efs_file_system_to_become_available(efs_file_system_creation_token)
     print("EFS file system is available!")
 
 
-def create_efs_mount_targets(efs_file_system_creation_token):
+def create_efs_mount_targets(file_system_id):
     efs_client = get_efs_client()
-    file_system_id = get_file_system_id_from_creation_token(
-        efs_client, efs_file_system_creation_token
-    )
 
+    eks_client = get_eks_client()
     ec2_client = get_ec2_client()
     efs_security_group_id = get_efs_security_group_id(ec2_client)
-    subnet_ids = get_cluster_public_subnet_ids(ec2_client)
+    subnet_ids = get_nodegroup_subnet_ids(eks_client)
 
     mount_target_ids = create_mount_targets(
         efs_client, efs_security_group_id, file_system_id, subnet_ids
@@ -391,20 +390,27 @@ def get_efs_security_group_id(ec2_client):
         Filters=[{"Name": "group-name", "Values": [EFS_SECURITY_GROUP_NAME]}]
     )["SecurityGroups"][0]["GroupId"]
 
+def get_nodegroup_subnet_ids(eks_client):
+    nodegroups = get_cluster_nodegroup(eks_client)
+    print(f"CLUSTER NODEGROUPS:  {nodegroups}")
+    cluster_public_subnets = []
 
-def get_cluster_public_subnet_ids(ec2_client):
-    subnets = ec2_client.describe_subnets(
-        Filters=[
-            {"Name": "tag:alpha.eksctl.io/cluster-name", "Values": [CLUSTER_NAME]},
-            {"Name": "tag:aws:cloudformation:logical-id", "Values": ["SubnetPublic*"]},
-        ]
-    )["Subnets"]
+    for nodegroup in nodegroups:
+        ng_subnets = eks_client.describe_nodegroup(
+            clusterName=CLUSTER_NAME,
+            nodegroupName=nodegroup
+        )["nodegroup"]["subnets"]
+        
+        for subnet in ng_subnets:
+            cluster_public_subnets.append(subnet)
 
-    def get_subnet_id(subnet):
-        return subnet["SubnetId"]
+    print("CLUSTER PUBLIC SUBNETS:  ", cluster_public_subnets)
+    return cluster_public_subnets
 
-    return list(map(get_subnet_id, subnets))
-
+def get_cluster_nodegroup(eks_client):
+    return eks_client.list_nodegroups(
+        clusterName=CLUSTER_NAME
+    )["nodegroups"]
 
 def create_mount_targets(efs_client, efs_security_group_id, file_system_id, subnet_ids):
     mount_target_ids = []

--- a/tests/e2e/utils/auto-efs-setup.py
+++ b/tests/e2e/utils/auto-efs-setup.py
@@ -304,6 +304,7 @@ def create_security_group_resource(ec2_client, vpc_id):
         VpcId=vpc_id,
     )["GroupId"]
 
+
 def authorize_security_group_ingress(cidr_block_ip, ec2_client, security_group_id):
     tcp_port = 2049
     ec2_client.authorize_security_group_ingress(
@@ -334,7 +335,9 @@ def create_efs_file_system():
     )
     wait_for_efs_file_system_to_become_available(efs_file_system_creation_token)
     file_system_id = get_file_system_id_from_name(efs_client)
-    print(f"EFS filesystem {EFS_FILE_SYSTEM_NAME} created! filesystem id: {file_system_id}")
+    print(
+        f"EFS filesystem {EFS_FILE_SYSTEM_NAME} created! filesystem id: {file_system_id}"
+    )
     create_efs_mount_targets(file_system_id)
 
 
@@ -390,6 +393,7 @@ def get_efs_security_group_id(ec2_client):
         Filters=[{"Name": "group-name", "Values": [EFS_SECURITY_GROUP_NAME]}]
     )["SecurityGroups"][0]["GroupId"]
 
+
 def get_nodegroup_subnet_ids(eks_client):
     nodegroups = get_cluster_nodegroup(eks_client)
     print(f"CLUSTER NODEGROUPS:  {nodegroups}")
@@ -397,20 +401,19 @@ def get_nodegroup_subnet_ids(eks_client):
 
     for nodegroup in nodegroups:
         ng_subnets = eks_client.describe_nodegroup(
-            clusterName=CLUSTER_NAME,
-            nodegroupName=nodegroup
+            clusterName=CLUSTER_NAME, nodegroupName=nodegroup
         )["nodegroup"]["subnets"]
-        
+
         for subnet in ng_subnets:
             cluster_public_subnets.append(subnet)
 
     print("CLUSTER PUBLIC SUBNETS:  ", cluster_public_subnets)
     return cluster_public_subnets
 
+
 def get_cluster_nodegroup(eks_client):
-    return eks_client.list_nodegroups(
-        clusterName=CLUSTER_NAME
-    )["nodegroups"]
+    return eks_client.list_nodegroups(clusterName=CLUSTER_NAME)["nodegroups"]
+
 
 def create_mount_targets(efs_client, efs_security_group_id, file_system_id, subnet_ids):
     mount_target_ids = []
@@ -591,7 +594,7 @@ if __name__ == "__main__":
     DIRECTORY_PATH = args.directory
 
     AWS_ACCOUNT_ID = boto3.client("sts").get_caller_identity()["Account"]
-    EFS_IAM_POLICY_NAME = "AmazonEKS_EFS_CSI_Driver_Policy"+EFS_FILE_SYSTEM_NAME
+    EFS_IAM_POLICY_NAME = "AmazonEKS_EFS_CSI_Driver_Policy" + EFS_FILE_SYSTEM_NAME
     EFS_IAM_POLICY_ARN = f"arn:aws:iam::{AWS_ACCOUNT_ID}:policy/{EFS_IAM_POLICY_NAME}"
 
     EFS_DYNAMIC_PROVISIONING_STORAGE_CLASS_FILE_PATH = (

--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -214,14 +214,3 @@ def print_banner(step_name: str):
     print("=" * width)
     print(step_name.center(width))
     print("=" * width)
-
-def load_cfg(file_path: str):
-    with open(file_path, "r") as stream:
-        try:
-            return yaml.safe_load(stream)
-        except yaml.YAMLError as exc:
-            print(exc)
-
-def write_cfg(config: dict, file_path: str):
-    with open(file_path, "w") as stream:
-        yaml.safe_dump(config, stream)

--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -214,3 +214,14 @@ def print_banner(step_name: str):
     print("=" * width)
     print(step_name.center(width))
     print("=" * width)
+
+def load_cfg(file_path: str):
+    with open(file_path, "r") as stream:
+        try:
+            return yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+def write_cfg(config: dict, file_path: str):
+    with open(file_path, "w") as stream:
+        yaml.safe_dump(config, stream)


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Fix for EFS auto-script for clusters with shared VPC and other README changes.

**Description of your changes:**
 - Fix for EFS auto-script for clusters with shared VPC by using the nodegroup name to get the subnet_id for EFS Volume instead of the VPC id
 - A previous PR broke EFS/FSx tests so the PR fixes that
 - I removed the video that showcased the dynamic provisioning since the claim name was different and folks were getting confused. By using the yaml files we can ensure that the same variable gets populated in the permissions and the claim. 
 
**Testing:**
This PR fixes this specific use case and is tested using the automated integration test.  Test was run on a cluster that shares a VPC with other clusters (cluster from bugbash) - 
Link to logs - https://gist.github.com/mbaijal/1c88c876a540e4494a92b46f7ca2ed6f


**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.