### PR TITLE
Remove unused mysql-pod and pv-claim

### DIFF
--- a/awsconfigs/apps/pipeline/kustomization.yaml
+++ b/awsconfigs/apps/pipeline/kustomization.yaml
@@ -22,6 +22,7 @@ generatorOptions:
   disableNameSuffixHash: true
 patchesStrategicMerge:
 - ./rds/disable-default-secret.yaml
+- ./rds/disable-mysql-pv-claim.yaml
 - ./s3/disable-default-secret.yaml
 - ./s3/aws-configuration-patch.yaml
 # Identifier for application manager to apply ownerReference.

--- a/awsconfigs/apps/pipeline/kustomization.yaml
+++ b/awsconfigs/apps/pipeline/kustomization.yaml
@@ -21,8 +21,8 @@ configMapGenerator:
 generatorOptions:
   disableNameSuffixHash: true
 patchesStrategicMerge:
-- ./rds/disable-default-secret.yaml
 - ./rds/disable-mysql-pv-claim.yaml
+- ./rds/disable-default-secret.yaml
 - ./s3/disable-default-secret.yaml
 - ./s3/aws-configuration-patch.yaml
 # Identifier for application manager to apply ownerReference.

--- a/awsconfigs/apps/pipeline/rds/disable-mysql-pv-claim.yaml
+++ b/awsconfigs/apps/pipeline/rds/disable-mysql-pv-claim.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim
+$patch: delete
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+$patch: delete
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  namespace: kubeflow
+  labels:
+    app: mysql
+$patch: delete
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql
+$patch: delete

--- a/awsconfigs/apps/pipeline/rds/kustomization.yaml
+++ b/awsconfigs/apps/pipeline/rds/kustomization.yaml
@@ -11,6 +11,7 @@ generatorOptions:
   disableNameSuffixHash: true
 patchesStrategicMerge:
 - disable-default-secret.yaml
+- disable-mysql-pv-claim.yaml
 # Identifier for application manager to apply ownerReference.
 # The ownerReference ensures the resources get garbage collected
 # when application is deleted.

--- a/awsconfigs/apps/pipeline/s3/disable-mysql-pv-claim.yaml
+++ b/awsconfigs/apps/pipeline/s3/disable-mysql-pv-claim.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim
+$patch: delete
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+$patch: delete
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  namespace: kubeflow
+  labels:
+    app: mysql
+$patch: delete
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql
+$patch: delete

--- a/awsconfigs/apps/pipeline/s3/kustomization.yaml
+++ b/awsconfigs/apps/pipeline/s3/kustomization.yaml
@@ -19,6 +19,7 @@ generatorOptions:
   disableNameSuffixHash: true
 patchesStrategicMerge:
 - disable-default-secret.yaml
+- disable-mysql-pv-claim.yaml
 - aws-configuration-patch.yaml
 # Identifier for application manager to apply ownerReference.
 # The ownerReference ensures the resources get garbage collected

--- a/tests/e2e/utils/rds-s3/auto-rds-s3-cleanup.py
+++ b/tests/e2e/utils/rds-s3/auto-rds-s3-cleanup.py
@@ -17,7 +17,7 @@ def main():
     region = metadata["CLUSTER"]["region"]
     cluster_name = metadata["CLUSTER"]["name"]
     secrets_manager_client = get_secrets_manager_client(region)
-    delete_s3_bucket(metadata, secrets_manager_client)
+    delete_s3_bucket(metadata, secrets_manager_client, region)
     delete_rds(metadata, secrets_manager_client, region)
     uninstall_secrets_manager(region, cluster_name)
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #87

**Description of your changes:**

- Removes 20gb pv-claim which costs user money
- Removes mysql pod that isn't used as well as service accounts

```
INFO     root:_client.py:203 Failed to automatically set namespace.
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
INFO     root:_client.py:452 Creating experiment experiment-uq89hbg9y4.
PASSED
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline 
-------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------
INFO     root:_client.py:452 Creating experiment experiment-7eymjrcoeu.
Handling connection for 8080
PASSED
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment PASSED

========================================================================================== warnings summary ===========================================================================================
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment
  /home/ubuntu/anaconda3/envs/py38/lib/python3.8/site-packages/mysql/connector/connection_cext.py:516: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
    self._cmysql.query(query,

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================================= 3 passed, 9 warnings in 2655.43s (0:44:15) ==============================================================================

```



**Testing:**
- [x] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.