### PR TITLE
Add kubeflow-training to notebook containers

### DIFF
--- a/components/notebook-dockerfiles/pytorch/requirements.txt
+++ b/components/notebook-dockerfiles/pytorch/requirements.txt
@@ -15,6 +15,7 @@ ipywidgets==7.6.5
 kfp==1.8.6
 kfp-server-api==1.7.1
 kfserving==0.6.1
+kubeflow-training==1.4.0
 
 # Common data science packages
 h5py==3.5.0

--- a/components/notebook-dockerfiles/tensorflow/requirements.txt
+++ b/components/notebook-dockerfiles/tensorflow/requirements.txt
@@ -15,6 +15,7 @@ ipywidgets==7.6.5
 kfp==1.8.6
 kfp-server-api==1.7.1
 kfserving==0.6.1
+kubeflow-training==1.4.0
 
 # Common data science packages
 h5py==3.1.0


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
**Description of your changes:**
Adds the kubeflow-training package to the tensorflow and pytorch notebook containers

Tested that imports are working fine. Two issues are being tracked here - 
1. https://github.com/kubeflow/training-operator/issues/1585
2. https://github.com/kubeflow/training-operator/issues/1584


**Testing:**
- [x] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.