### PR TITLE
Added copy button to code samples

### DIFF
--- a/website/assets/css/copy-code-button.css
+++ b/website/assets/css/copy-code-button.css
@@ -1,0 +1,84 @@
+.highlight-wrapper {
+    display: block;
+  }
+  
+  /* Start: Turn off individual column border, margin, and padding when line numbers are showing */
+  
+  .highlight-wrapper .lntd pre {
+      padding: 0;
+  }
+  
+  .chroma .lntd pre {
+      border: 0px solid #ccc;
+  }
+  
+  .chroma .lntd:first-child {
+    padding: 7px 7px 7px 10px;
+    margin: 0;
+  }
+  
+  .chroma .lntd:last-child {
+    padding: 7px 10px 7px 7px;
+    margin: 0;
+  } 
+
+  /* End: Turn off individual column border, margin, and padding when line numbers are showing */
+  
+  .highlight {
+    position: relative;
+    z-index: 0;
+    padding: 0;
+    margin:40px 0 10px 0;
+    border-radius: 4px;
+  }
+  
+  .highlight > .chroma {
+    position: static;
+    z-index: 1;
+    border-top-left-radius: 0px;
+    border-top-right-radius: 0px;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 10px;
+  }
+  
+  .copy-code-button {
+    position: absolute;
+    z-index: 2;
+    right: 0;
+    top: 0px;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 14px;
+    letter-spacing: 0.5px;
+    width: 30px;
+    color: #ffffff;
+    background-color: #000000;
+    border: 1.25px solid #232326;
+    border-top-left-radius: 0px;
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+    border-bottom-left-radius: 4px;
+    white-space: nowrap;
+    padding: 6px 6px 7px 6px;
+    margin: 0 0 0 1px;
+    cursor: pointer;
+    opacity: 0.6;
+  }
+  
+  .copy-code-button:hover,
+  .copy-code-button:focus,
+  .copy-code-button:active,
+  .copy-code-button:active:hover {
+    color: #222225;
+    background-color: #b3b3b3;
+    opacity: 0.8;
+  }
+  
+  .copyable-text-area {
+    position: absolute;
+    height: 0;
+    z-index: -1;
+    opacity: .01;
+  }
+  

