### PR TITLE
OIDC for fsx test; cleanup kfp pods

### DIFF
--- a/tests/e2e/fixtures/storage_efs_dependencies.py
+++ b/tests/e2e/fixtures/storage_efs_dependencies.py
@@ -275,10 +275,10 @@ def static_provisioning(metadata, region, request, cluster, create_efs_volume):
         efs_claim["claim_name"] = claim_name
 
     def on_delete():
+        kubectl_delete(efs_permissions_filepath)
         kubectl_delete(efs_pvc_filepath)
         kubectl_delete(efs_pv_filepath)
-        kubectl_delete(efs_sc_filepath)
-        kubectl_delete(efs_permissions_filepath)
+        kubectl_delete(efs_sc_filepath)   
 
     return configure_resource_fixture(
         metadata, request, efs_claim, "efs_claim", on_create, on_delete

--- a/tests/e2e/fixtures/storage_efs_dependencies.py
+++ b/tests/e2e/fixtures/storage_efs_dependencies.py
@@ -287,6 +287,7 @@ def static_provisioning(metadata, region, request, cluster, create_efs_volume):
 
 @pytest.fixture(scope="class")
 def dynamic_provisioning(metadata, region, request, cluster):
+    associate_iam_oidc_provider(cluster, region)
     claim_name = rand_name("efs-claim-auto-dyn-")
     efs_pvc_filepath = (
         "../../docs/deployment/add-ons/storage/efs/dynamic-provisioning/pvc.yaml"

--- a/tests/e2e/fixtures/storage_fsx_dependencies.py
+++ b/tests/e2e/fixtures/storage_fsx_dependencies.py
@@ -26,7 +26,6 @@ from e2e.utils.constants import (
     DEFAULT_USER_NAMESPACE,
 )
 
-
 def get_fsx_dns_name(fsx_client, file_system_id):
     response = fsx_client.describe_file_systems(FileSystemIds=[file_system_id])
     return response["FileSystems"][0]["DNSName"]
@@ -118,7 +117,8 @@ def static_provisioning(metadata, region, request, cluster):
         )
 
         # delete the security group
-        ec2_client.delete_security_group(GroupId=sg_id)
+        # TODO: This needs to be fixed. we need to wait for fsx volume to be deleted but fsx does not provided a deleted status, needs a workaround. 
+        # ec2_client.delete_security_group(GroupId=sg_id)
 
         # Delete the config file
         os.remove(config_filename)

--- a/tests/e2e/fixtures/storage_fsx_dependencies.py
+++ b/tests/e2e/fixtures/storage_fsx_dependencies.py
@@ -7,7 +7,7 @@ import os, stat, sys
 from e2e.utils.config import metadata
 from e2e.fixtures.kustomize import kustomize, configure_manifests
 from e2e.conftest import region
-from e2e.fixtures.cluster import cluster
+from e2e.fixtures.cluster import cluster, associate_iam_oidc_provider
 from e2e.fixtures.clients import account_id
 from e2e.utils.utils import rand_name
 from e2e.utils.config import configure_resource_fixture
@@ -39,6 +39,7 @@ def get_fsx_mount_name(fsx_client, file_system_id):
 
 @pytest.fixture(scope="class")
 def static_provisioning(metadata, region, request, cluster):
+    associate_iam_oidc_provider(cluster, region)
     claim_name = rand_name("fsx-claim-")
     fsx_pv_filepath = "../../docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/pv.yaml"
     fsx_pvc_filepath = "../../docs/deployment/add-ons/storage/fsx-for-lustre/static-provisioning/pvc.yaml"

--- a/tests/e2e/tests/test_storage_efs.py
+++ b/tests/e2e/tests/test_storage_efs.py
@@ -143,6 +143,11 @@ class TestEFS_Static:
         print(f"read_pipeline run id is {read_run_id}")
         wait_for_kfp_run_succeeded_from_run_id(kfp_client, read_run_id)
 
+        write_pod_name, _ = get_pod_from_label(cluster, region, DEFAULT_USER_NAMESPACE, "pipeline/runid",write_run_id)
+        read_pod_name, _ = get_pod_from_label(cluster, region, DEFAULT_USER_NAMESPACE, "pipeline/runid",read_run_id)
+        subprocess.run(f"kubectl delete pod -n {DEFAULT_USER_NAMESPACE} {write_pod_name}".split())
+        subprocess.run(f"kubectl delete pod -n {DEFAULT_USER_NAMESPACE} {read_pod_name}".split())
+
 
 class TestEFS_Dynamic:
     @pytest.fixture(scope="class")
@@ -229,3 +234,8 @@ class TestEFS_Dynamic:
             cluster, region, DEFAULT_USER_NAMESPACE, CLAIM_NAME
         )
         assert claim_status == "Bound"
+
+        write_pod_name, _ = get_pod_from_label(cluster, region, DEFAULT_USER_NAMESPACE, "pipeline/runid",write_run_id)
+        read_pod_name, _ = get_pod_from_label(cluster, region, DEFAULT_USER_NAMESPACE, "pipeline/runid",read_run_id)
+        subprocess.run(f"kubectl delete pod -n {DEFAULT_USER_NAMESPACE} {write_pod_name}".split())
+        subprocess.run(f"kubectl delete pod -n {DEFAULT_USER_NAMESPACE} {read_pod_name}".split())

--- a/tests/e2e/tests/test_storage_fsx.py
+++ b/tests/e2e/tests/test_storage_fsx.py
@@ -132,3 +132,8 @@ class TestFSx:
         )
         assert pvc_name == CLAIM_NAME
         assert claim_status == "Bound"
+
+        write_pod_name, _ = get_pod_from_label(cluster, region, DEFAULT_USER_NAMESPACE, "pipeline/runid",write_run_id)
+        read_pod_name, _ = get_pod_from_label(cluster, region, DEFAULT_USER_NAMESPACE, "pipeline/runid",read_run_id)
+        subprocess.run(f"kubectl delete pod -n {DEFAULT_USER_NAMESPACE} {write_pod_name}".split())
+        subprocess.run(f"kubectl delete pod -n {DEFAULT_USER_NAMESPACE} {read_pod_name}".split())


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
Removed OIDC set up for FSx by mistake while moving from manual to auto setup. Adding it back
also added it for the dynamic setup of EFS. 

This passed for me because I usually ran all these tests on the same cluster and static efs does setup OIDC. 

**Description of your changes:**


**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.