### PR TITLE
Fix broken manifest paths

### DIFF
--- a/deployment/cognito-rds-s3/kustomization.yaml
+++ b/deployment/cognito-rds-s3/kustomization.yaml
@@ -3,62 +3,62 @@ kind: Kustomization
 
 resources:
   # Kubeflow namespace
-  - ../../../upstream/common/kubeflow-namespace/base
+  - ../../upstream/common/kubeflow-namespace/base
   # Kubeflow Roles
-  - ../../../upstream/common/kubeflow-roles/base
+  - ../../upstream/common/kubeflow-roles/base
   # Cert-Manager
-  - ../../../upstream/common/cert-manager/cert-manager/base
-  - ../../../upstream/common/cert-manager/kubeflow-issuer/base
+  - ../../upstream/common/cert-manager/cert-manager/base
+  - ../../upstream/common/cert-manager/kubeflow-issuer/base
   # Istio
-  - ../../../upstream/common/istio-1-11/istio-crds/base
-  - ../../../upstream/common/istio-1-11/istio-namespace/base
-  - ../../../upstream/common/istio-1-11/istio-install/base
+  - ../../upstream/common/istio-1-11/istio-crds/base
+  - ../../upstream/common/istio-1-11/istio-namespace/base
+  - ../../upstream/common/istio-1-11/istio-install/base
   # KNative
-  - ../../../upstream/common/knative/knative-serving/overlays/gateways
-  - ../../../upstream/common/knative/knative-eventing/base
-  - ../../../upstream/common/istio-1-11/cluster-local-gateway/base
+  - ../../upstream/common/knative/knative-serving/overlays/gateways
+  - ../../upstream/common/knative/knative-eventing/base
+  - ../../upstream/common/istio-1-11/cluster-local-gateway/base
   # Kubeflow Istio Resources
-  - ../../../upstream/common/istio-1-11/kubeflow-istio-resources/base
+  - ../../upstream/common/istio-1-11/kubeflow-istio-resources/base
 
   # KFServing
-  - ../../../upstream/apps/kfserving/upstream/overlays/kubeflow
+  - ../../upstream/apps/kfserving/upstream/overlays/kubeflow
   # Central Dashboard
-  - ../../../upstream/apps/centraldashboard/upstream/overlays/kserve
+  - ../../upstream/apps/centraldashboard/upstream/overlays/kserve
   # Notebooks
-  - ../../../awsconfigs/apps/jupyter-web-app
-  - ../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+  - ../../awsconfigs/apps/jupyter-web-app
+  - ../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
   # Admission Webhook
-  - ../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
+  - ../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
   # Profiles + KFAM
-  - ../../../upstream/apps/profiles/upstream/overlays/kubeflow
+  - ../../upstream/apps/profiles/upstream/overlays/kubeflow
   # Volumes Web App
-  - ../../../upstream/apps/volumes-web-app/upstream/overlays/istio
+  - ../../upstream/apps/volumes-web-app/upstream/overlays/istio
   # Tensorboard
-  - ../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
-  - ../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+  - ../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+  - ../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
   # Training Operator
-  - ../../../upstream/apps/training-operator/upstream/overlays/kubeflow
+  - ../../upstream/apps/training-operator/upstream/overlays/kubeflow
   # AWS Telemetry - This is an optional component. See usage tracking documentation for more information
-  - ../../../awsconfigs/common/aws-telemetry
+  - ../../awsconfigs/common/aws-telemetry
 
   # KServe
-  - ../../../upstream/contrib/kserve/kserve
-  - ../../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
+  - ../../upstream/contrib/kserve/kserve
+  - ../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
 
   # Configured for AWS Cognito
 
   # Ingress
-  - ../../../awsconfigs/common/istio-ingress/overlays/cognito
+  - ../../awsconfigs/common/istio-ingress/overlays/cognito
   # ALB controller
-  - ../../../awsconfigs/common/aws-alb-ingress-controller/base
+  - ../../awsconfigs/common/aws-alb-ingress-controller/base
   # Authservice
-  - ../../../awsconfigs/common/aws-authservice/base
+  - ../../awsconfigs/common/aws-authservice/base
 
   # Configured for AWS RDS and AWS S3
 
   # AWS Secret Manager
