### PR TITLE
Fix EFS Cleanup to wait for deletion of mount targets

### DIFF
--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -219,3 +219,28 @@ def print_banner(step_name: str):
     print("=" * width)
     print(step_name.center(width))
     print("=" * width)
+
+
+def get_security_group_id_from_name(
+    ec2_client, eks_client, security_group_name, cluster_name
+):
+    cluster_info = eks_client.describe_cluster(name=cluster_name)["cluster"]
+    vpc_id = cluster_info["resourcesVpcConfig"]["vpcId"]
+
+    response = ec2_client.describe_security_groups(
+        Filters=[
+            {
+                "Name": "vpc-id",
+                "Values": [
+                    vpc_id,
+                ],
+            },
+            {
+                "Name": "group-name",
+                "Values": [
+                    security_group_name,
+                ],
+            },
+        ]
+    )
+    return response["SecurityGroups"][0]["GroupId"]


### PR DESCRIPTION
**Description of your changes:**
EFS Cleanup was failing sometimes since there was a delay in the cleanup of mount targets and this caused the `delete-file-system` call to fail. This has been fixed here. 

Testing - 
Tests have passed but with some local hacks - one final clean run pending. 
Logs will be added here - https://gist.github.com/mbaijal/21b1c4f2c6e0de86fc585acaf9a0e571


**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.