### PR TITLE
add region field to deleteBucket call in rds-s3 cleanup

### DIFF
--- a/tests/e2e/utils/rds-s3/auto-rds-s3-cleanup.py
+++ b/tests/e2e/utils/rds-s3/auto-rds-s3-cleanup.py
@@ -17,7 +17,7 @@ def main():
     region = metadata["CLUSTER"]["region"]
     cluster_name = metadata["CLUSTER"]["name"]
     secrets_manager_client = get_secrets_manager_client(region)
-    delete_s3_bucket(metadata, secrets_manager_client)
+    delete_s3_bucket(metadata, secrets_manager_client, region)
     delete_rds(metadata, secrets_manager_client, region)
     uninstall_secrets_manager(region, cluster_name)
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves cleanup script bug mentioned in  #215
The first issue is due to different python versions being used can resolve in a separate pr. 

**Description of your changes:**

- add region field to deleteBucket call in rds-s3 cleanup

**Testing:**
- [x] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.