-  - ../../../awsconfigs/common/aws-secrets-manager
+  - ../../awsconfigs/common/aws-secrets-manager
   # Kubeflow Pipelines
-  - ../../../awsconfigs/apps/pipeline
+  - ../../awsconfigs/apps/pipeline
   # Katib
-  - ../../../awsconfigs/apps/katib-external-db-with-kubeflow
+  - ../../awsconfigs/apps/katib-external-db-with-kubeflow

--- a/deployment/cognito/kustomization.yaml
+++ b/deployment/cognito/kustomization.yaml
@@ -3,57 +3,57 @@ kind: Kustomization
 
 resources:
   # Kubeflow namespace
-  - ../../../upstream/common/kubeflow-namespace/base
+  - ../../upstream/common/kubeflow-namespace/base
   # Kubeflow Roles
-  - ../../../upstream/common/kubeflow-roles/base
+  - ../../upstream/common/kubeflow-roles/base
   # Cert-Manager
-  - ../../../upstream/common/cert-manager/cert-manager/base
-  - ../../../upstream/common/cert-manager/kubeflow-issuer/base
+  - ../../upstream/common/cert-manager/cert-manager/base
+  - ../../upstream/common/cert-manager/kubeflow-issuer/base
   # Istio
-  - ../../../upstream/common/istio-1-11/istio-crds/base
-  - ../../../upstream/common/istio-1-11/istio-namespace/base
-  - ../../../upstream/common/istio-1-11/istio-install/base
+  - ../../upstream/common/istio-1-11/istio-crds/base
+  - ../../upstream/common/istio-1-11/istio-namespace/base
+  - ../../upstream/common/istio-1-11/istio-install/base
   # KNative
-  - ../../../upstream/common/knative/knative-serving/overlays/gateways
-  - ../../../upstream/common/knative/knative-eventing/base
-  - ../../../upstream/common/istio-1-11/cluster-local-gateway/base
+  - ../../upstream/common/knative/knative-serving/overlays/gateways
+  - ../../upstream/common/knative/knative-eventing/base
+  - ../../upstream/common/istio-1-11/cluster-local-gateway/base
   # Kubeflow Istio Resources
-  - ../../../upstream/common/istio-1-11/kubeflow-istio-resources/base
+  - ../../upstream/common/istio-1-11/kubeflow-istio-resources/base
 
   # Kubeflow Pipelines
-  - ../../../upstream/apps/pipeline/upstream/env/platform-agnostic-multi-user
+  - ../../upstream/apps/pipeline/upstream/env/platform-agnostic-multi-user
   # KFServing
-  - ../../../upstream/apps/kfserving/upstream/overlays/kubeflow
+  - ../../upstream/apps/kfserving/upstream/overlays/kubeflow
   # Katib
-  - ../../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
+  - ../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
   # Central Dashboard
-  - ../../../upstream/apps/centraldashboard/upstream/overlays/kserve
+  - ../../upstream/apps/centraldashboard/upstream/overlays/kserve
   # Notebooks
-  - ../../../awsconfigs/apps/jupyter-web-app
-  - ../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+  - ../../awsconfigs/apps/jupyter-web-app
+  - ../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
   # Admission Webhook
-  - ../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
+  - ../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
   # Profiles + KFAM
-  - ../../../upstream/apps/profiles/upstream/overlays/kubeflow
+  - ../../upstream/apps/profiles/upstream/overlays/kubeflow
   # Volumes Web App
-  - ../../../upstream/apps/volumes-web-app/upstream/overlays/istio
+  - ../../upstream/apps/volumes-web-app/upstream/overlays/istio
   # Tensorboard
-  - ../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
-  - ../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+  - ../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+  - ../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
   # Training Operator
-  - ../../../upstream/apps/training-operator/upstream/overlays/kubeflow
+  - ../../upstream/apps/training-operator/upstream/overlays/kubeflow
   # AWS Telemetry - This is an optional component. See usage tracking documentation for more information
-  - ../../../awsconfigs/common/aws-telemetry
+  - ../../awsconfigs/common/aws-telemetry
 
   # KServe
