### PR TITLE
Update manifests for 1.5.0 upstream

### DIFF
--- a/docs/deployment/cognito-rds-s3/kustomization.yaml
+++ b/docs/deployment/cognito-rds-s3/kustomization.yaml
@@ -2,61 +2,63 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-# Kubeflow namespace
-- ../../../upstream/common/kubeflow-namespace/base
-# Kubeflow Roles
-- ../../../upstream/common/kubeflow-roles/base
-# Cert-Manager
-- ../../../upstream/common/cert-manager/cert-manager/base
-- ../../../upstream/common/cert-manager/kubeflow-issuer/base
-# Istio
-- ../../../upstream/common/istio-1-9/istio-crds/base
-- ../../../upstream/common/istio-1-9/istio-namespace/base
-- ../../../upstream/common/istio-1-9/istio-install/base
-# KNative
-- ../../../upstream/common/knative/knative-serving/overlays/gateways
-- ../../../upstream/common/knative/knative-eventing/base
-- ../../../upstream/common/istio-1-9/cluster-local-gateway/base
-# Kubeflow Istio Resources
-- ../../../upstream/common/istio-1-9/kubeflow-istio-resources/base
+  # Kubeflow namespace
+  - ../../../upstream/common/kubeflow-namespace/base
+  # Kubeflow Roles
+  - ../../../upstream/common/kubeflow-roles/base
+  # Cert-Manager
+  - ../../../upstream/common/cert-manager/cert-manager/base
+  - ../../../upstream/common/cert-manager/kubeflow-issuer/base
+  # Istio
+  - ../../../upstream/common/istio-1-11/istio-crds/base
+  - ../../../upstream/common/istio-1-11/istio-namespace/base
+  - ../../../upstream/common/istio-1-11/istio-install/base
+  # KNative
+  - ../../../upstream/common/knative/knative-serving/overlays/gateways
+  - ../../../upstream/common/knative/knative-eventing/base
+  - ../../../upstream/common/istio-1-11/cluster-local-gateway/base
+  # Kubeflow Istio Resources
+  - ../../../upstream/common/istio-1-11/kubeflow-istio-resources/base
 
-# KFServing
-- ../../../upstream/apps/kfserving/upstream/overlays/kubeflow
-# Central Dashboard
-- ../../../upstream/apps/centraldashboard/upstream/overlays/istio
-# Notebooks
-- ../../../awsconfigs/apps/jupyter-web-app
-- ../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
-# Admission Webhook
-- ../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
-# Profiles + KFAM
-- ../../../upstream/apps/profiles/upstream/overlays/kubeflow
-# Volumes Web App
-- ../../../upstream/apps/volumes-web-app/upstream/overlays/istio
-# Tensorboard
-- ../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
-- ../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
-# Training Operator
-- ../../../upstream/apps/training-operator/upstream/overlays/kubeflow
-# MPI Operator
-- ../../../upstream/apps/mpi-job/upstream/overlays/kubeflow
-# AWS Telemetry - This is an optional component. See usage tracking documentation for more information
-- ../../../awsconfigs/common/aws-telemetry
+  # KFServing
+  - ../../../upstream/apps/kfserving/upstream/overlays/kubeflow
+  # Central Dashboard
+  - ../../../upstream/apps/centraldashboard/upstream/overlays/kserve
+  # Notebooks
+  - ../../../awsconfigs/apps/jupyter-web-app
+  - ../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+  # Admission Webhook
+  - ../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
+  # Profiles + KFAM
+  - ../../../upstream/apps/profiles/upstream/overlays/kubeflow
+  # Volumes Web App
+  - ../../../upstream/apps/volumes-web-app/upstream/overlays/istio
+  # Tensorboard
+  - ../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+  - ../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+  # Training Operator
+  - ../../../upstream/apps/training-operator/upstream/overlays/kubeflow
+  # AWS Telemetry - This is an optional component. See usage tracking documentation for more information
+  - ../../../awsconfigs/common/aws-telemetry
 
-# Configured for AWS Cognito
+  # KServe
+  - ../../../upstream/contrib/kserve/kserve
+  - ../../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
 
-# Ingress
-- ../../../awsconfigs/common/istio-ingress/overlays/cognito
-# ALB controller
-- ../../../awsconfigs/common/aws-alb-ingress-controller/base
-# Authservice
-- ../../../awsconfigs/common/aws-authservice/base
+  # Configured for AWS Cognito
 
-# Configured for AWS RDS and AWS S3
+  # Ingress
+  - ../../../awsconfigs/common/istio-ingress/overlays/cognito
+  # ALB controller
+  - ../../../awsconfigs/common/aws-alb-ingress-controller/base
+  # Authservice
+  - ../../../awsconfigs/common/aws-authservice/base
 
