### PR TITLE
Links to KFP and Katib MySQL were switched

### DIFF
--- a/website/content/en/docs/deployment/rds-s3/guide.md
+++ b/website/content/en/docs/deployment/rds-s3/guide.md
@@ -10,7 +10,7 @@ This guide can be used to deploy Kubeflow Pipelines (KFP) and Katib with RDS and
 
 [Amazon Relational Database Service (RDS)](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html) is a managed relational database service that facilitates several database management tasks such as database scaling, database backups, database software patching, OS patching, and more.
 
-In the [default Kubeflow installation](/kubeflow-manifests/docs/deployment/vanilla/guide/), the [KFP](https://github.com/kubeflow/manifests/blob/v1.4-branch/apps/katib/upstream/components/mysql/mysql.yaml) and [Katib](https://github.com/kubeflow/manifests/blob/v1.4-branch/apps/pipeline/upstream/third-party/mysql/base/mysql-deployment.yaml) components both use their own MySQL pod to persist KFP data (such as experiments, pipelines, jobs, etc.) and Katib experiment observation logs, respectively. 
+In the [default Kubeflow installation](/kubeflow-manifests/docs/deployment/vanilla/guide/), the [KFP](https://github.com/kubeflow/manifests/blob/v1.4-branch/apps/pipeline/upstream/third-party/mysql/base/mysql-deployment.yaml) and [Katib](https://github.com/kubeflow/manifests/blob/v1.4-branch/apps/katib/upstream/components/mysql/mysql.yaml) components both use their own MySQL pod to persist KFP data (such as experiments, pipelines, jobs, etc.) and Katib experiment observation logs, respectively. 
 
 Compared to the MySQL setup in the default installation, using RDS provides the following advantages:
 - Availability: RDS provides high availability and failover support for DB instances using Multi Availability Zone (Mulit-AZ) deployments with a single standby DB instance, increasing the availability of KFP and Katib services during unexpected network events.


### PR DESCRIPTION
**Description of your changes:**
I was reading the documentation for [RDS and S3](https://awslabs.github.io/kubeflow-manifests/docs/deployment/rds-s3/guide/) and noticed the links to the KFP and Katib MySQL components were mixed up. This PR switches the links so the KFP text points to the KFP file and the Katib text points to the Katib file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.