### PR TITLE
Add PR build stack components

### DIFF
--- a/.github/workflows/issue-comment-pr-build.yml
+++ b/.github/workflows/issue-comment-pr-build.yml
@@ -1,0 +1,17 @@
+name: PR comment
+
+on: issue_comment
+
+jobs:
+  pr_commented:
+    # This job only runs for pull request comments
+    name: PR comment
+    if: github.event.issue.pull_request && github.event.comment.body == '/test'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+        # todo: Change endpoint once test stack is deployed
+          echo Event body $GITHUB_CONTEXT; curl -v -X POST https://zg5ki2u7h8.execute-api.us-west-2.amazonaws.com/prod/ -d '{"pr_id": '"$NUMBER"'}'
+        env:
+          NUMBER: ${{ github.event.issue.number }}
+          GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/tests/pr-build/Dockerfile.pr
+++ b/tests/pr-build/Dockerfile.pr
@@ -1,0 +1,41 @@
+FROM public.ecr.aws/ubuntu/ubuntu:18.04
+
+RUN apt-get update && apt-get install -y curl \
+    wget \
+    git \
+    python3.8 \
+    python3-pip \
+    python3.8-dev \
+    vim \
+    sudo \
+    jq \
+    unzip
+
+# Install awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+ && unzip -qq awscliv2.zip \
+ && ./aws/install
+
+# Install kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.8/bin/linux/amd64/kubectl \
+ && chmod +x ./kubectl \
+ && cp ./kubectl /bin
+
+# Install eksctl
+RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && mv /tmp/eksctl /bin
+
+# Install kustomize 
+RUN wget "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.2.1/kustomize_kustomize.v3.2.1_linux_amd64" \
+ && chmod +x ./kustomize_kustomize.v3.2.1_linux_amd64 \
+ && cp ./kustomize_kustomize.v3.2.1_linux_amd64 /bin/kustomize
+
+ENV REPO_PATH=/kubeflow-manifests
+COPY ./tests/e2e/requirements.txt requirements.txt
+
+RUN ln -s /usr/bin/python3.8 /usr/bin/python \
+ && python -m pip install --upgrade pip
+
+RUN python -m pip install -r requirements.txt
+
+WORKDIR /$REPO_PATH
+CMD ["./tests/pr-build/scripts/run_test.sh"]

--- a/tests/pr-build/pr.buildspec.yaml
+++ b/tests/pr-build/pr.buildspec.yaml
@@ -1,0 +1,20 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      # Get cached test image
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_CACHE_URI || true
+      - docker pull ${ECR_CACHE_URI}:latest --quiet || true
+
+      # Build test image
+      - >
+        docker build -f ./tests/pr-build/Dockerfile.pr . -t ${ECR_CACHE_URI}:latest --quiet
+        || echo "Docker Build Failed" || true
+  build:
+    commands:
+      # Run tests
+      - docker run --name kf-distro-pr-build $(env | cut -f1 -d= | sed 's/^/-e /') --mount type=bind,source="$(pwd)/",target="/kubeflow-manifests/" ${ECR_CACHE_URI}:latest
+
+      # Push test image to cache ECR repo
+      - docker push ${ECR_CACHE_URI}:latest || true

--- a/tests/pr-build/scripts/run_test.sh
+++ b/tests/pr-build/scripts/run_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# All the inputs to this script as environment variables 
+# REPO_PATH : Local root path of the kubeflow-manifest github repo 
+
+# Script configuration
+set -euo pipefail
+
+function onError {
+  echo "Run test FAILED. Exiting."
+}
+trap onError ERR
+
+export E2E_TEST_DIR=${REPO_PATH}/tests/e2e
+
+cd $E2E_TEST_DIR
+pytest tests/test_sanity_portforward.py -s -q  --region $AWS_DEFAULT_REGION
+
+


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
This PR addresses 2 issues:
- Enforces PR testing before merging
- Allows both PR submitters and approvers to view the status of PR testing

**Description of your changes:**

The PR build process will work as follows:

1. A user comments /test
2. A Github action is triggered and formats the PR details into a request payload
3. The request is made to an API Gateway https endpoint
4. The API Gateway forwards the event payload a Lambda
5. Lambda makes a request to Codebuild to start a build for the PR
6. Codebuild will pull any hardcoded variables (such as access keys) from AWS secrets manager and pass to the test as environment variables 
7. Codebuild will run the test according to the arguments in the buildspec configuration
8. Upon completion, the [github-codebuild-logs](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:277187709615:applications~github-codebuild-logs) (https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:277187709615:applications~github-codebuild-logs) serverless program will use a Github Access Token to comment the build logs and result on the PR.

Diagram:
![codebuild-gh-action](https://user-images.githubusercontent.com/91350438/167781158-4474c45c-d7dd-48d8-b4a3-016385dfd312.png)


This PR adds the Github action that will send the PR details payload to the API gateway endpoint.
The stack containing the endpoint is deployed internally. 

**Testing:**
This process can be tested in action on the following PR https://github.com/rrrkharse/kubeflow-manifests/pull/5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.