### PR TITLE
Added support for non-root EFS files ownership

### DIFF
--- a/deployments/add-ons/storage/efs/dynamic-provisioning/sc.yaml
+++ b/deployments/add-ons/storage/efs/dynamic-provisioning/sc.yaml
@@ -7,6 +7,8 @@ mountOptions:
   - tls
 parameters:
   directoryPerms: '700'
+  gid: <YOUR_GID>
+  uid: <YOUR_UID>
   fileSystemId: <YOUR_FILE_SYSTEM_ID>
   provisioningMode: efs-ap
 provisioner: efs.csi.aws.com

--- a/deployments/add-ons/storage/efs/dynamic-provisioning/sc.yaml
+++ b/deployments/add-ons/storage/efs/dynamic-provisioning/sc.yaml
@@ -7,8 +7,8 @@ mountOptions:
   - tls
 parameters:
   directoryPerms: '700'
-  gid: <YOUR_GID>
-  uid: <YOUR_UID>
+  gid: '100'
+  uid: '1000'
   fileSystemId: <YOUR_FILE_SYSTEM_ID>
   provisioningMode: efs-ap
 provisioner: efs.csi.aws.com

--- a/tests/e2e/utils/auto-efs-setup.py
+++ b/tests/e2e/utils/auto-efs-setup.py
@@ -149,7 +149,7 @@ def create_efs_iam_policy():
 
 
 def get_efs_iam_policy_document():
-    url = "https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v1.3.6/docs/iam-policy-example.json"
+    url = "https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v1.4.0/docs/iam-policy-example.json"
     response = urllib.request.urlopen(url)
     data = response.read()
     return data.decode("utf-8")
@@ -197,7 +197,7 @@ def install_efs_driver():
     print("Installing EFS driver...")
 
     kubectl_kustomize_apply(
-        "https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v1.3.6"
+        "https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v1.4.0"
     )
 
     print("EFS driver installed!")

--- a/tests/e2e/utils/auto-efs-setup.py
+++ b/tests/e2e/utils/auto-efs-setup.py
@@ -498,6 +498,8 @@ def edit_dynamic_provisioning_storage_class_fields(
     print("Editing storage class with appropriate values...")
 
     storage_class_file_yaml_content["parameters"]["fileSystemId"] = file_system_id
+    storage_class_file_yaml_content["parameters"]["gid"] = str(EFS_GID)
+    storage_class_file_yaml_content["parameters"]["uid"] = str(EFS_UID)
 
     with open(EFS_DYNAMIC_PROVISIONING_STORAGE_CLASS_FILE_PATH, "w") as file:
         file.write(yaml.dump(storage_class_file_yaml_content))
@@ -573,6 +575,22 @@ parser.add_argument(
     help=f"Default is set to {EFS_THROUGHPUT_MODE_DEFAULT}",
     required=False,
 )
+EFS_GID_DEFAULT = 100
+parser.add_argument(
+    "--efs_gid",
+    type=int,
+    default=EFS_GID_DEFAULT,
+    help=f"POSIX group Id to be applied for Access Point root directory creation. Default is set to {EFS_GID_DEFAULT}",
+    required=False,
+)
+EFS_UID_DEFAULT = 1000
+parser.add_argument(
+    "--efs_uid",
+    type=int,
+    default=EFS_UID_DEFAULT,
+    help=f"POSIX user Id to be applied for Access Point root directory creation. Default is set to {EFS_UID_DEFAULT}",
+    required=False,
+)
 DEFAULT_DIRECTORY_PATH = ""
 parser.add_argument(
     "--directory",
@@ -591,6 +609,8 @@ if __name__ == "__main__":
     EFS_SECURITY_GROUP_NAME = args.efs_security_group_name
     EFS_FILE_SYSTEM_PERFORMANCE_MODE = args.efs_performance_mode
     EFS_FILE_SYSTEM_THROUGHPUT_MODE = args.efs_throughput_mode
+    EFS_GID = args.efs_gid
+    EFS_UID = args.efs_uid
     DIRECTORY_PATH = args.directory
 
     AWS_ACCOUNT_ID = boto3.client("sts").get_caller_identity()["Account"]

--- a/website/content/en/docs/deployment/add-ons/storage/efs/guide.md
+++ b/website/content/en/docs/deployment/add-ons/storage/efs/guide.md
@@ -239,10 +239,12 @@ yq e '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName = env(CLAIM
 kubectl apply -f $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
 ```
 
-#### Automated setup default EFS owner  
-The automated setup sets the default Kubeflow Notebook user (Jovyan) as owner of the EFS file system by default.  
-You can always change the `uid` and `gid` used for the setup by passing different parameters to the script.  
-See [Advanced Customization](#advanced-customization) for more details on the different parameters that are available.
+#### Dynamic provisioning  default owner 
+For dynamic provisioning (manual and automated setup), we already set the default Kubeflow Notebook user (Jovyan) as owner of the EFS file system by default.    
+##### Changing the default values
+You can always change the `uid` and `gid` used for the setup.  
+For the manual setup, you need to edit the `uid` and `gid` in the storage class inside `dynamic-provisioning/sc.yaml`.    
+For the automated setup, you can specify the `uid` and `gid` as arguments to the script, see [Advanced Customization](#advanced-customization) for more details on the different parameters that are available.  
 
 ### 3.4 Use existing EFS volume as workspace or data volume for a Notebook
 

--- a/website/content/en/docs/deployment/add-ons/storage/efs/guide.md
+++ b/website/content/en/docs/deployment/add-ons/storage/efs/guide.md
@@ -239,6 +239,11 @@ yq e '.spec.template.spec.volumes[0].persistentVolumeClaim.claimName = env(CLAIM
 kubectl apply -f $GITHUB_STORAGE_DIR/notebook-sample/set-permission-job.yaml
 ```
 
+#### Automated setup default EFS owner  
+The automated setup sets the default Kubeflow Notebook user (Jovyan) as owner of the EFS file system by default.  
+You can always change the `uid` and `gid` used for the setup by passing different parameters to the script.  
+See [Advanced Customization](#advanced-customization) for more details on the different parameters that are available.
+
 ### 3.4 Use existing EFS volume as workspace or data volume for a Notebook
 
 Spin up a new Kubeflow notebook server and specify the name of the PVC to be used as the workspace volume or the data volume and specify your desired mount point. We'll assume you created a PVC with the name `efs-claim` via Kubeflow Volumes UI or via the manual setup step [Static Provisioning](#4-option-2-static-provisioning). For our example here, we are using the AWS Optimized Tensorflow 2.6 CPU image provided in the Notebook configuration options (`public.ecr.aws/c9e4w0g3/notebook-servers/jupyter-tensorflow`). Additionally, use the existing `efs-claim` volume as the workspace volume at the default mount point `/home/jovyan`. The server might take a few minutes to come up. 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #267 

**Description of your changes:**
Added `uid` & `gid` parameters for the automated script to setup EFS for non-root user.

**Testing:**
- [x] Tested read/write of volumes on vanilla kubeflow 1.4.1 using `v1.4.1-aws-b1.0.0` on a new eks cluster. 
- [x] Tested read/write of volumes on vanilla kubeflow 1.5.1 using latest main (https://github.com/awslabs/kubeflow-manifests/commit/5d348d4a6cea3f8f0a8c21cfff97bb5e32e46e0f) on a new eks cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.