### PR TITLE
Add permissions info for running rds-s3 auto setup script

### DIFF
--- a/docs/deployment/rds-s3/guide.md
+++ b/docs/deployment/rds-s3/guide.md
@@ -79,7 +79,7 @@ cd tests/e2e
 ```bash
 pip install -r requirements.txt
 ```
-3. [Create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_cliwpsapi) with the permissions in [auto-setup-iam-policy.json](https://github.com/kubeflow/manifests/blob/v1.4-branch/tests/e2e/utils/rds-s3/auto-setup-iam-policy.json). Take note of the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` of the IAM user that you created to use in the following step.
+3. [Create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_cliwpsapi) with the permissions in [auto-setup-iam-policy.json](https://github.com/kubeflow/manifests/blob/main/tests/e2e/utils/rds-s3/auto-setup-iam-policy.json). Take note of the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` of the IAM user that you created to use in the following step.
 4. Export values for `CLUSTER_REGION`, `CLUSTER_NAME`, `S3_BUCKET`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`. Then, run the `auto-rds-s3-setup.py` script.
 ```
 export CLUSTER_REGION=

--- a/docs/deployment/rds-s3/guide.md
+++ b/docs/deployment/rds-s3/guide.md
@@ -79,7 +79,7 @@ cd tests/e2e
 ```bash
 pip install -r requirements.txt
 ```
-3. [Create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_cliwpsapi) with permissions to get bucket locations and allow read and write access to objects in an S3 bucket where you want to store the Kubeflow artifacts. Take note of the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` of the IAM user that you created to use in the following step.
+3. [Create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_cliwpsapi) with the permissions in [auto-setup-iam-policy.json](https://github.com/kubeflow/manifests/blob/v1.4-branch/tests/e2e/utils/rds-s3/auto-setup-iam-policy.json). Take note of the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` of the IAM user that you created to use in the following step.
 4. Export values for `CLUSTER_REGION`, `CLUSTER_NAME`, `S3_BUCKET`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`. Then, run the `auto-rds-s3-setup.py` script.
 ```
 export CLUSTER_REGION=

--- a/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
+++ b/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
@@ -4,7 +4,7 @@ import subprocess
 import json
 import yaml
 
-from importlib_metadata import metadata
+from importlib.metadata import metadata
 from e2e.fixtures.cluster import create_iam_service_account
 from e2e.utils.config import configure_env_file
 from e2e.utils.utils import (

--- a/tests/e2e/utils/rds-s3/auto-setup-iam-policy.json
+++ b/tests/e2e/utils/rds-s3/auto-setup-iam-policy.json
@@ -1,0 +1,28 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "rds:*",
+                "secretsmanager:*",
+                "s3:*",
+                "cloudformation:*",
+                "ec2:*",
+                "eks:*",
+                "iam:GetOpenIDConnectProvider",
+                "iam:CreateOpenIDConnectProvider",
+                "iam:TagOpenIDConnectProvider",
+                "iam:CreateRole",
+                "iam:AttachRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:GetRole",
+                "iam:PassRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:DetachRolePolicy"
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #219 

**Description of your changes:**
- Fix import syntax error
- Add sample policy with permissions scoped to run the auto setup script

Note: IAM policy file link will need to be merged into the main branch for the link to work.

**Testing:**
```
~/kf/issue-219/tests/e2e origin/main*
kf-e2e-test-env ❯ PYTHONPATH=.. python utils/rds-s3/auto-rds-s3-setup.py --region ap-southeast-2 --cluster kf-test-auto-setup-6 --bucket wowee-bucket-2 --s3_aws_access_key_id <hidden> --s3_aws_secret_access_key <hidden> --rds_secret_name rds-weecret --s3_secret_name s3-weecret --db_instance_name wee-db --db_subnet_group_name db-subnet-wee
=================================================================
                    Prerequisites Verification
=================================================================
Verifying eksctl is installed...
eksctl found!
Verifying kubectl is installed...
kubectl found!
=================================================================
                             S3 Setup
=================================================================
Creating S3 bucket...
S3 bucket created!
Creating S3 secret...
S3 secret created!
=================================================================
                            RDS Setup
=================================================================
Creating DB subnet group...
DB subnet group created!
Creating DB instance...
DB instance created!
Waiting for RDS DB instance to become available...
RDS DB instance is available!
Creating RDS secret...
RDS secret created!
=================================================================
                      Cluster Secrets Setup
=================================================================
Creating secrets IAM service account...
2022-05-08 23:42:54 [ℹ]  eksctl version 0.67.0
2022-05-08 23:42:54 [ℹ]  using region ap-southeast-2
2022-05-08 23:42:54 [!]  no IAM OIDC provider associated with cluster, try 'eksctl utils associate-iam-oidc-provider --region=ap-southeast-2 --cluster=kf-test-auto-setup-6'
Error: unable to create iamserviceaccount(s) without IAM OIDC provider enabled
Traceback (most recent call last):
  File "/Users/rkharse/kf/issue-219/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py", line 617, in <module>
    main()
  File "/Users/rkharse/kf/issue-219/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py", line 37, in main
    setup_cluster_secrets()
  File "/Users/rkharse/kf/issue-219/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py", line 343, in setup_cluster_secrets
    setup_iam_service_account()
  File "/Users/rkharse/kf/issue-219/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py", line 348, in setup_iam_service_account
    create_secrets_iam_service_account()
  File "/Users/rkharse/kf/issue-219/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py", line 358, in create_secrets_iam_service_account
    create_iam_service_account(
  File "/Users/rkharse/kf/issue-219/tests/e2e/fixtures/cluster.py", line 65, in create_iam_service_account
    assert retcode == 0
AssertionError

...

~/kf/issue-219/tests/e2e origin/main*
kf-e2e-test-env ❯ PYTHONPATH=.. python utils/rds-s3/auto-rds-s3-setup.py --region ap-southeast-2 --cluster kf-test-auto-setup-6 --bucket wowee-bucket-2 --s3_aws_access_key_id <hidden> --s3_aws_secret_access_key <hidden> --rds_secret_name rds-weecret --s3_secret_name s3-weecret --db_instance_name wee-db --db_subnet_group_name db-subnet-wee
=================================================================
                    Prerequisites Verification
=================================================================
Verifying eksctl is installed...
eksctl found!
Verifying kubectl is installed...
kubectl found!
=================================================================
                             S3 Setup
=================================================================
Skipping S3 bucket creation, bucket 'wowee-bucket-2' already exists!
Skipping S3 secret creation, secret 's3-weecret' already exists!
=================================================================
                            RDS Setup
=================================================================
Skipping RDS setup, DB instance 'wee-db' already exists!
=================================================================
                      Cluster Secrets Setup
=================================================================
Creating secrets IAM service account...
2022-05-08 23:43:27 [ℹ]  eksctl version 0.67.0
2022-05-08 23:43:27 [ℹ]  using region ap-southeast-2
2022-05-08 23:43:29 [ℹ]  1 iamserviceaccount (kubeflow/kubeflow-secrets-manager-sa) was included (based on the include/exclude rules)
2022-05-08 23:43:29 [!]  metadata of serviceaccounts that exist in Kubernetes will be updated, as --override-existing-serviceaccounts was set
2022-05-08 23:43:29 [ℹ]  1 task: { 2 sequential sub-tasks: { create IAM role for serviceaccount "kubeflow/kubeflow-secrets-manager-sa", create serviceaccount "kubeflow/kubeflow-secrets-manager-sa" } }
2022-05-08 23:43:29 [ℹ]  building iamserviceaccount stack "eksctl-kf-test-auto-setup-6-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-05-08 23:43:29 [ℹ]  deploying stack "eksctl-kf-test-auto-setup-6-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-05-08 23:43:29 [ℹ]  waiting for CloudFormation stack "eksctl-kf-test-auto-setup-6-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-05-08 23:43:46 [ℹ]  waiting for CloudFormation stack "eksctl-kf-test-auto-setup-6-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-05-08 23:44:03 [ℹ]  waiting for CloudFormation stack "eksctl-kf-test-auto-setup-6-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-05-08 23:44:24 [ℹ]  waiting for CloudFormation stack "eksctl-kf-test-auto-setup-6-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-05-08 23:44:31 [ℹ]  created namespace "kubeflow"
2022-05-08 23:44:31 [ℹ]  created serviceaccount "kubeflow/kubeflow-secrets-manager-sa"
Secrets IAM service account created!
Installing secrets provider...
serviceaccount/secrets-store-csi-driver created
clusterrole.rbac.authorization.k8s.io/secretproviderclasses-role created
clusterrolebinding.rbac.authorization.k8s.io/secretproviderclasses-rolebinding created
csidriver.storage.k8s.io/secrets-store.csi.k8s.io created
customresourcedefinition.apiextensions.k8s.io/secretproviderclasses.secrets-store.csi.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io created
daemonset.apps/csi-secrets-store created
clusterrole.rbac.authorization.k8s.io/secretprovidersyncing-role created
clusterrolebinding.rbac.authorization.k8s.io/secretprovidersyncing-rolebinding created
serviceaccount/csi-secrets-store-provider-aws created
clusterrole.rbac.authorization.k8s.io/csi-secrets-store-provider-aws-cluster-role created
clusterrolebinding.rbac.authorization.k8s.io/csi-secrets-store-provider-aws-cluster-rolebinding created
daemonset.apps/csi-secrets-store-provider-aws created
Secrets provider install done!
Setting up Kubeflow Pipeline...
Retrieving DB instance info...
Editing ../../awsconfigs/apps/pipeline/rds/params.env with appropriate values...
Editing ../../awsconfigs/apps/pipeline/s3/params.env with appropriate values...
Kubeflow pipeline setup done!
=================================================================
                      RDS S3 Setup Complete
=================================================================

~/kf/issue-219/tests/e2e origin/main* 1m 35s
kf-e2e-test-env ❮ PYTHONPATH=.. python utils/rds-s3/auto-rds-s3-cleanup.py
Deleting S3 bucket...
Deleting RDS instance...
RDS instance has been successfully deleted
Deleting DB Subnet Group...
DB Subnet Group has been successfully deleted
serviceaccount "secrets-store-csi-driver" deleted
clusterrole.rbac.authorization.k8s.io "secretproviderclasses-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "secretproviderclasses-rolebinding" deleted
csidriver.storage.k8s.io "secrets-store.csi.k8s.io" deleted
customresourcedefinition.apiextensions.k8s.io "secretproviderclasses.secrets-store.csi.x-k8s.io" deleted
customresourcedefinition.apiextensions.k8s.io "secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io" deleted
daemonset.apps "csi-secrets-store" deleted
clusterrole.rbac.authorization.k8s.io "secretprovidersyncing-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "secretprovidersyncing-rolebinding" deleted
serviceaccount "csi-secrets-store-provider-aws" deleted
clusterrole.rbac.authorization.k8s.io "csi-secrets-store-provider-aws-cluster-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "csi-secrets-store-provider-aws-cluster-rolebinding" deleted
daemonset.apps "csi-secrets-store-provider-aws" deleted
Secrets Manager Driver successfully deleted
2022-05-08 23:53:37 [ℹ]  eksctl version 0.67.0
2022-05-08 23:53:37 [ℹ]  using region ap-southeast-2
2022-05-08 23:53:37 [ℹ]  1 iamserviceaccount (kubeflow/kubeflow-secrets-manager-sa) was included (based on the include/exclude rules)
2022-05-08 23:53:38 [ℹ]  1 task: { 2 sequential sub-tasks: { delete IAM role for serviceaccount "kubeflow/kubeflow-secrets-manager-sa" [async], delete serviceaccount "kubeflow/kubeflow-secrets-manager-sa" } }
2022-05-08 23:53:39 [ℹ]  will delete stack "eksctl-kf-test-auto-setup-6-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-05-08 23:53:39 [ℹ]  deleted serviceaccount "kubeflow/kubeflow-secrets-manager-sa"
IAM service account kubeflow-secrets-manager-sa successfully deleted
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.