-  - ../../../upstream/contrib/kserve/kserve
-  - ../../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
+  - ../../upstream/contrib/kserve/kserve
+  - ../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
 
   # Configured for AWS Cognito
 
   # Ingress
-  - ../../../awsconfigs/common/istio-ingress/overlays/cognito
+  - ../../awsconfigs/common/istio-ingress/overlays/cognito
   # ALB controller
-  - ../../../awsconfigs/common/aws-alb-ingress-controller/base
+  - ../../awsconfigs/common/aws-alb-ingress-controller/base
   # Authservice
-  - ../../../awsconfigs/common/aws-authservice/base
+  - ../../awsconfigs/common/aws-authservice/base

--- a/deployment/rds-s3/base/kustomization.yaml
+++ b/deployment/rds-s3/base/kustomization.yaml
@@ -3,53 +3,53 @@ kind: Kustomization
 
 resources:
   # Cert-Manager
-  - ../../../../upstream/common/cert-manager/cert-manager/base
-  - ../../../../upstream/common/cert-manager/kubeflow-issuer/base
+  - ../../../upstream/common/cert-manager/cert-manager/base
+  - ../../../upstream/common/cert-manager/kubeflow-issuer/base
   # Istio
-  - ../../../../upstream/common/istio-1-11/istio-crds/base
-  - ../../../../upstream/common/istio-1-11/istio-namespace/base
-  - ../../../../upstream/common/istio-1-11/istio-install/base
+  - ../../../upstream/common/istio-1-11/istio-crds/base
+  - ../../../upstream/common/istio-1-11/istio-namespace/base
+  - ../../../upstream/common/istio-1-11/istio-install/base
   # OIDC Authservice
-  - ../../../../upstream/common/oidc-authservice/base
+  - ../../../upstream/common/oidc-authservice/base
   # Dex
-  - ../../../../upstream/common/dex/overlays/istio
+  - ../../../upstream/common/dex/overlays/istio
   # KNative
-  - ../../../../upstream/common/knative/knative-serving/overlays/gateways
-  - ../../../../upstream/common/knative/knative-eventing/base
-  - ../../../../upstream/common/istio-1-11/cluster-local-gateway/base
+  - ../../../upstream/common/knative/knative-serving/overlays/gateways
+  - ../../../upstream/common/knative/knative-eventing/base
+  - ../../../upstream/common/istio-1-11/cluster-local-gateway/base
   # Kubeflow namespace
-  - ../../../../upstream/common/kubeflow-namespace/base
+  - ../../../upstream/common/kubeflow-namespace/base
   # Kubeflow Roles
-  - ../../../../upstream/common/kubeflow-roles/base
+  - ../../../upstream/common/kubeflow-roles/base
   # Kubeflow Istio Resources
-  - ../../../../upstream/common/istio-1-11/kubeflow-istio-resources/base
+  - ../../../upstream/common/istio-1-11/kubeflow-istio-resources/base
 
   # KFServing
-  - ../../../../upstream/apps/kfserving/upstream/overlays/kubeflow
+  - ../../../upstream/apps/kfserving/upstream/overlays/kubeflow
   # Central Dashboard
-  - ../../../../upstream/apps/centraldashboard/upstream/overlays/kserve
+  - ../../../upstream/apps/centraldashboard/upstream/overlays/kserve
   # Admission Webhook
-  - ../../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
+  - ../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
   # Jupyter Web App
-  - ../../../../awsconfigs/apps/jupyter-web-app
+  - ../../../awsconfigs/apps/jupyter-web-app
   # Notebook Controller
-  - ../../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+  - ../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
   # Profiles + KFAM
-  - ../../../../upstream/apps/profiles/upstream/overlays/kubeflow
+  - ../../../upstream/apps/profiles/upstream/overlays/kubeflow
   # Volumes Web App
-  - ../../../../upstream/apps/volumes-web-app/upstream/overlays/istio
+  - ../../../upstream/apps/volumes-web-app/upstream/overlays/istio
   # Tensorboard Controller
-  - ../../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+  - ../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
   # Tensorboards Web App