-# AWS Secret Manager
-- ../../../awsconfigs/common/aws-secrets-manager
-# Kubeflow Pipelines
-- ../../../awsconfigs/apps/pipeline
-# Katib
-- ../../../awsconfigs/apps/katib-external-db-with-kubeflow
+  # Configured for AWS RDS and AWS S3
+
+  # AWS Secret Manager
+  - ../../../awsconfigs/common/aws-secrets-manager
+  # Kubeflow Pipelines
+  - ../../../awsconfigs/apps/pipeline
+  # Katib
+  - ../../../awsconfigs/apps/katib-external-db-with-kubeflow

--- a/docs/deployment/cognito/kustomization.yaml
+++ b/docs/deployment/cognito/kustomization.yaml
@@ -2,56 +2,58 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-# Kubeflow namespace
-- ../../../upstream/common/kubeflow-namespace/base
-# Kubeflow Roles
-- ../../../upstream/common/kubeflow-roles/base
-# Cert-Manager
-- ../../../upstream/common/cert-manager/cert-manager/base
-- ../../../upstream/common/cert-manager/kubeflow-issuer/base
-# Istio
-- ../../../upstream/common/istio-1-9/istio-crds/base
-- ../../../upstream/common/istio-1-9/istio-namespace/base
-- ../../../upstream/common/istio-1-9/istio-install/base
-# KNative
-- ../../../upstream/common/knative/knative-serving/overlays/gateways
-- ../../../upstream/common/knative/knative-eventing/base
-- ../../../upstream/common/istio-1-9/cluster-local-gateway/base
-# Kubeflow Istio Resources
-- ../../../upstream/common/istio-1-9/kubeflow-istio-resources/base
+  # Kubeflow namespace
+  - ../../../upstream/common/kubeflow-namespace/base
+  # Kubeflow Roles
+  - ../../../upstream/common/kubeflow-roles/base
+  # Cert-Manager
+  - ../../../upstream/common/cert-manager/cert-manager/base
+  - ../../../upstream/common/cert-manager/kubeflow-issuer/base
+  # Istio
+  - ../../../upstream/common/istio-1-11/istio-crds/base
+  - ../../../upstream/common/istio-1-11/istio-namespace/base
+  - ../../../upstream/common/istio-1-11/istio-install/base
+  # KNative
+  - ../../../upstream/common/knative/knative-serving/overlays/gateways
+  - ../../../upstream/common/knative/knative-eventing/base
+  - ../../../upstream/common/istio-1-11/cluster-local-gateway/base
+  # Kubeflow Istio Resources
+  - ../../../upstream/common/istio-1-11/kubeflow-istio-resources/base
 
-# Kubeflow Pipelines
-- ../../../upstream/apps/pipeline/upstream/env/platform-agnostic-multi-user
-# KFServing
-- ../../../upstream/apps/kfserving/upstream/overlays/kubeflow
-# Katib
-- ../../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
-# Central Dashboard
-- ../../../upstream/apps/centraldashboard/upstream/overlays/istio
-# Notebooks
-- ../../../awsconfigs/apps/jupyter-web-app
-- ../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
-# Admission Webhook
-- ../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
-# Profiles + KFAM
-- ../../../upstream/apps/profiles/upstream/overlays/kubeflow
-# Volumes Web App
-- ../../../upstream/apps/volumes-web-app/upstream/overlays/istio
-# Tensorboard
-- ../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
-- ../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
-# Training Operator
-- ../../../upstream/apps/training-operator/upstream/overlays/kubeflow
-# MPI Operator
-- ../../../upstream/apps/mpi-job/upstream/overlays/kubeflow
-# AWS Telemetry - This is an optional component. See usage tracking documentation for more information
-- ../../../awsconfigs/common/aws-telemetry
+  # Kubeflow Pipelines
+  - ../../../upstream/apps/pipeline/upstream/env/platform-agnostic-multi-user
+  # KFServing
+  - ../../../upstream/apps/kfserving/upstream/overlays/kubeflow
+  # Katib
+  - ../../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
+  # Central Dashboard
+  - ../../../upstream/apps/centraldashboard/upstream/overlays/kserve
+  # Notebooks
+  - ../../../awsconfigs/apps/jupyter-web-app
+  - ../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+  # Admission Webhook
+  - ../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
+  # Profiles + KFAM
+  - ../../../upstream/apps/profiles/upstream/overlays/kubeflow
+  # Volumes Web App
+  - ../../../upstream/apps/volumes-web-app/upstream/overlays/istio
+  # Tensorboard
+  - ../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+  - ../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+  # Training Operator
+  - ../../../upstream/apps/training-operator/upstream/overlays/kubeflow
+  # AWS Telemetry - This is an optional component. See usage tracking documentation for more information
+  - ../../../awsconfigs/common/aws-telemetry
 
