### PR TITLE
Minor fixes

### DIFF
--- a/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
+++ b/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
@@ -18,6 +18,7 @@ from e2e.utils.utils import (
     write_yaml_file,
     load_yaml_file,
     wait_for,
+    WaitForCircuitBreakerError
 )
 
 from shutil import which
@@ -295,7 +296,7 @@ def wait_for_rds_db_instance_to_become_available(rds_client):
             DBInstanceIdentifier=DB_INSTANCE_NAME
         )["DBInstances"][0]["DBInstanceStatus"]
         if status == "failed":
-            raise Exception(
+            raise WaitForCircuitBreakerError(
                 "An unexpected error occurred while waiting for the RDS DB instance to become available!"
             )
         assert status == "available"
@@ -400,11 +401,7 @@ def setup_kubeflow_pipeline():
     print("Setting up Kubeflow Pipeline...")
 
     print("Retrieving DB instance info...")
-    try:
-        db_instance_info = get_db_instance_info()
-    except get_rds_client(CLUSTER_REGION).exceptions.DBInstanceNotFoundFault:
-        print("Could not retrieve DB instance info, aborting Kubeflow pipeline setup!")
-        return
+    db_instance_info = get_db_instance_info()
 
     pipeline_rds_params_env_file = "../../awsconfigs/apps/pipeline/rds/params.env"
     pipeline_rds_secret_provider_class_file = (

--- a/website/content/en/docs/component-guides/katib.md
+++ b/website/content/en/docs/component-guides/katib.md
@@ -183,9 +183,9 @@ After installing Kubeflow on AWS with one of the available [deployment options](
                      - "python3"
                      - "/opt/mxnet-mnist/mnist.py"
                      - "--batch-size=64"
-                     - "--lr=${trialParameters.learningRate}"
-                     - "--num-layers=${trialParameters.numberLayers}"
-                     - "--optimizer=${trialParameters.optimizer}"
+                     - "--lr=\${trialParameters.learningRate}"
+                     - "--num-layers=\${trialParameters.numberLayers}"
+                     - "--optimizer=\${trialParameters.optimizer}"
                restartPolicy: Never
    EOF
    ```

--- a/website/content/en/docs/component-guides/profiles.md
+++ b/website/content/en/docs/component-guides/profiles.md
@@ -52,6 +52,7 @@ After installing Kubeflow on AWS with one of the available [deployment options](
    export CLUSTER_REGION=<your region>
    export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
    export PROFILE_NAME=<the name of the profile to be created>
+   export PROFILE_CONTROLLER_POLICY_NAME=<the name of the profile controller policy to be created>
    ```
 
 2. Create an IAM policy using the [IAM Profile controller policy](https://github.com/awslabs/kubeflow-manifests/blob/main/awsconfigs/infra_configs/iam_profile_controller_policy.json) file.
@@ -59,7 +60,7 @@ After installing Kubeflow on AWS with one of the available [deployment options](
    ```bash
    aws iam create-policy \
    --region $CLUSTER_REGION \
-   --policy-name kf-profile-controller-policy \
+   --policy-name ${PROFILE_CONTROLLER_POLICY_NAME} \
    --policy-document file://awsconfigs/infra_configs/iam_profile_controller_policy.json
    ```
 
@@ -80,7 +81,7 @@ After installing Kubeflow on AWS with one of the available [deployment options](
    --cluster=$CLUSTER_NAME \
    --name="profiles-controller-service-account" \
    --namespace=kubeflow \
-   --attach-policy-arn="arn:aws:iam::${AWS_ACCOUNT_ID}:policy/kf-profile-controller-policy" \
+   --attach-policy-arn="arn:aws:iam::${AWS_ACCOUNT_ID}:policy/${PROFILE_CONTROLLER_POLICY_NAME}" \
    --region=$CLUSTER_REGION \
    --override-existing-serviceaccounts \
    --approve

--- a/website/content/en/docs/deployment/rds-s3/guide.md
+++ b/website/content/en/docs/deployment/rds-s3/guide.md
@@ -49,15 +49,11 @@ To install for both RDS and S3, complete all the steps below.
 ## 1.0 Prerequisites
 Follow the steps in [Prerequisites](/kubeflow-manifests/docs/deployment/prerequisites/) to make sure that you have everything you need to get started. 
 
-1. Verify that you are in the root of your repository by running the `pwd` command. The path should be <PATH/kubeflow-manifests>:
-  ```bash
-  pwd 
-  ```
-
-4. Create an OIDC provider for your cluster .
-
-   **Important :**  
-   You must make sure you have an [OIDC provider](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) for your cluster and that it was added from `eksctl` >= `0.56`. If you already have an OIDC provider in place, then you must make sure you have the tag `alpha.eksctl.io/cluster-name` with the cluster name as its value. If you don't have the tag, you can add it via the AWS Console by navigating to IAM->Identity providers->Your OIDC->Tags.
+Make sure you are starting from the repository root directory. 
+Export the below variable:
+```bash
+export REPO_ROOT=$(pwd)
+```
 
 ## 2.0 Set up RDS, S3, and configure Secrets
 
@@ -79,16 +75,16 @@ cd tests/e2e
 ```bash
 pip install -r requirements.txt
 ```
-3. [Create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_cliwpsapi) with permissions to get bucket locations and allow read and write access to objects in an S3 bucket where you want to store the Kubeflow artifacts. Take note of the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` of the IAM user that you created to use in the following step.
-4. Export values for `CLUSTER_REGION`, `CLUSTER_NAME`, `S3_BUCKET`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`. Then, run the `auto-rds-s3-setup.py` script.
+3. [Create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_cliwpsapi) with permissions to get bucket locations and allow read and write access to objects in an S3 bucket where you want to store the Kubeflow artifacts. Take note of the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` of the IAM user that you created to use in the following step, which will be referenced as `MINIO_AWS_ACCESS_KEY_ID` and `MINIO_AWS_SECRET_ACCESS_KEY` respectively.
+4. Export values for `CLUSTER_REGION`, `CLUSTER_NAME`, `S3_BUCKET`, `MINIO_AWS_ACCESS_KEY_ID`, and `MINIO_AWS_SECRET_ACCESS_KEY`. Then, run the `auto-rds-s3-setup.py` script.
 ```bash
 export CLUSTER_REGION=
 export CLUSTER_NAME=
 export S3_BUCKET=
-export AWS_ACCESS_KEY_ID=
-export AWS_SECRET_ACCESS_KEY=
+export MINIO_AWS_ACCESS_KEY_ID=
+export MINIO_AWS_SECRET_ACCESS_KEY=
 
-PYTHONPATH=.. python utils/rds-s3/auto-rds-s3-setup.py --region $CLUSTER_REGION --cluster $CLUSTER_NAME --bucket $S3_BUCKET --s3_aws_access_key_id $AWS_ACCESS_KEY_ID --s3_aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+PYTHONPATH=.. python utils/rds-s3/auto-rds-s3-setup.py --region $CLUSTER_REGION --cluster $CLUSTER_NAME --bucket $S3_BUCKET --s3_aws_access_key_id $MINIO_AWS_ACCESS_KEY_ID --s3_aws_secret_access_key $MINIO_AWS_SECRET_ACCESS_KEY
 ```  
 
 ### Advanced customization
@@ -246,18 +242,21 @@ Once you have the resources ready, you can deploy the Kubeflow manifests for one
 
 Use the following command to deploy the Kubeflow manifests for both RDS and S3:
 ```sh
+cd $REPO_ROOT  # exported in 1.1 Prerequisites
 while ! kustomize build deployment/rds-s3 | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
 ```
 
 #### [RDS] Deploy RDS only
 Use the following command to deploy the Kubeflow manifests for RDS only:
 ```sh
+cd $REPO_ROOT  # exported in 1.1 Prerequisites
 while ! kustomize build deployment/rds-s3/rds-only | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
 ```
 
 #### [S3] Deploy S3 only
 Use the following command to deploy the Kubeflow manifests for S3 only:
 ```sh
+cd $REPO_ROOT  # exported in 1.1 Prerequisites
 while ! kustomize build deployment/rds-s3/s3-only | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
 ```
 


### PR DESCRIPTION
- Fixed an issue where unsuccessful RDS DB creation would not terminate the script and would falsely print a success message
- Added a short circuit to the wait loop for RDS DB instantiation to terminate when the DB instance creation status reaches `failed`
- Fixed an issue where the sample `experiment.yaml` in the Katib Profile IRSA setup instructions had incorrect formatting
- Added the `PROFILE_CONTROLLER_POLICY_NAME` env variable to the Profile IRSA setup instructions to allow specifying the name of the profile controller policy to be created
- Added a step to change directory to the repository root before running the RDS/S3 `kustomize` build and apply step


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.