### PR TITLE
Fix FSx Cleanup to wait for filesystem deletion such that security group can be deleted

### DIFF
--- a/tests/e2e/utils/auto-fsx-setup.py
+++ b/tests/e2e/utils/auto-fsx-setup.py
@@ -324,6 +324,9 @@ def create_fsx_file_system():
         SecurityGroupIds=[security_group_id],
         StorageCapacity=1200,
         LustreConfiguration={"DeploymentType": "SCRATCH_2"},
+        Tags=[
+            {"Key": "Name", "Value": FSX_FILE_SYSTEM_NAME},
+        ],
     )
     global FSX_FILE_SYSTEM_ID
     FSX_FILE_SYSTEM_ID = response["FileSystem"]["FileSystemId"]


### PR DESCRIPTION
**Description of your changes:**
1. Adds a wait for the FSx filesystem to get deleted. Done this by catching the exception. 
2. Added a filesystem name tag to the FSx filesystem. 

Testing is work in progress. 
Logs will be added here - https://gist.github.com/mbaijal/3ded4bee01ea362b30dd77366854c4b1


**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.