-# Configured for AWS Cognito
+  # KServe
+  - ../../../upstream/contrib/kserve/kserve
+  - ../../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
 
-# Ingress
-- ../../../awsconfigs/common/istio-ingress/overlays/cognito
-# ALB controller
-- ../../../awsconfigs/common/aws-alb-ingress-controller/base
-# Authservice
-- ../../../awsconfigs/common/aws-authservice/base
+  # Configured for AWS Cognito
+
+  # Ingress
+  - ../../../awsconfigs/common/istio-ingress/overlays/cognito
+  # ALB controller
+  - ../../../awsconfigs/common/aws-alb-ingress-controller/base
+  # Authservice
+  - ../../../awsconfigs/common/aws-authservice/base

--- a/docs/deployment/rds-s3/base/kustomization.yaml
+++ b/docs/deployment/rds-s3/base/kustomization.yaml
@@ -2,53 +2,54 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-# Cert-Manager
-- ../../../../upstream/common/cert-manager/cert-manager/base
-- ../../../../upstream/common/cert-manager/kubeflow-issuer/base
-# Istio
-- ../../../../upstream/common/istio-1-9/istio-crds/base
-- ../../../../upstream/common/istio-1-9/istio-namespace/base
-- ../../../../upstream/common/istio-1-9/istio-install/base
-# OIDC Authservice
-- ../../../../upstream/common/oidc-authservice/base
-# Dex
-- ../../../../upstream/common/dex/overlays/istio
-# KNative
-- ../../../../upstream/common/knative/knative-serving/overlays/gateways
-- ../../../../upstream/common/knative/knative-eventing/base
-- ../../../../upstream/common/istio-1-9/cluster-local-gateway/base
-# Kubeflow namespace
-- ../../../../upstream/common/kubeflow-namespace/base
-# Kubeflow Roles
-- ../../../../upstream/common/kubeflow-roles/base
-# Kubeflow Istio Resources
-- ../../../../upstream/common/istio-1-9/kubeflow-istio-resources/base
+  # Cert-Manager
+  - ../../../../upstream/common/cert-manager/cert-manager/base
+  - ../../../../upstream/common/cert-manager/kubeflow-issuer/base
+  # Istio
+  - ../../../../upstream/common/istio-1-11/istio-crds/base
+  - ../../../../upstream/common/istio-1-11/istio-namespace/base
+  - ../../../../upstream/common/istio-1-11/istio-install/base
+  # OIDC Authservice
+  - ../../../../upstream/common/oidc-authservice/base
+  # Dex
+  - ../../../../upstream/common/dex/overlays/istio
+  # KNative
+  - ../../../../upstream/common/knative/knative-serving/overlays/gateways
+  - ../../../../upstream/common/knative/knative-eventing/base
+  - ../../../../upstream/common/istio-1-11/cluster-local-gateway/base
+  # Kubeflow namespace
+  - ../../../../upstream/common/kubeflow-namespace/base
+  # Kubeflow Roles
+  - ../../../../upstream/common/kubeflow-roles/base
+  # Kubeflow Istio Resources
+  - ../../../../upstream/common/istio-1-11/kubeflow-istio-resources/base
 
+  # KFServing
+  - ../../../../upstream/apps/kfserving/upstream/overlays/kubeflow
+  # Central Dashboard
+  - ../../../../upstream/apps/centraldashboard/upstream/overlays/kserve
+  # Admission Webhook
+  - ../../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
+  # Jupyter Web App
+  - ../../../../awsconfigs/apps/jupyter-web-app
+  # Notebook Controller
+  - ../../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+  # Profiles + KFAM
+  - ../../../../upstream/apps/profiles/upstream/overlays/kubeflow
+  # Volumes Web App
+  - ../../../../upstream/apps/volumes-web-app/upstream/overlays/istio
+  # Tensorboard Controller
+  - ../../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+  # Tensorboards Web App
+  - ../../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+  # Training Operator
+  - ../../../../upstream/apps/training-operator/upstream/overlays/kubeflow
+  # User namespace
+  - ../../../../upstream/common/user-namespace/base
 
