### PR TITLE
Enable secure connection in minio config for S3 integration

### DIFF
--- a/awsconfigs/apps/pipeline/s3/config
+++ b/awsconfigs/apps/pipeline/s3/config
@@ -5,7 +5,7 @@ artifactRepository:
         bucket: $(kfp-artifact-bucket-name),
         keyPrefix: artifacts,
         endpoint: s3.amazonaws.com,
-        insecure: true,
+        insecure: false,
         accessKeySecret: {
             name: mlpipeline-minio-artifact,
             key: accesskey


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
#225 

Minio is trying to access an s3 bucket that requires a secure connection to access.
This is failing due to the current configuration applied to minio. 

**Description of your changes:**
```
{
artifactRepository:
{
    s3: {
       ...
        insecure: false, # Changed from true

        ...
    },
    archiveLogs: true
}
```

**Testing:**
***Without policy applied***
```
...
Forwarding from 127.0.0.1:8080 -> 8080
Forwarding from [::1]:8080 -> 8080
{'region': 'eu-north-1', 'cluster_name': 'e2e-test-cluster-6zd8d7q4cb', 'test_rds_s3_cfn_stack': {'stack_name': 'test-e2e-rds-s3-stack-p3kut34721', 'params': {'VpcId': 'vpc-030
bba31e300977a1', 'Subnets': 'subnet-057d8c2fa52802403,subnet-08908a9b3708a0a32,subnet-0924a4637b9929edb', 'SecurityGroupId': 'sg-07cc282d30edf0fbf', 'DBUsername': 'adminzhy9wnc
7cp', 'DBPassword': 'Kubefl0wash4cpnoy8', 'S3SecretString': '{"accesskey": "<>", "secretkey": "<>"}'}}, 'kustomize_path'
: '../../docs/deployment/rds-s3/'}
Created metadata file for TestRDSS3 /home/ubuntu/wow/kubeflow-manifests/tests/e2e/.metadata/metadata-1653432679603578783.json
Handling connection for 8080
Handling connection for 8080
INFO     root:_client.py:203 Failed to automatically set namespace.
-------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------
INFO     root:_client.py:452 Creating experiment experiment-1sfqd8sidi.
PASSED
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
-------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------
INFO     root:_client.py:452 Creating experiment experiment-juhlb8qo7d.
PASSED
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment ^[[A^[[A^[[A^[[B^[[B^[[B^[[B^[[B^[[B^[[B^[[B^[[B^[[B^[[BPASSED

=============================================================================== warnings summary ==============================================================================$
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment
  /home/ubuntu/env/lib/python3.8/site-packages/mysql/connector/connection_cext.py:516: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
    self._cmysql.query(query,

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================== 3 passed, 9 warnings in 2473.23s (0:41:13) ==================================================================
```

***With policy applied***
S3 bucket policy set manually before running integ test:
```
{
    "Version": "2012-10-17",
    "Id": "ExamplePolicy",
    "Statement": [
        {
            "Sid": "AllowSSLRequestsOnly",
            "Effect": "Deny",
            "Principal": "*",
            "Action": "s3:*",
            "Resource": [
                "arn:aws:s3:::test-e2e-rds-s3-stack-p3kut34721-mys3bucket-1naj4twy7mkaw",
                "arn:aws:s3:::test-e2e-rds-s3-stack-p3kut34721-mys3bucket-1naj4twy7mkaw/*"
            ],
            "Condition": {
                "Bool": {
                    "aws:SecureTransport": "false"
                }
            }
        }
    ]
```

Results
```
(env) ubuntu@ip-172-31-46-102:~/wow/kubeflow-manifests/tests/e2e$ pytest tests/test_rds_s3.py -s -q --region eu-north-1 --accesskey <> --secretkey <>
VBxCugfglUkY0UDaeIVqpNx5lWI9q   --keepsuccess --metadata /home/ubuntu/wow/kubeflow-manifests/tests/e2e/.metadata/metadata-1653432679603578783.json

Forwarding from 127.0.0.1:8080 -> 8080
Forwarding from [::1]:8080 -> 8080
{'region': 'eu-north-1', 'cluster_name': 'e2e-test-cluster-6zd8d7q4cb', 'test_rds_s3_cfn_stack': {'stack_name': 'test-e2e-rds-s3-stack-p3kut34721', 'params': {'VpcId': 'vpc-030bba31e300977a1', 'Subnets': 'subnet-057d8c2fa52802403,subnet-08908a9b3708a0a32,subnet-0924a4637b9929edb', 'SecurityGroupId': 'sg-07cc282d30edf0fbf', 'DBUsername': 'adminzhy9wnc7cp', 'DBPassword': 'Kubefl0wash4cpnoy8', 'S3SecretString': '{"accesskey": "<>", "secretkey": "<>"}'}}, 'kustomize_path': '../../docs/deployment/rds-s3/'}
Created metadata file for TestRDSS3 /home/ubuntu/wow/kubeflow-manifests/tests/e2e/.metadata/metadata-1653433354042132700.json
Handling connection for 8080
Handling connection for 8080
INFO     root:_client.py:203 Failed to automatically set namespace.
-------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------
INFO     root:_client.py:452 Creating experiment experiment-a7m2cq51w5.
PASSED
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
-------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------
INFO     root:_client.py:452 Creating experiment experiment-dqorzmoaj7.
PASSED
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment ^[[D^[[D^[[D^[[D^[[A^[[A^[[A^[[A^[[A^[[A^[[A^[[A^[[A^[[A^[[A^[[A^[[A^[[A^[[APASSED

=============================================================================== warnings summary ===============================================================================
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment
  /home/ubuntu/env/lib/python3.8/site-packages/mysql/connector/connection_cext.py:516: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
    self._cmysql.query(query,

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================== 3 passed, 9 warnings in 328.20s (0:05:28) ===================================================================


```



Manual run from UI
<img width="1553" alt="Screen Shot 2022-05-24 at 5 23 22 PM" src="https://user-images.githubusercontent.com/91350438/170152898-d3a6bc85-eb4e-4224-8ccb-faa01696bc99.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.