--- a/website/assets/css/syntax.css
+++ b/website/assets/css/syntax.css
@@ -1,0 +1,87 @@
+/* Tango Chromastyle Code Syntax Highlighting CSS */
+
+/* Background */ .bg { background-color: #f8f8f8 }
+/* PreWrapper */ .chroma { background-color: #f8f8f8; }
+/* Other */ .chroma .x { color: #000000 }
+/* Error */ .chroma .err { color: #a40000 }
+/* CodeLine */ .chroma .cl {  }
+/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
+/* LineHighlight */ .chroma .hl { background-color: #ffffcc }
+/* LineNumbersTable */ .chroma .lnt { white-space: pre; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineNumbers */ .chroma .ln { white-space: pre; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* Line */ .chroma .line { display: flex; }
+/* Keyword */ .chroma .k { color: #204a87; font-weight: bold }
+/* KeywordConstant */ .chroma .kc { color: #204a87; font-weight: bold }
+/* KeywordDeclaration */ .chroma .kd { color: #204a87; font-weight: bold }
+/* KeywordNamespace */ .chroma .kn { color: #204a87; font-weight: bold }
+/* KeywordPseudo */ .chroma .kp { color: #204a87; font-weight: bold }
+/* KeywordReserved */ .chroma .kr { color: #204a87; font-weight: bold }
+/* KeywordType */ .chroma .kt { color: #204a87; font-weight: bold }
+/* Name */ .chroma .n { color: #000000 }
+/* NameAttribute */ .chroma .na { color: #c4a000 }
+/* NameBuiltin */ .chroma .nb { color: #204a87 }
+/* NameBuiltinPseudo */ .chroma .bp { color: #3465a4 }
+/* NameClass */ .chroma .nc { color: #000000 }
+/* NameConstant */ .chroma .no { color: #000000 }
+/* NameDecorator */ .chroma .nd { color: #5c35cc; font-weight: bold }
+/* NameEntity */ .chroma .ni { color: #ce5c00 }
+/* NameException */ .chroma .ne { color: #cc0000; font-weight: bold }
+/* NameFunction */ .chroma .nf { color: #000000 }
+/* NameFunctionMagic */ .chroma .fm { color: #000000 }
+/* NameLabel */ .chroma .nl { color: #f57900 }
+/* NameNamespace */ .chroma .nn { color: #000000 }
+/* NameOther */ .chroma .nx { color: #000000 }
+/* NameProperty */ .chroma .py { color: #000000 }
+/* NameTag */ .chroma .nt { color: #204a87; font-weight: bold }
+/* NameVariable */ .chroma .nv { color: #000000 }
+/* NameVariableClass */ .chroma .vc { color: #000000 }
+/* NameVariableGlobal */ .chroma .vg { color: #000000 }
+/* NameVariableInstance */ .chroma .vi { color: #000000 }
+/* NameVariableMagic */ .chroma .vm { color: #000000 }
+/* Literal */ .chroma .l { color: #000000 }
+/* LiteralDate */ .chroma .ld { color: #000000 }
+/* LiteralString */ .chroma .s { color: #4e9a06 }
+/* LiteralStringAffix */ .chroma .sa { color: #4e9a06 }
+/* LiteralStringBacktick */ .chroma .sb { color: #4e9a06 }
+/* LiteralStringChar */ .chroma .sc { color: #4e9a06 }
+/* LiteralStringDelimiter */ .chroma .dl { color: #4e9a06 }
+/* LiteralStringDoc */ .chroma .sd { color: #8f5902; font-style: italic }
+/* LiteralStringDouble */ .chroma .s2 { color: #4e9a06 }
+/* LiteralStringEscape */ .chroma .se { color: #4e9a06 }
+/* LiteralStringHeredoc */ .chroma .sh { color: #4e9a06 }
+/* LiteralStringInterpol */ .chroma .si { color: #4e9a06 }
+/* LiteralStringOther */ .chroma .sx { color: #4e9a06 }
+/* LiteralStringRegex */ .chroma .sr { color: #4e9a06 }
+/* LiteralStringSingle */ .chroma .s1 { color: #4e9a06 }
+/* LiteralStringSymbol */ .chroma .ss { color: #4e9a06 }
+/* LiteralNumber */ .chroma .m { color: #0000cf; font-weight: bold }
+/* LiteralNumberBin */ .chroma .mb { color: #0000cf; font-weight: bold }
+/* LiteralNumberFloat */ .chroma .mf { color: #0000cf; font-weight: bold }
+/* LiteralNumberHex */ .chroma .mh { color: #0000cf; font-weight: bold }
+/* LiteralNumberInteger */ .chroma .mi { color: #0000cf; font-weight: bold }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #0000cf; font-weight: bold }
+/* LiteralNumberOct */ .chroma .mo { color: #0000cf; font-weight: bold }
+/* Operator */ .chroma .o { color: #ce5c00; font-weight: bold }
+/* OperatorWord */ .chroma .ow { color: #204a87; font-weight: bold }
+/* Punctuation */ .chroma .p { color: #000000; font-weight: bold }
+/* Comment */ .chroma .c { color: #8f5902; font-style: italic }
+/* CommentHashbang */ .chroma .ch { color: #8f5902; font-style: italic }
+/* CommentMultiline */ .chroma .cm { color: #8f5902; font-style: italic }
+/* CommentSingle */ .chroma .c1 { color: #8f5902; font-style: italic }
+/* CommentSpecial */ .chroma .cs { color: #8f5902; font-style: italic }
+/* CommentPreproc */ .chroma .cp { color: #8f5902; font-style: italic }
+/* CommentPreprocFile */ .chroma .cpf { color: #8f5902; font-style: italic }
+/* Generic */ .chroma .g { color: #000000 }
+/* GenericDeleted */ .chroma .gd { color: #a40000 }
+/* GenericEmph */ .chroma .ge { color: #000000; font-style: italic }
+/* GenericError */ .chroma .gr { color: #ef2929 }
+/* GenericHeading */ .chroma .gh { color: #000080; font-weight: bold }
+/* GenericInserted */ .chroma .gi { color: #00a000 }
+/* GenericOutput */ .chroma .go { color: #000000; font-style: italic }
+/* GenericPrompt */ .chroma .gp { color: #8f5902 }
+/* GenericStrong */ .chroma .gs { color: #000000; font-weight: bold }
+/* GenericSubheading */ .chroma .gu { color: #800080; font-weight: bold }
+/* GenericTraceback */ .chroma .gt { color: #a40000; font-weight: bold }
+/* GenericUnderline */ .chroma .gl { color: #000000; text-decoration: underline }
+/* TextWhitespace */ .chroma .w { color: #f8f8f8; text-decoration: underline }

--- a/website/assets/js/copy-code-button.js
+++ b/website/assets/js/copy-code-button.js
@@ -1,0 +1,54 @@
+// Add Copy Code Snippet button
+// Source: https://digitaldrummerj.me/hugo-add-copy-code-snippet-button
+
+function createCopyButton(highlightDiv) {
+    const button = document.createElement("button");
+    button.className = "copy-code-button";
+    button.type = "button";
+    button.innerText = "⧉";
+    button.addEventListener("click", () => copyCodeToClipboard(button, highlightDiv));
+    highlightDiv.insertBefore(button, highlightDiv.firstChild);
+  
+    const wrapper = document.createElement("div");
+    wrapper.className = "highlight-wrapper";
+    highlightDiv.parentNode.insertBefore(wrapper, highlightDiv);
+    wrapper.appendChild(highlightDiv);
+  }
+  
+  document.querySelectorAll(".highlight").forEach((highlightDiv) => createCopyButton(highlightDiv));
+  async function copyCodeToClipboard(button, highlightDiv) {
+    const codeToCopy = highlightDiv.querySelector(":last-child > .chroma > code").innerText;
+    try {
+      var result = await navigator.permissions.query({ name: "clipboard-write" });
+      if (result.state == "granted" || result.state == "prompt") {
+        await navigator.clipboard.writeText(codeToCopy);
+      } else {
+        copyCodeBlockExecCommand(codeToCopy, highlightDiv);
+      }
+    } catch (_) {
+      copyCodeBlockExecCommand(codeToCopy, highlightDiv);
+    } finally {
+   button.blur();
+    button.innerText = "✓";
+    setTimeout(function () {
+      button.innerText = "⧉";
+    }, 2000);  }
+  }
+  
+  function copyCodeBlockExecCommand(codeToCopy, highlightDiv) {
+    const textArea = document.createElement("textArea");
+    textArea.contentEditable = "true";
+    textArea.readOnly = "false";
+    textArea.className = "copyable-text-area";
+    textArea.value = codeToCopy;
+    highlightDiv.insertBefore(textArea, highlightDiv.firstChild);
+    const range = document.createRange();
+    range.selectNodeContents(textArea);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    textArea.setSelectionRange(0, 999999);
+    document.execCommand("copy");
+    highlightDiv.removeChild(textArea);
+  }
+  

--- a/website/assets/scss/_variables_project.scss
+++ b/website/assets/scss/_variables_project.scss
@@ -151,4 +151,5 @@ html.smooth-scroll {
       #pageContent .lead:nth-child(2n+0) > .text {
         -ms-flex-order: 1;
             order: 1; } }
-  
+
+

--- a/website/config.toml
+++ b/website/config.toml
@@ -45,8 +45,17 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
       unsafe = true
   [markup.highlight]
     # See a complete list of available styles at https://xyproto.github.io/splash/docs/all.html
-    style = "tango"
-    guessSyntax = "true"
+    style = 'tango'
+    guessSyntax = false
+    lineNumbersInTable = true
+    noClasses = false
+    anchorLineNos = false
+    codeFences = true
+    hl_Lines = ''
+    lineAnchors = ''
+    lineNoStart = 1
+    lineNos = false
+
 
 ###############################################################################
 # Docsy - Image processing configuration

--- a/website/content/en/docs/component-guides/pipelines.md
+++ b/website/content/en/docs/component-guides/pipelines.md
@@ -181,13 +181,13 @@ These steps continue from the configuration steps above but can be used as a sta
 
 1. Port forward the central dashboard.
 
-   ```
+   ```bash
    kubectl port-forward svc/istio-ingressgateway -n istio-system 8080:80
    ```
 
 2. Install the verification script dependencies. The script requires python 3.6 or greater.
 
-   ```
+   ```bash
    pip install boto3 kfp requests
    ```
 
@@ -252,7 +252,7 @@ These steps continue from the configuration steps above but can be used as a sta
 
 4. Run the created script file.
 
-   ```
+   ```bash
    python <script_file>.py
    ```
 

--- a/website/content/en/docs/deployment/add-ons/storage/efs/guide.md
+++ b/website/content/en/docs/deployment/add-ons/storage/efs/guide.md
@@ -76,19 +76,19 @@ The script applies some default values for the file system name, performance mod
 ### 2.2 [Option 2] Manual setup
 If you prefer to manually setup each component then you can follow this manual guide.  As mentioned, it you have two options between **Static and Dynamic provisioing** later in step 4 of this section.  
 
-```
+```bash
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
 ```
 
 #### 1. Install the EFS CSI driver
 We recommend installing the EFS CSI Driver v1.3.4 directly from the [the aws-efs-csi-driver github repo](https://github.com/kubernetes-sigs/aws-efs-csi-driver) as follows:
 
-```
+```bash
 kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v1.3.4"
 ```
 
 You can confirm that EFS CSI Driver was installed into the default kube-system namespace for you. You can check using the following command:
-```
+```bash
 kubectl get csidriver
 
 NAME              ATTACHREQUIRED   PODINFOONMOUNT   MODES        AGE
@@ -100,12 +100,12 @@ The CSI driver's service account (created during installation) requires IAM perm
 
 1. Download the IAM policy document from GitHub as follows.
 
-```
+```bash
 curl -o iam-policy-example.json https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v1.3.4/docs/iam-policy-example.json
 ```
 
 2. Create the policy.
-```
+```bash
 aws iam create-policy \
     --policy-name AmazonEKS_EFS_CSI_Driver_Policy \
     --policy-document file://iam-policy-example.json
@@ -113,7 +113,7 @@ aws iam create-policy \
 
 3. Create an IAM role and attach the IAM policy to it. Annotate the Kubernetes service account with the IAM role ARN and the IAM role with the Kubernetes service account name. You can create the role using eksctl as follows:
 
-```
+```bash
 eksctl create iamserviceaccount \
     --name efs-csi-controller-sa \
     --namespace kube-system \
@@ -125,7 +125,7 @@ eksctl create iamserviceaccount \
 ```
 
 4. You can verify by describing the specified service account to check if it has been correctly annotated:
-```
+```bash
 kubectl describe -n kube-system serviceaccount efs-csi-controller-sa
 ```
 
@@ -139,20 +139,20 @@ In the following section, you have to choose between setting up [dynamic provisi
 
 #### 4. [Option 1] Dynamic provisioning  
 1. Use the `$file_system_id` you recorded in section 3 above or use the AWS Console to get the filesystem id of the EFS file system you want to use. Now edit the `dynamic-provisioning/sc.yaml` file by chaning `<YOUR_FILE_SYSTEM_ID>` with your `fs-xxxxxx` file system id. You can also change it using the following command :  
-```
+```bash
 file_system_id=$file_system_id yq e '.parameters.fileSystemId = env(file_system_id)' -i $GITHUB_STORAGE_DIR/efs/dynamic-provisioning/sc.yaml
 ```  
   
 2. Create the storage class using the following command :  
-```
+```bash
 kubectl apply -f $GITHUB_STORAGE_DIR/efs/dynamic-provisioning/sc.yaml
 ```  
 3. Verify your setup by checking which storage classes are created for your cluster. You can use the following command  
-```
+```bash
 kubectl get sc
 ```  
 4. The `StorageClass` is a cluster scoped resources but the `PersistentVolumeClaim` needs to be in the namespace you will be accessing it from. Let's edit the pvc.yaml accordingly 
-```
+```bash
 yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i $GITHUB_STORAGE_DIR/efs/dynamic-provisioning/pvc.yaml
 yq e '.metadata.name = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/efs/dynamic-provisioning/pvc.yaml
 
@@ -165,19 +165,19 @@ Note : The `StorageClass` is a cluster scoped resource which means we only need 
 Using [this sample](https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/examples/kubernetes/multiple_pods), we provided the required spec files in the sample subdirectory. However, you can create the PVC another way. 
 
 1. Use the `$file_system_id` you recorded in section 3 above or use the AWS Console to get the filesystem id of the EFS file system you want to use. Now edit the last line of the static-provisioning/pv.yaml file to specify the `volumeHandle` field to point to your EFS filesystem. Replace `$file_system_id` if it is not already set. 
-```
+```bash
 file_system_id=$file_system_id yq e '.spec.csi.volumeHandle = env(file_system_id)' -i $GITHUB_STORAGE_DIR/efs/static-provisioning/pv.yaml
 yq e '.metadata.name = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/efs/static-provisioning/pv.yaml
 ```
 
 2. The `PersistentVolume` and `StorageClass` are cluster scoped resources but the `PersistentVolumeClaim` needs to be in the namespace you will be accessing it from. Replace the `kubeflow-user-example-com` namespace specified the below with the namespace for your kubeflow user and edit the `static-provisioning/pvc.yaml` file accordingly. 
-```
+```bash
 yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i $GITHUB_STORAGE_DIR/efs/static-provisioning/pvc.yaml
 yq e '.metadata.name = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/efs/static-provisioning/pvc.yaml
 ```
 
 3. Now create the required persistentvolume, persistentvolumeclaim and storageclass resources as -
-```
+```bash
 kubectl apply -f $GITHUB_STORAGE_DIR/efs/static-provisioning/sc.yaml
 kubectl apply -f $GITHUB_STORAGE_DIR/efs/static-provisioning/pv.yaml
 kubectl apply -f $GITHUB_STORAGE_DIR/efs/static-provisioning/pvc.yaml
@@ -185,7 +185,7 @@ kubectl apply -f $GITHUB_STORAGE_DIR/efs/static-provisioning/pvc.yaml
 
 ### 2.3 Check your setup
 Use the following commands to ensure all resources have been deployed as expected and the PersistentVolume is correctly bound to the PersistentVolumeClaim
-```
+```bash
 # Only for Static Provisioning
 kubectl get pv
 
@@ -193,7 +193,7 @@ NAME    CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM               
 efs-pv  5Gi        RWX            Retain           Bound    kubeflow-user-example-com/efs-claim   efs-sc                  5d16h
 ```
 
-```
+```bash
 # Both Static and Dynamic Provisioning
 kubectl get pvc -n $PVC_NAMESPACE
 
@@ -218,11 +218,11 @@ To learn more about how to change the default Storage Class, you can refer to th
   
 For instance, if you have a default class set to `gp2` and another class `efs-sc`, then you would need to do the following : 
 1. Remove `gp2` as your default storage class
-```
+```bash
 kubectl patch storageclass gp2 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 ```
 2. Set `efs-sc` as your default storage class
-```
+```bash
 kubectl patch storageclass efs-sc -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 ```
 
@@ -231,7 +231,7 @@ Note: As mentioned, make sure to change your default storage class only after yo
 ### 3.3 Note about permissions
 This step may not be necessary but you might need to specify some additional directory permissions on your worker node before you can use these as mount points. By default, new Amazon EFS file systems are owned by root:root, and only the root user (UID 0) has read-write-execute permissions. If your containers are not running as root, you must change the Amazon EFS file system permissions to allow other users to modify the file system. The set-permission-job.yaml is an example of how you could set these permissions to be able to use the efs as your workspace in your kubeflow notebook. Modify it accordingly if you run into similar permission issues with any other job pod. 
 
-```
+```bash
 yq e '.metadata.name = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
 yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
 yq e '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
@@ -256,7 +256,7 @@ Note: The following steps are run from the terminal on your gateway node connect
 
 #### 1. Download the dataset to the EFS Volume 
 In the Kubeflow Notebook created above, use the following snippet to download the data into the `/home/jovyan/.keras` directory (which is mounted onto the EFS Volume). 
-```
+```bash
 import pathlib
 import tensorflow as tf
 dataset_url = "https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz"
@@ -268,7 +268,7 @@ data_dir = pathlib.Path(data_dir)
 
 #### 2. Build and push the Docker image
 In the `training-sample` directory, we have provided a sample training script and Dockerfile which you can use as follows to build a docker image. Be sure to point the `$IMAGE_URI` to your registry and specify an appropriate tag.
-```
+```bash
 export IMAGE_URI=<dockerimage:tag>
 cd training-sample
 
@@ -280,26 +280,26 @@ cd -
 
 #### 3. Configure the TFjob spec file
 Once the docker image is built, replace the `<dockerimage:tag>` in the `tfjob.yaml` file, line #17. 
-```
+```bash
 yq e '.spec.tfReplicaSpecs.Worker.template.spec.containers[0].image = env(IMAGE_URI)' -i training-sample/tfjob.yaml
 ```
 Also, specify the name of the PVC you created.
-```
+```bash
 yq e '.spec.tfReplicaSpecs.Worker.template.spec.volumes[0].persistentVolumeClaim.claimName = env(CLAIM_NAME)' -i training-sample/tfjob.yaml
 ```
 Make sure to run it in the same namespace as the claim:
-```
+```bash
 yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i training-sample/tfjob.yaml
 ```
 
 #### 4. Create the TFjob and use the provided commands to check the training logs 
 At this point, we are ready to train the model using the `training-sample/training.py` script and the data available on the shared volume with the Kubeflow TFJob operator as -
-```
+```bash
 kubectl apply -f training-sample/tfjob.yaml
 ```
 
 In order to check that the training job is running as expected, you can check the events in the TFJob describe response as well as the job logs.
-```
+```bash
 kubectl describe tfjob image-classification-pvc -n $PVC_NAMESPACE
 kubectl logs -n $PVC_NAMESPACE image-classification-pvc-worker-0 -f
 ```
@@ -308,22 +308,22 @@ kubectl logs -n $PVC_NAMESPACE image-classification-pvc-worker-0 -f
 This section cleans up the resources created in this guide. To clean up other resources, such as the Kubeflow deployment, see [Uninstall Kubeflow](/kubeflow-manifests/docs/deployment/uninstall-kubeflow/).
 
 ### 4.1 Clean up the TFJob
-```
+```bash
 kubectl delete tfjob -n $PVC_NAMESPACE image-classification-pvc
 ```
 
 ### 4.2 Delete the Kubeflow Notebook
 Login to the dashboard to stop and/or terminate any kubeflow notebooks you created for this session or use the following command:
-```
+```bash
 kubectl delete notebook -n $PVC_NAMESPACE <notebook-name>
 ``` 
 Use the following command to delete the permissions job:
-```
+```bash
 kubectl delete pod -n $PVC_NAMESPACE $CLAIM_NAME
 ```
 
 ### 4.3 Delete PVC, PV, and SC in the following order
-```
+```bash
 kubectl delete pvc -n $PVC_NAMESPACE $CLAIM_NAME
 kubectl delete pv efs-pv
 kubectl delete sc efs-sc

--- a/website/content/en/docs/deployment/add-ons/storage/efs/guide.md
+++ b/website/content/en/docs/deployment/add-ons/storage/efs/guide.md
@@ -256,7 +256,7 @@ Note: The following steps are run from the terminal on your gateway node connect
 
 #### 1. Download the dataset to the EFS Volume 
 In the Kubeflow Notebook created above, use the following snippet to download the data into the `/home/jovyan/.keras` directory (which is mounted onto the EFS Volume). 
-```bash
+```python
 import pathlib
 import tensorflow as tf
 dataset_url = "https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz"

--- a/website/content/en/docs/deployment/add-ons/storage/fsx-for-lustre/guide.md
+++ b/website/content/en/docs/deployment/add-ons/storage/fsx-for-lustre/guide.md
@@ -42,24 +42,24 @@ You can either use Automated or Manual setup. We currently only support **Static
 The script automates all the manual resource creation steps but is currently only available for **Static Provisioning** option.  
 It performs the required cluster configuration, creates an FSx file system and it also takes care of creating a storage class for static provisioning. Once done, move to section 3.0. 
 1. Run the following commands from the `tests/e2e` directory:
-```
+```bash
 cd $GITHUB_ROOT/tests/e2e
 ```
 2. Install the script dependencies 
-```
+```bash
 pip install -r requirements.txt
 ```
 3. Run the automated script as follows.   
 
 Note: If you want the script to create a new security group for FSx, specify a name for `SECURITY_GROUP_TO_CREATE`. On the other hand, if you want to use an existing Security group, you can specify that name too.
-```
+```bash
 export SECURITY_GROUP_TO_CREATE=$CLAIM_NAME
 
 python utils/auto-fsx-setup.py --region $CLUSTER_REGION --cluster $CLUSTER_NAME --fsx_file_system_name $CLAIM_NAME --fsx_security_group_name $SECURITY_GROUP_TO_CREATE
 ```
 
 4. The script above takes care of creating the `PersistentVolume (PV)` which is a cluster scoped resource. In order to create the `PersistentVolumeClaim (PVC)` you can either use the yaml file provided in this directory or use the Kubeflow UI directly but the PVC needs to be in the user namespace you will be accessing it from. 
-```
+```bash
 yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i $GITHUB_STORAGE_DIR/fsx-for-lustre/static-provisioning/pvc.yaml
 yq e '.metadata.name = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/fsx-for-lustre/static-provisioning/pvc.yaml
 yq e '.spec.volumeName = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/fsx-for-lustre/static-provisioning/pvc.yaml
@@ -77,12 +77,12 @@ If you prefer to manually setup each component then you can follow this manual g
 #### 1. Install the FSx CSI Driver
 We recommend installing the FSx CSI Driver v0.7.1 directly from the [the aws-fsx-csi-driver GitHub repository](https://github.com/kubernetes-sigs/aws-fsx-csi-driver) as follows:
 
-```
+```bash
 kubectl apply -k "github.com/kubernetes-sigs/aws-fsx-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v0.7.1"
 ```
 
 You can confirm that FSx CSI Driver was installed using the following command:
-```
+```bash
 kubectl get csidriver -A
 
 NAME              ATTACHREQUIRED   PODINFOONMOUNT   MODES        AGE
@@ -93,7 +93,7 @@ fsx.csi.aws.com   false            false            Persistent   14s
 The CSI driver's service account (created during installation) requires IAM permission to make calls to AWS APIs on your behalf. Here, we will be annotating the Service Account `fsx-csi-controller-sa` with an IAM Role which has the required permissions.
 
 1. Create the policy using the json file provided as follows:
-```
+```bash
 aws iam create-policy \
     --policy-name Amazon_FSx_Lustre_CSI_Driver \
     --policy-document file://fsx-for-lustre/fsx-csi-driver-policy.json
@@ -101,7 +101,7 @@ aws iam create-policy \
 
 2. Create an IAM role and attach the IAM policy to it. Annotate the Kubernetes service account with the IAM role ARN and the IAM role with the Kubernetes service account name. You can create the role using eksctl as follows:
 
-```
+```bash
 eksctl create iamserviceaccount \
     --name fsx-csi-controller-sa \
     --namespace kube-system \
@@ -113,7 +113,7 @@ eksctl create iamserviceaccount \
 ```
 
 3. You can verify by describing the specified service account to check if it has been correctly annotated:
-```
+```bash
 kubectl describe -n kube-system serviceaccount fsx-csi-controller-sa
 ```
 
@@ -126,51 +126,51 @@ Note: For this guide, we assume that you are creating your FSx Filesystem in the
 [Using this sample from official Kubeflow Docs](https://www.kubeflow.org/docs/distributions/aws/customizing-aws/storage/#amazon-fsx-for-lustre) 
 
 1. Use the AWS Console to get the filesystem id of the FSx volume you want to use. You could also use the following command to list all the volumes available in your region. Either way, make sure that `file_system_id` is set. 
-```
+```bash
 aws fsx describe-file-systems --query "FileSystems[*].FileSystemId" --output text --region $CLUSTER_REGION
 ```
 
-```
+```bash
 export file_system_id=<fsx-id-to-use>
 ```
 
 2. Once you have the filesystem id, Use the following command to retrieve DNSName, and MountName values.
-```
+```bash
 export dns_name=$(aws fsx describe-file-systems --file-system-ids $file_system_id --query "FileSystems[0].DNSName" --output text --region $CLUSTER_REGION)
 
 export mount_name=$(aws fsx describe-file-systems --file-system-ids $file_system_id --query "FileSystems[0].LustreConfiguration.MountName" --output text --region $CLUSTER_REGION)
 ```
 
 3. Now edit the `fsx-for-lustre/static-provisioning/pv.yaml` to replace <file_system_id>, <dns_name>, and <mount_name> with your values.
-```
+```bash
 yq e '.spec.csi.volumeHandle = env(file_system_id)' -i $GITHUB_STORAGE_DIR/fsx-for-lustre/static-provisioning/pv.yaml
 yq e '.spec.csi.volumeAttributes.dnsname = env(dns_name)' -i $GITHUB_STORAGE_DIR/fsx-for-lustre/static-provisioning/pv.yaml
 yq e '.spec.csi.volumeAttributes.mountname = env(mount_name)' -i $GITHUB_STORAGE_DIR/fsx-for-lustre/static-provisioning/pv.yaml
 ```
 
 4. The `PersistentVolume` is a cluster scoped resource but the `PersistentVolumeClaim` needs to be in the namespace you will be accessing it from. Replace the `kubeflow-user-example-com` namespace specified the below with the namespace for your kubeflow user and edit the `fsx-for-lustre/static-provisioning/pvc.yaml` file accordingly. 
-```
+```bash
 yq e '.spec.volumeName = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/fsx-for-lustre/static-provisioning/pvc.yaml
 yq e '.metadata.name = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/fsx-for-lustre/static-provisioning/pvc.yaml
 yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i $GITHUB_STORAGE_DIR/fsx-for-lustre/static-provisioning/pvc.yaml
 ```
 
 5. Now create the required `PersistentVolume` and `PersistentVolumeClaim` resources as -
-```
+```bash
 kubectl apply -f $GITHUB_STORAGE_DIR/fsx-for-lustre/static-provisioning/pv.yaml
 kubectl apply -f $GITHUB_STORAGE_DIR/fsx-for-lustre/static-provisioning/pvc.yaml
 ```
 
 ### 2.3 Check your setup 
 Use the following commands to ensure all resources have been deployed as expected and the PersistentVolume is correctly bound to the PersistentVolumeClaim
-```
+```bash
 kubectl get pv
 
 NAME    CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                 STORAGECLASS   REASON   AGE
 fsx-pv  1200Gi     RWX            Recycle          Bound    kubeflow-user-example-com/fsx-claim                           11s
 ```
 
-```
+```bash
 kubectl get pvc -n $PVC_NAMESPACE
 
 NAME        STATUS   VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   AGE
@@ -187,7 +187,7 @@ For more details on how to access your Kubeflow dashboard, refer to one of the [
 ### 3.2 Note about permissions
 This step may not be necessary but you might need to specify some additional directory permissions on your worker node before you can use these as mount points. By default, new Amazon FSx file systems are owned by root:root, and only the root user (UID 0) has read-write-execute permissions. If your containers are not running as root, you must change the Amazon FSx file system permissions to allow other users to modify the file system. The set-permission-job.yaml is an example of how you could set these permissions to be able to use the fsx as your workspace in your kubeflow notebook. Modify it accordingly if you run into similar permission issues with any other job pod. 
 
-```
+```bash
 yq e '.metadata.name = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
 yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
 yq e '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName = env(CLAIM_NAME)' -i $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
@@ -210,7 +210,7 @@ Note: The following steps are run from the terminal on your gateway node connect
 
 ### 1. Download the dataset to the FSx Volume 
 In the Kubeflow Notebook created above, use the following snippet to download the data into the `/home/jovyan/.keras` directory (which is mounted onto the FSx Volume). 
-```
+```bash
 import pathlib
 import tensorflow as tf
 dataset_url = "https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz"
@@ -222,7 +222,7 @@ data_dir = pathlib.Path(data_dir)
 
 ### 2. Build and push the Docker image
 In the `training-sample` directory, we have provided a sample training script and Dockerfile which you can use as follows to build a docker image. Be sure to point the `$IMAGE_URI` to your registry and specify an appropriate tag:
-```
+```bash
 export IMAGE_URI=<dockerimage:tag>
 cd training-sample
 
@@ -234,27 +234,27 @@ cd -
 
 ### 3. Configure the TFjob spec file
 Once the docker image is built, replace the `<dockerimage:tag>` in the `tfjob.yaml` file, line #17. 
-```
+```bash
 yq e '.spec.tfReplicaSpecs.Worker.template.spec.containers[0].image = env(IMAGE_URI)' -i training-sample/tfjob.yaml
 ```
 Also, specify the name of the PVC you created:
-```
+```bash
 export CLAIM_NAME=fsx-claim
 yq e '.spec.tfReplicaSpecs.Worker.template.spec.volumes[0].persistentVolumeClaim.claimName = env(CLAIM_NAME)' -i training-sample/tfjob.yaml
 ```
 Make sure to run it in the same namespace as the claim:
-```
+```bash
 yq e '.metadata.namespace = env(PVC_NAMESPACE)' -i training-sample/tfjob.yaml
 ```
 
 ### 4. Create the TFjob and use the provided commands to check the training logs 
 At this point, we are ready to train the model using the `training-sample/training.py` script and the data available on the shared volume with the Kubeflow TFJob operator.
-```
+```bash
 kubectl apply -f training-sample/tfjob.yaml
 ```
 
 In order to check that the training job is running as expected, you can check the events in the TFJob describe response as well as the job logs.
-```
+```bash
 kubectl describe tfjob image-classification-pvc -n $PVC_NAMESPACE
 kubectl logs -n $PVC_NAMESPACE image-classification-pvc-worker-0 -f
 ```
@@ -263,27 +263,27 @@ kubectl logs -n $PVC_NAMESPACE image-classification-pvc-worker-0 -f
 This section cleans up the resources created in this guide. To clean up other resources, such as the Kubeflow deployment, see [Uninstall Kubeflow](/kubeflow-manifests/docs/deployment/uninstall-kubeflow/).
 
 ### 4.1 Clean up the TFJob
-```
+```bash
 kubectl delete tfjob -n $PVC_NAMESPACE image-classification-pvc
 ```
 
 ### 4.2 Delete the Kubeflow Notebook
 Log in to the dashboard to stop and/or terminate any Kubeflow Notebooks that you created for this session or use the following commands: 
-```
+```bash
 kubectl delete notebook -n $PVC_NAMESPACE <notebook-name>
 ``` 
-```
+```bash
 kubectl delete pod -n $PVC_NAMESPACE $CLAIM_NAME
 ```
 
 ### 4.3 Delete PVC, PV, and SC in the following order
-```
+```bash
 kubectl delete pvc -n $PVC_NAMESPACE $CLAIM_NAME
 kubectl delete pv fsx-pv
 ```
 
 ### 4.4 Delete the FSx filesystem
-```
+```bash
 aws fsx delete-file-system --file-system-id $file_system_id
 ```
 Make sure to delete any other resources that you have created such as security groups via the AWS Console or using the AWS CLI. 

--- a/website/content/en/docs/deployment/add-ons/storage/fsx-for-lustre/guide.md
+++ b/website/content/en/docs/deployment/add-ons/storage/fsx-for-lustre/guide.md
@@ -210,7 +210,7 @@ Note: The following steps are run from the terminal on your gateway node connect
 
 ### 1. Download the dataset to the FSx Volume 
 In the Kubeflow Notebook created above, use the following snippet to download the data into the `/home/jovyan/.keras` directory (which is mounted onto the FSx Volume). 
-```bash
+```python
 import pathlib
 import tensorflow as tf
 dataset_url = "https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz"

--- a/website/content/en/docs/deployment/cognito-rds-s3/guide.md
+++ b/website/content/en/docs/deployment/cognito-rds-s3/guide.md
@@ -26,11 +26,11 @@ Refer to the [general prerequisites guide](/kubeflow-manifests/docs/deployment/p
     1. Configure Ingress
 2. Deploy Kubeflow. Choose one of the two options to deploy kubeflow:
     1. **[Option 1]** Install with a single command:
-        ```
+        ```sh
         while ! kustomize build docs/deployment/cognito-rds-s3 | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
         ```
     1. **[Option 2]** Install individual components:
-        ```
+        ```sh
         # Kubeflow namespace
         kustomize build upstream/common/kubeflow-namespace/base | kubectl apply -f -
         

--- a/website/content/en/docs/deployment/cognito/guide-automated.md
+++ b/website/content/en/docs/deployment/cognito/guide-automated.md
@@ -14,7 +14,7 @@ This guide assumes you have Python 3.8 installed and that you have completed the
 
 1. The following steps automate [section 1.0(Custom domain and certificates)](/kubeflow-manifests/docs/deployment/cognito/guide/#10-custom-domain-and-certificates) (creating a custom domain to host Kubeflow and TLS certificates for the domain), [section 2.0(Cognito user pool)](/kubeflow-manifests/docs/deployment/cognito/guide/#20-cognito-user-pool) (creating a Cognito Userpool used for user authentication) and[section 3.0(Configure Ingress)](/kubeflow-manifests/docs/deployment/cognito/guide/#30-configure-ingress) (configuring ingress and load balancer controller manifests) of the cognito guide.
     1. Install dependencies for the scripts
-        ```
+        ```sh
         pip install -r tests/e2e/requirements.txt
         ```
     1. Substitute values in `tests/e2e/utils/cognito_bootstrap/config.yaml`.
@@ -24,7 +24,7 @@ This guide assumes you have Python 3.8 installed and that you have completed the
         1. Cluster name and region where kubeflow will be deployed in `cluster.name` and `cluster.region` (e.g. us-west-2) respectively.
         1. Name of cognito userpool in `cognitoUserpool.name` e.g. kubeflow-users.
         1. The config file will look something like:
-            1. ```
+            1. ```yaml
                 cognitoUserpool:
                     name: kubeflow-users
                 cluster:
@@ -38,13 +38,13 @@ This guide assumes you have Python 3.8 installed and that you have completed the
                         name: platform.example.com
                 ```
     1. Run the script to create the resources
-        1. ```
+        1. ```sh
             cd tests/e2e
             PYTHONPATH=.. python utils/cognito_bootstrap/cognito_pre_deployment.py
             cd -
             ```
     1. The script will update the config file with the resource names/ids/ARNs it created. It will look something like:
-        1. ```
+        1. ```yaml
             cognitoUserpool:
                 ARN: arn:aws:cognito-idp:us-west-2:123456789012:userpool/us-west-2_yasI9dbxF
                 appClientId: 5jmk7ljl2a74jk3n0a0fvj3l31
@@ -76,7 +76,7 @@ This guide assumes you have Python 3.8 installed and that you have completed the
 
 1. Updating the domain with ALB address
     1. Check if ALB is provisioned. It takes around 3-5 minutes
-        1. ```
+        1. ```sh
             kubectl get ingress -n istio-system
             Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
             NAME            CLASS    HOSTS   ADDRESS                                                                  PORTS   AGE
@@ -84,7 +84,7 @@ This guide assumes you have Python 3.8 installed and that you have completed the
             ```
         2. If `ADDRESS` is empty after a few minutes, check the logs of alb-ingress-controller by following [this guide](/kubeflow-manifests/docs/troubleshooting-aws/#alb-fails-to-provision)
     1. Substitute the ALB address under `kubeflow.alb.dns` in `tests/e2e/utils/cognito_bootstrap/config.yaml`. The kubeflow section of the config file will look like:
-        1. ```
+        1. ```yaml
             kubeflow:
                 alb:
                     dns: ebde55ee-istiosystem-istio-2af2-1100502020.us-west-2.elb.amazonaws.com
@@ -93,7 +93,7 @@ This guide assumes you have Python 3.8 installed and that you have completed the
                         policyArn: arn:aws:iam::123456789012:policy/alb_ingress_controller_kube-eks-clusterxxx
             ```
     1. Run the following script to update the subdomain with ALB address
-        1. ```
+        1. ```sh
             cd tests/e2e
             PYTHONPATH=.. python utils/cognito_bootstrap/cognito_post_deployment.py
             cd -

--- a/website/content/en/docs/deployment/rds-s3/guide.md
+++ b/website/content/en/docs/deployment/rds-s3/guide.md
@@ -50,7 +50,7 @@ To install for both RDS and S3, complete all the steps below.
 Follow the steps in [Prerequisites](/kubeflow-manifests/docs/deployment/prerequisites/) to make sure that you have everything you need to get started. 
 
 1. Verify that you are in the root of your repository by running the `pwd` command. The path should be <PATH/kubeflow-manifests>:
-  ```
+  ```bash
   pwd 
   ```
 
@@ -81,7 +81,7 @@ pip install -r requirements.txt
 ```
 3. [Create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_cliwpsapi) with permissions to get bucket locations and allow read and write access to objects in an S3 bucket where you want to store the Kubeflow artifacts. Take note of the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` of the IAM user that you created to use in the following step.
 4. Export values for `CLUSTER_REGION`, `CLUSTER_NAME`, `S3_BUCKET`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`. Then, run the `auto-rds-s3-setup.py` script.
-```
+```bash
 export CLUSTER_REGION=
 export CLUSTER_NAME=
 export S3_BUCKET=
@@ -376,6 +376,6 @@ cd tests/e2e
 pip install -r requirements.txt
 ```
 3. Make sure that you have the configuration file created by the script in `tests/e2e/utils/rds-s3/metadata.yaml`.
-```
+```bash
 PYTHONPATH=.. python utils/rds-s3/auto-rds-s3-cleanup.py
 ```  

--- a/website/layouts/partials/hooks/body-end.html
+++ b/website/layouts/partials/hooks/body-end.html
@@ -1,0 +1,5 @@
+{{ if (findRE "<pre" .Content 1) }}
+{{ $jsCopy := resources.Get "js/copy-code-button.js" | minify }}
+<script src="{{ $jsCopy.RelPermalink }}"></script>
+{{ end }}
+

--- a/website/layouts/partials/hooks/head-end.html
+++ b/website/layouts/partials/hooks/head-end.html
@@ -1,0 +1,7 @@
+{{ if (findRE "<pre" .Content 1) }}
+    {{ $syntax := resources.Get "css/syntax.css" | minify }}
+    <link href="{{ $syntax.RelPermalink }}" rel="stylesheet">
+
+    {{ $copyCss := resources.Get "css/copy-code-button.css" | minify }}
+    <link href="{{ $copyCss.RelPermalink }}" rel="stylesheet">
+{{ end }}


### PR DESCRIPTION
Added copy button to code samples for the Kubeflow on AWS website.

This button requires that all code samples have a code language identifier in markdown. I went through and added missing code language identifiers as well. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.