-# KFServing
-- ../../../../upstream/apps/kfserving/upstream/overlays/kubeflow
-# Central Dashboard
-- ../../../../upstream/apps/centraldashboard/upstream/overlays/istio
-# Admission Webhook
-- ../../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
-# Notebook Controller
-- ../../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
-# Jupyter Web App
-- ../../../../awsconfigs/apps/jupyter-web-app
-# Profiles + KFAM
-- ../../../../upstream/apps/profiles/upstream/overlays/kubeflow
-# Volumes Web App
-- ../../../../upstream/apps/volumes-web-app/upstream/overlays/istio
-# Tensorboards Web App
-- ../../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
-# Tensorboard Controller
-- ../../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
-# Training Operator
-- ../../../../upstream/apps/training-operator/upstream/overlays/kubeflow
-# MPI Operator
-- ../../../../upstream/apps/mpi-job/upstream/overlays/kubeflow
-# AWS Telemetry - This is an optional component. See usage tracking documentation for more information
-- ../../../../awsconfigs/common/aws-telemetry
+  # KServe
+  - ../../../../upstream/contrib/kserve/kserve
+  - ../../../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
 
-# User namespace
-- ../../../../upstream/common/user-namespace/base
+  # AWS Telemetry - This is an optional component. See usage tracking documentation for more information
+  - ../../../../awsconfigs/common/aws-telemetry

--- a/docs/deployment/rds-s3/kustomization.yaml
+++ b/docs/deployment/rds-s3/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-- ./base
+  - ./base
 resources:
-# Configured for AWS RDS and AWS S3
+  # Configured for AWS RDS and AWS S3
 
-# AWS Secret Manager
-- ../../../awsconfigs/common/aws-secrets-manager
-# Kubeflow Pipelines
-- ../../../awsconfigs/apps/pipeline
-# Katib
-- ../../../awsconfigs/apps/katib-external-db-with-kubeflow
+  # AWS Secret Manager
+  - ../../../awsconfigs/common/aws-secrets-manager
+  # Kubeflow Pipelines
+  - ../../../awsconfigs/apps/pipeline
+  # Katib
+  - ../../../awsconfigs/apps/katib-external-db-with-kubeflow

--- a/docs/deployment/rds-s3/rds-only/kustomization.yaml
+++ b/docs/deployment/rds-s3/rds-only/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-- ../../rds-s3/base
+  - ../../rds-s3/base
 resources:
-# Configured for AWS RDS 
+  # Configured for AWS RDS
 
-# AWS Secret Manager
-- ../../../../awsconfigs/common/aws-secrets-manager/rds
-# Kubeflow Pipelines
-- ../../../../awsconfigs/apps/pipeline/rds
-# Katib
-- ../../../../awsconfigs/apps/katib-external-db-with-kubeflow
+  # AWS Secret Manager
+  - ../../../../awsconfigs/common/aws-secrets-manager/rds
+  # Kubeflow Pipelines
+  - ../../../../awsconfigs/apps/pipeline/rds
+  # Katib
+  - ../../../../awsconfigs/apps/katib-external-db-with-kubeflow

--- a/docs/deployment/rds-s3/s3-only/kustomization.yaml
+++ b/docs/deployment/rds-s3/s3-only/kustomization.yaml
@@ -2,14 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-- ../../rds-s3/base
+  - ../../rds-s3/base
 resources:
-# Configured for AWS S3
+  # Configured for AWS S3
 
-# AWS Secret Manager
-- ../../../../awsconfigs/common/aws-secrets-manager/s3
-# Kubeflow Pipelines
-- ../../../../awsconfigs/apps/pipeline/s3
+  # AWS Secret Manager
+  - ../../../../awsconfigs/common/aws-secrets-manager/s3
+  # Kubeflow Pipelines
+  - ../../../../awsconfigs/apps/pipeline/s3
 
-# Katib
-- ../../../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
+  # Katib
+  - ../../../../upstream/apps/katib/upstream/installs/katib-with-kubeflow