-  - ../../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+  - ../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
   # Training Operator
-  - ../../../../upstream/apps/training-operator/upstream/overlays/kubeflow
+  - ../../../upstream/apps/training-operator/upstream/overlays/kubeflow
   # User namespace
-  - ../../../../upstream/common/user-namespace/base
+  - ../../../upstream/common/user-namespace/base
 
   # KServe
-  - ../../../../upstream/contrib/kserve/kserve
-  - ../../../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
+  - ../../../upstream/contrib/kserve/kserve
+  - ../../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
 
   # AWS Telemetry - This is an optional component. See usage tracking documentation for more information
-  - ../../../../awsconfigs/common/aws-telemetry
+  - ../../../awsconfigs/common/aws-telemetry

--- a/deployment/rds-s3/kustomization.yaml
+++ b/deployment/rds-s3/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
   # Configured for AWS RDS and AWS S3
 
   # AWS Secret Manager
-  - ../../../awsconfigs/common/aws-secrets-manager
+  - ../../awsconfigs/common/aws-secrets-manager
   # Kubeflow Pipelines
-  - ../../../awsconfigs/apps/pipeline
+  - ../../awsconfigs/apps/pipeline
   # Katib
-  - ../../../awsconfigs/apps/katib-external-db-with-kubeflow
+  - ../../awsconfigs/apps/katib-external-db-with-kubeflow

--- a/deployment/rds-s3/rds-only/kustomization.yaml
+++ b/deployment/rds-s3/rds-only/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
   # Configured for AWS RDS
 
   # AWS Secret Manager
-  - ../../../../awsconfigs/common/aws-secrets-manager/rds
+  - ../../../awsconfigs/common/aws-secrets-manager/rds
   # Kubeflow Pipelines
-  - ../../../../awsconfigs/apps/pipeline/rds
+  - ../../../awsconfigs/apps/pipeline/rds
   # Katib
-  - ../../../../awsconfigs/apps/katib-external-db-with-kubeflow
+  - ../../../awsconfigs/apps/katib-external-db-with-kubeflow

--- a/deployment/rds-s3/s3-only/kustomization.yaml
+++ b/deployment/rds-s3/s3-only/kustomization.yaml
@@ -7,9 +7,9 @@ resources:
   # Configured for AWS S3
 
   # AWS Secret Manager
-  - ../../../../awsconfigs/common/aws-secrets-manager/s3
+  - ../../../awsconfigs/common/aws-secrets-manager/s3
   # Kubeflow Pipelines
-  - ../../../../awsconfigs/apps/pipeline/s3
+  - ../../../awsconfigs/apps/pipeline/s3
 
   # Katib
-  - ../../../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
+  - ../../../upstream/apps/katib/upstream/installs/katib-with-kubeflow

--- a/deployment/vanilla/kustomization.yaml
+++ b/deployment/vanilla/kustomization.yaml
@@ -3,57 +3,57 @@ kind: Kustomization
 
 resources:
   # Cert-Manager
-  - ../../../upstream/common/cert-manager/cert-manager/base
-  - ../../../upstream/common/cert-manager/kubeflow-issuer/base
+  - ../../upstream/common/cert-manager/cert-manager/base
+  - ../../upstream/common/cert-manager/kubeflow-issuer/base
   # Istio
-  - ../../../upstream/common/istio-1-11/istio-crds/base
-  - ../../../upstream/common/istio-1-11/istio-namespace/base
-  - ../../../upstream/common/istio-1-11/istio-install/base
+  - ../../upstream/common/istio-1-11/istio-crds/base
+  - ../../upstream/common/istio-1-11/istio-namespace/base
+  - ../../upstream/common/istio-1-11/istio-install/base
   # OIDC Authservice
-  - ../../../upstream/common/oidc-authservice/base
+  - ../../upstream/common/oidc-authservice/base
   # Dex
-  - ../../../upstream/common/dex/overlays/istio
+  - ../../upstream/common/dex/overlays/istio
   # KNative
