### PR TITLE
Fix broken manifest paths in e2e tests

### DIFF
--- a/tests/e2e/tests/test_cognito.py
+++ b/tests/e2e/tests/test_cognito.py
@@ -16,7 +16,7 @@ from e2e.fixtures.cognito_dependencies import (
 
 @pytest.fixture(scope="class")
 def kustomize_path():
-    return "../../docs/deployment/cognito"
+    return "../../deployment/cognito"
 
 
 @pytest.fixture(scope="class")

--- a/tests/e2e/tests/test_rds_s3.py
+++ b/tests/e2e/tests/test_rds_s3.py
@@ -55,7 +55,7 @@ from e2e.utils.custom_resources import (
 from kfp_server_api.exceptions import ApiException as KFPApiException
 from kubernetes.client.exceptions import ApiException as K8sApiException
 
-RDS_S3_KUSTOMIZE_MANIFEST_PATH = "../../docs/deployment/rds-s3/"
+RDS_S3_KUSTOMIZE_MANIFEST_PATH = "../../deployment/rds-s3/"
 RDS_S3_CLOUDFORMATION_TEMPLATE_PATH = "./resources/cloudformation-templates/rds-s3.yaml"
 CUSTOM_RESOURCE_TEMPLATES_FOLDER = "./resources/custom-resource-templates"
 DISABLE_PIPELINE_CACHING_PATCH_FILE = (

--- a/tests/e2e/tests/test_sanity.py
+++ b/tests/e2e/tests/test_sanity.py
@@ -39,7 +39,7 @@ from kfp_server_api.exceptions import ApiException as KFPApiException
 from kubernetes.client.exceptions import ApiException as K8sApiException
 
 
-GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../docs/deployment/vanilla"
+GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../deployment/vanilla"
 CUSTOM_RESOURCE_TEMPLATES_FOLDER = "./resources/custom-resource-templates"
 
 

--- a/tests/e2e/tests/test_sanity_portforward.py
+++ b/tests/e2e/tests/test_sanity_portforward.py
@@ -39,7 +39,7 @@ from kfp_server_api.exceptions import ApiException as KFPApiException
 from kubernetes.client.exceptions import ApiException as K8sApiException
 
 
-GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../docs/deployment/vanilla"
+GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../deployment/vanilla"
 CUSTOM_RESOURCE_TEMPLATES_FOLDER = "./resources/custom-resource-templates"
 
 

--- a/tests/e2e/tests/test_storage_efs.py
+++ b/tests/e2e/tests/test_storage_efs.py
@@ -54,7 +54,7 @@ from e2e.utils.utils import (
 from e2e.resources.pipelines.pipeline_read_from_volume import read_from_volume_pipeline
 from e2e.resources.pipelines.pipeline_write_to_volume import write_to_volume_pipeline
 
-GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../docs/deployment/vanilla"
+GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../deployment/vanilla"
 MOUNT_PATH = "/home/jovyan/"
 
 

--- a/tests/e2e/tests/test_storage_fsx.py
+++ b/tests/e2e/tests/test_storage_fsx.py
@@ -45,7 +45,7 @@ from e2e.utils.custom_resources import get_pvc_status, get_service_account, get_
 from e2e.resources.pipelines.pipeline_read_from_volume import read_from_volume_pipeline
 from e2e.resources.pipelines.pipeline_write_to_volume import write_to_volume_pipeline
 
-GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../docs/deployment/vanilla"
+GENERIC_KUSTOMIZE_MANIFEST_PATH = "../../deployment/vanilla"
 DISABLE_PIPELINE_CACHING_PATCH_FILE = (
     "./resources/custom-resource-templates/patch-disable-pipeline-caching.yaml"
 )


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Paths in integration tests were also broken by https://github.com/awslabs/kubeflow-manifests/pull/227

Profile IRSA tests are broken for other reasons and will be fixed in https://github.com/awslabs/kubeflow-manifests/pull/224

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.