--- a/docs/deployment/vanilla/kustomization.yaml
+++ b/docs/deployment/vanilla/kustomization.yaml
@@ -2,56 +2,58 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-# Cert-Manager
-- ../../../upstream/common/cert-manager/cert-manager/base
-- ../../../upstream/common/cert-manager/kubeflow-issuer/base
-# Istio
-- ../../../upstream/common/istio-1-9/istio-crds/base
-- ../../../upstream/common/istio-1-9/istio-namespace/base
-- ../../../upstream/common/istio-1-9/istio-install/base
-# OIDC Authservice
-- ../../../upstream/common/oidc-authservice/base
-# Dex
-- ../../../upstream/common/dex/overlays/istio
-# KNative
-- ../../../upstream/common/knative/knative-serving/overlays/gateways
-- ../../../upstream/common/knative/knative-eventing/base
-- ../../../upstream/common/istio-1-9/cluster-local-gateway/base
-# Kubeflow namespace
-- ../../../upstream/common/kubeflow-namespace/base
-# Kubeflow Roles
-- ../../../upstream/common/kubeflow-roles/base
-# Kubeflow Istio Resources
-- ../../../upstream/common/istio-1-9/kubeflow-istio-resources/base
+  # Cert-Manager
+  - ../../../upstream/common/cert-manager/cert-manager/base
+  - ../../../upstream/common/cert-manager/kubeflow-issuer/base
+  # Istio
+  - ../../../upstream/common/istio-1-11/istio-crds/base
+  - ../../../upstream/common/istio-1-11/istio-namespace/base
+  - ../../../upstream/common/istio-1-11/istio-install/base
+  # OIDC Authservice
+  - ../../../upstream/common/oidc-authservice/base
+  # Dex
+  - ../../../upstream/common/dex/overlays/istio
+  # KNative
+  - ../../../upstream/common/knative/knative-serving/overlays/gateways
+  - ../../../upstream/common/knative/knative-eventing/base
+  - ../../../upstream/common/istio-1-11/cluster-local-gateway/base
+  # Kubeflow namespace
+  - ../../../upstream/common/kubeflow-namespace/base
+  # Kubeflow Roles
+  - ../../../upstream/common/kubeflow-roles/base
+  # Kubeflow Istio Resources
+  - ../../../upstream/common/istio-1-11/kubeflow-istio-resources/base
 
+  # Kubeflow Pipelines
+  - ../../../upstream/apps/pipeline/upstream/env/platform-agnostic-multi-user
+  # KFServing
+  - ../../../upstream/apps/kfserving/upstream/overlays/kubeflow
+  # Katib
+  - ../../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
+  # Central Dashboard
+  - ../../../upstream/apps/centraldashboard/upstream/overlays/kserve
+  # Admission Webhook
+  - ../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
+  # Jupyter Web App
+  - ../../../awsconfigs/apps/jupyter-web-app
+  # Notebook Controller
+  - ../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+  # Profiles + KFAM
+  - ../../../upstream/apps/profiles/upstream/overlays/kubeflow
+  # Volumes Web App
+  - ../../../upstream/apps/volumes-web-app/upstream/overlays/istio
+  # Tensorboard Controller
+  - ../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+  # Tensorboards Web App
+  - ../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+  # Training Operator
+  - ../../../upstream/apps/training-operator/upstream/overlays/kubeflow
+  # User namespace
+  - ../../../upstream/common/user-namespace/base
 
-# Kubeflow Pipelines
-- ../../../upstream/apps/pipeline/upstream/env/platform-agnostic-multi-user
-# KFServing
-- ../../../upstream/apps/kfserving/upstream/overlays/kubeflow
-# Katib
-- ../../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
-# Central Dashboard
-- ../../../upstream/apps/centraldashboard/upstream/overlays/istio
-# Admission Webhook
-- ../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
-# Jupyter Web App
-- ../../../awsconfigs/apps/jupyter-web-app
-# Notebook Controller
-- ../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
-# Profiles + KFAM
-- ../../../upstream/apps/profiles/upstream/overlays/kubeflow
-# Volumes Web App
-- ../../../upstream/apps/volumes-web-app/upstream/overlays/istio
-# Tensorboards Web App
--  ../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
-# Tensorboard Controller
--  ../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
-# Training Operator
-- ../../../upstream/apps/training-operator/upstream/overlays/kubeflow
-# MPI Operator
-- ../../../upstream/apps/mpi-job/upstream/overlays/kubeflow
-# User namespace
-- ../../../upstream/common/user-namespace/base
-# AWS Telemetry - This is an optional component. See usage tracking documentation for more information
-- ../../../awsconfigs/common/aws-telemetry
+  # KServe
+  - ../../../upstream/contrib/kserve/kserve
+  - ../../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
+
+  # AWS Telemetry - This is an optional component. See usage tracking documentation for more information
+  - ../../../awsconfigs/common/aws-telemetry


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Update manifests for 1.5.0 [upstream](https://github.com/kubeflow/manifests/blob/v1.5-branch/example/kustomization.yaml) 



**Testing:**
```
~/kf/update-manifests/tests/e2e v1.5-manifests 31s
kf-e2e-test-env ❯ pytest tests/test_manifest_builds.py
...
============================================================================== 6 passed in 30.74s ==============================================================================
```

[Uploading output.txt.zip…]()


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.