-  - ../../../upstream/common/knative/knative-serving/overlays/gateways
-  - ../../../upstream/common/knative/knative-eventing/base
-  - ../../../upstream/common/istio-1-11/cluster-local-gateway/base
+  - ../../upstream/common/knative/knative-serving/overlays/gateways
+  - ../../upstream/common/knative/knative-eventing/base
+  - ../../upstream/common/istio-1-11/cluster-local-gateway/base
   # Kubeflow namespace
-  - ../../../upstream/common/kubeflow-namespace/base
+  - ../../upstream/common/kubeflow-namespace/base
   # Kubeflow Roles
-  - ../../../upstream/common/kubeflow-roles/base
+  - ../../upstream/common/kubeflow-roles/base
   # Kubeflow Istio Resources
-  - ../../../upstream/common/istio-1-11/kubeflow-istio-resources/base
+  - ../../upstream/common/istio-1-11/kubeflow-istio-resources/base
 
   # Kubeflow Pipelines
-  - ../../../upstream/apps/pipeline/upstream/env/platform-agnostic-multi-user
+  - ../../upstream/apps/pipeline/upstream/env/platform-agnostic-multi-user
   # KFServing
-  - ../../../upstream/apps/kfserving/upstream/overlays/kubeflow
+  - ../../upstream/apps/kfserving/upstream/overlays/kubeflow
   # Katib
-  - ../../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
+  - ../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
   # Central Dashboard
-  - ../../../upstream/apps/centraldashboard/upstream/overlays/kserve
+  - ../../upstream/apps/centraldashboard/upstream/overlays/kserve
   # Admission Webhook
-  - ../../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
+  - ../../upstream/apps/admission-webhook/upstream/overlays/cert-manager
   # Jupyter Web App
-  - ../../../awsconfigs/apps/jupyter-web-app
+  - ../../awsconfigs/apps/jupyter-web-app
   # Notebook Controller
-  - ../../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
+  - ../../upstream/apps/jupyter/notebook-controller/upstream/overlays/kubeflow
   # Profiles + KFAM
-  - ../../../upstream/apps/profiles/upstream/overlays/kubeflow
+  - ../../upstream/apps/profiles/upstream/overlays/kubeflow
   # Volumes Web App
-  - ../../../upstream/apps/volumes-web-app/upstream/overlays/istio
+  - ../../upstream/apps/volumes-web-app/upstream/overlays/istio
   # Tensorboard Controller
-  - ../../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+  - ../../upstream/apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
   # Tensorboards Web App
-  - ../../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
+  - ../../upstream/apps/tensorboard/tensorboards-web-app/upstream/overlays/istio
   # Training Operator
-  - ../../../upstream/apps/training-operator/upstream/overlays/kubeflow
+  - ../../upstream/apps/training-operator/upstream/overlays/kubeflow
   # User namespace
-  - ../../../upstream/common/user-namespace/base
+  - ../../upstream/common/user-namespace/base
 
   # KServe
-  - ../../../upstream/contrib/kserve/kserve
-  - ../../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
+  - ../../upstream/contrib/kserve/kserve
+  - ../../upstream/contrib/kserve/models-web-app/overlays/kubeflow
 
   # AWS Telemetry - This is an optional component. See usage tracking documentation for more information
-  - ../../../awsconfigs/common/aws-telemetry
+  - ../../awsconfigs/common/aws-telemetry

--- a/tests/e2e/tests/test_manifest_builds.py
+++ b/tests/e2e/tests/test_manifest_builds.py
@@ -12,7 +12,7 @@ def kustomize_build(manifest_path):
     return subprocess.call(f"kustomize build {manifest_path}".split())
 
 TO_ROOT = "../../"
-DEPLOYMENTS_FOLDER = TO_ROOT + "docs/deployment/"
+DEPLOYMENTS_FOLDER = TO_ROOT + "deployment/"
 
 class TestManifestBuilds:
     @pytest.fixture(scope="class")


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
After https://github.com/awslabs/kubeflow-manifests/pull/227 some paths were broken which resulted in kustomize build failures.


**Testing:**
```
~/kf/update-manifests/tests/e2e v1.5-manifests*
kf-e2e-test-env ❯ pytest tests/test_manifest_builds.py
...
============================================================================== 6 passed in 26.16s ==============================================================================
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.