### PR TITLE
Add prereq upstream clone step to test_manifest_builds

### DIFF
--- a/tests/e2e/tests/test_manifest_builds.py
+++ b/tests/e2e/tests/test_manifest_builds.py
@@ -6,38 +6,45 @@ Todo: These scenarios should be tested by our unit tests.
 import pytest
 import subprocess
 
+from e2e.fixtures.kustomize import clone_upstream
+
 def kustomize_build(manifest_path):
     return subprocess.call(f"kustomize build {manifest_path}".split())
 
 TO_ROOT = "../../"
 DEPLOYMENTS_FOLDER = TO_ROOT + "docs/deployment/"
 
-def test_vanilla():
-    manifest_path = DEPLOYMENTS_FOLDER + "vanilla"
-    retcode = kustomize_build(manifest_path)
-    assert retcode == 0
+class TestManifestBuilds:
+    @pytest.fixture(scope="class")
+    def setup(self, clone_upstream):
+        print("Cloning upstream")
 
-def test_rds_s3():
-    manifest_path = DEPLOYMENTS_FOLDER + "rds-s3/base"
-    retcode = kustomize_build(manifest_path)
-    assert retcode == 0
+    def test_vanilla(self, setup):
+        manifest_path = DEPLOYMENTS_FOLDER + "vanilla"
+        retcode = kustomize_build(manifest_path)
+        assert retcode == 0
 
-def test_rds():
-    manifest_path = DEPLOYMENTS_FOLDER + "rds-s3/rds-only"
-    retcode = kustomize_build(manifest_path)
-    assert retcode == 0
+    def test_rds_s3(self, setup):
+        manifest_path = DEPLOYMENTS_FOLDER + "rds-s3/base"
+        retcode = kustomize_build(manifest_path)
+        assert retcode == 0
 
-def test_s3():
-    manifest_path = DEPLOYMENTS_FOLDER + "rds-s3/s3-only"
-    retcode = kustomize_build(manifest_path)
-    assert retcode == 0
+    def test_rds(self, setup):
+        manifest_path = DEPLOYMENTS_FOLDER + "rds-s3/rds-only"
+        retcode = kustomize_build(manifest_path)
+        assert retcode == 0
 
-def test_cognito():
-    manifest_path = DEPLOYMENTS_FOLDER + "cognito"
-    retcode = kustomize_build(manifest_path)
-    assert retcode == 0
+    def test_s3(self, setup):
+        manifest_path = DEPLOYMENTS_FOLDER + "rds-s3/s3-only"
+        retcode = kustomize_build(manifest_path)
+        assert retcode == 0
 
-def test_cognito_rds_s3():
-    manifest_path = DEPLOYMENTS_FOLDER + "cognito-rds-s3"
-    retcode = kustomize_build(manifest_path)
-    assert retcode == 0
+    def test_cognito(self, setup):
+        manifest_path = DEPLOYMENTS_FOLDER + "cognito"
+        retcode = kustomize_build(manifest_path)
+        assert retcode == 0
+
+    def test_cognito_rds_s3(self, setup):
+        manifest_path = DEPLOYMENTS_FOLDER + "cognito-rds-s3"
+        retcode = kustomize_build(manifest_path)
+        assert retcode == 0


### PR DESCRIPTION
If upstream directory is not present tests will fail. Added step to clone upstream repo.

Test output is 32.2 MB.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.