### PR TITLE
Minor improvements: Path fixes, increase time in while loop, cognito guide cleanup

### DIFF
--- a/tests/e2e/fixtures/kustomize.py
+++ b/tests/e2e/fixtures/kustomize.py
@@ -17,7 +17,7 @@ def apply_kustomize(path):
     """
     Equivalent to:
 
-    while ! kustomize build <PATH> | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+    while ! kustomize build <PATH> | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 30; done
 
     but creates a temporary file instead of piping.
     """

--- a/website/content/en/docs/deployment/add-ons/load-balancer/guide.md
+++ b/website/content/en/docs/deployment/add-ons/load-balancer/guide.md
@@ -121,7 +121,7 @@ Set up resources required for the Load Balancer controller:
 ### Build Manifests and deploy components
 Run the following command to build and install the components specified in the Load Balancer [kustomize](https://github.com/awslabs/kubeflow-manifests/blob/main/deployments/add-ons/load-balancer/kustomization.yaml) file.
 ```bash
-while ! kustomize build deployments/add-ons/load-balancer | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+while ! kustomize build deployments/add-ons/load-balancer | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 30; done
 ```
 
 ### Update the domain with ALB address

--- a/website/content/en/docs/deployment/cognito-rds-s3/guide.md
+++ b/website/content/en/docs/deployment/cognito-rds-s3/guide.md
@@ -27,7 +27,7 @@ Refer to the [general prerequisites guide](/kubeflow-manifests/docs/deployment/p
 2. Deploy Kubeflow. Choose one of the two options to deploy kubeflow:
     1. **[Option 1]** Install with a single command:
         ```sh
-        while ! kustomize build deployments/cognito-rds-s3 | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+        while ! kustomize build deployments/cognito-rds-s3 | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 30; done
         ```
     1. **[Option 2]** Install individual components:
         ```sh
@@ -38,9 +38,9 @@ Refer to the [general prerequisites guide](/kubeflow-manifests/docs/deployment/p
         kustomize build upstream/common/kubeflow-roles/base | kubectl apply -f -
         
         # Istio
-        kustomize build upstream/common/istio-1-9/istio-crds/base | kubectl apply -f -
-        kustomize build upstream/common/istio-1-9/istio-namespace/base | kubectl apply -f -
-        kustomize build upstream/common/istio-1-9/istio-install/base | kubectl apply -f -
+        kustomize build upstream/common/istio-1-11/istio-crds/base | kubectl apply -f -
+        kustomize build upstream/common/istio-1-11/istio-namespace/base | kubectl apply -f -
+        kustomize build upstream/common/istio-1-11/istio-install/base | kubectl apply -f -
 
         # Cert-Manager
         kustomize build upstream/common/cert-manager/cert-manager/base | kubectl apply -f -
@@ -49,10 +49,10 @@ Refer to the [general prerequisites guide](/kubeflow-manifests/docs/deployment/p
         # KNative
         kustomize build upstream/common/knative/knative-serving/overlays/gateways | kubectl apply -f -
         kustomize build upstream/common/knative/knative-eventing/base | kubectl apply -f -
-        kustomize build upstream/common/istio-1-9/cluster-local-gateway/base | kubectl apply -f -
+        kustomize build upstream/common/istio-1-11/cluster-local-gateway/base | kubectl apply -f -
         
         # Kubeflow Istio Resources
-        kustomize build upstream/common/istio-1-9/kubeflow-istio-resources/base | kubectl apply -f -
+        kustomize build upstream/common/istio-1-11/kubeflow-istio-resources/base | kubectl apply -f -
         
         # KServe
         kustomize build awsconfigs/apps/kserve | kubectl apply -f -

--- a/website/content/en/docs/deployment/cognito/guide.md
+++ b/website/content/en/docs/deployment/cognito/guide.md
@@ -217,4 +217,4 @@ From this point onwards, we will be creating/updating the DNS records **only in 
 
 ## 7.0 Uninstall Kubeflow
 
-To delete the resources created in this guide, refer to the [Uninstall section in Automated Cognito deployment guide](/kubeflow-manifests/docs/deployment/cognito/guide-automated/#uninstall-kubeflow)
+To delete the resources created in this guide, refer to the [Uninstall section in Automated Cognito deployment guide]({{< ref "/docs/deployment/cognito/guide-automated.md#uninstall-kubeflow" >}})

--- a/website/content/en/docs/deployment/cognito/guide.md
+++ b/website/content/en/docs/deployment/cognito/guide.md
@@ -99,7 +99,7 @@ From this point onwards, we will be creating/updating the DNS records **only in 
 1. Choose one of the two options to deploy kubeflow:
     1. **[Option 1]** Install with a single command:
         ```bash
-        while ! kustomize build deployments/cognito | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+        while ! kustomize build deployments/cognito | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 30; done
         ```
     1. **[Option 2]** Install individual components:
         ```bash
@@ -110,9 +110,9 @@ From this point onwards, we will be creating/updating the DNS records **only in 
         kustomize build upstream/common/kubeflow-roles/base | kubectl apply -f -
         
         # Istio
-        kustomize build upstream/common/istio-1-9/istio-crds/base | kubectl apply -f -
-        kustomize build upstream/common/istio-1-9/istio-namespace/base | kubectl apply -f -
-        kustomize build upstream/common/istio-1-9/istio-install/base | kubectl apply -f -
+        kustomize build upstream/common/istio-1-11/istio-crds/base | kubectl apply -f -
+        kustomize build upstream/common/istio-1-11/istio-namespace/base | kubectl apply -f -
+        kustomize build upstream/common/istio-1-11/istio-install/base | kubectl apply -f -
         
         # Cert-Manager
         kustomize build upstream/common/cert-manager/cert-manager/base | kubectl apply -f -
@@ -121,10 +121,10 @@ From this point onwards, we will be creating/updating the DNS records **only in 
         # KNative
         kustomize build upstream/common/knative/knative-serving/overlays/gateways | kubectl apply -f -
         kustomize build upstream/common/knative/knative-eventing/base | kubectl apply -f -
-        kustomize build upstream/common/istio-1-9/cluster-local-gateway/base | kubectl apply -f -
+        kustomize build upstream/common/istio-1-11/cluster-local-gateway/base | kubectl apply -f -
         
         # Kubeflow Istio Resources
-        kustomize build upstream/common/istio-1-9/kubeflow-istio-resources/base | kubectl apply -f -
+        kustomize build upstream/common/istio-1-11/kubeflow-istio-resources/base | kubectl apply -f -
         
         # Kubeflow Pipelines
         # reapply manifest if you see an error
@@ -214,3 +214,7 @@ From this point onwards, we will be creating/updating the DNS records **only in 
             ```
 1. Open the central dashboard at `https://kubeflow.platform.example.com`. It will redirect to Cognito for login. Use the credentials of the user that you just created a Profile for in previous step.
 > Note: It might a few minutes for DNS changes to propagate and for your URL to work. Check if the DNS entry propogated with the [Google Admin Toolbox](https://toolbox.googleapps.com/apps/dig/#CNAME/)
+
+## 7.0 Uninstall Kubeflow
+
+To delete the resources created in this guide, refer to the [Uninstall section in Automated Cognito deployment guide](/kubeflow-manifests/docs/deployment/cognito/guide-automated/#uninstall-kubeflow)

--- a/website/content/en/docs/deployment/rds-s3/guide.md
+++ b/website/content/en/docs/deployment/rds-s3/guide.md
@@ -243,21 +243,21 @@ Once you have the resources ready, you can deploy the Kubeflow manifests for one
 Use the following command to deploy the Kubeflow manifests for both RDS and S3:
 ```sh
 cd $REPO_ROOT  # exported in 1.1 Prerequisites
-while ! kustomize build deployments/rds-s3 | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+while ! kustomize build deployments/rds-s3 | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 30; done
 ```
 
 #### [RDS] Deploy RDS only
 Use the following command to deploy the Kubeflow manifests for RDS only:
 ```sh
 cd $REPO_ROOT  # exported in 1.1 Prerequisites
-while ! kustomize build deployments/rds-s3/rds-only | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+while ! kustomize build deployments/rds-s3/rds-only | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 30; done
 ```
 
 #### [S3] Deploy S3 only
 Use the following command to deploy the Kubeflow manifests for S3 only:
 ```sh
 cd $REPO_ROOT  # exported in 1.1 Prerequisites
-while ! kustomize build deployments/rds-s3/s3-only | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+while ! kustomize build deployments/rds-s3/s3-only | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 30; done
 ```
 
 Once everything is installed successfully, you can access the Kubeflow Central Dashboard [by logging in to your cluster](/kubeflow-manifests/docs/deployment/vanilla/guide/#connect-to-your-kubeflow-cluster).

--- a/website/content/en/docs/deployment/vanilla/guide.md
+++ b/website/content/en/docs/deployment/vanilla/guide.md
@@ -36,7 +36,7 @@ Option 2 targets customization and ability to pick and choose individual compone
 You can install all Kubeflow official components (residing under `apps`) and all common services (residing under `common`) using the following command:
 
 ```sh
-while ! kustomize build deployments/vanilla | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+while ! kustomize build deployments/vanilla | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 30; done
 ```
 
 Once everything is installed successfully, you can access the Kubeflow Central Dashboard [by logging into your cluster](#connect-to-your-kubeflow-cluster).
@@ -73,9 +73,9 @@ network authorization, and implement routing policies.
 Install Istio:
 
 ```sh
-kustomize build upstream/common/istio-1-9/istio-crds/base | kubectl apply -f -
-kustomize build upstream/common/istio-1-9/istio-namespace/base | kubectl apply -f -
-kustomize build upstream/common/istio-1-9/istio-install/base | kubectl apply -f -
+kustomize build upstream/common/istio-1-11/istio-crds/base | kubectl apply -f -
+kustomize build upstream/common/istio-1-11/istio-namespace/base | kubectl apply -f -
+kustomize build upstream/common/istio-1-11/istio-install/base | kubectl apply -f -
 ```
 
 #### Dex
@@ -106,7 +106,7 @@ Install Knative Serving:
 
 ```sh
 kustomize build upstream/common/knative/knative-serving/base | kubectl apply -f -
-kustomize build upstream/common/istio-1-9/cluster-local-gateway/base | kubectl apply -f -
+kustomize build upstream/common/istio-1-11/cluster-local-gateway/base | kubectl apply -f -
 ```
 
 Optionally, you can install Knative Eventing, which can be used for inference request logging.
@@ -150,7 +150,7 @@ well.
 Install Istio resources:
 
 ```sh
-kustomize build upstream/common/istio-1-9/kubeflow-istio-resources/base | kubectl apply -f -
+kustomize build upstream/common/istio-1-11/kubeflow-istio-resources/base | kubectl apply -f -
 ```
 
 #### Kubeflow Pipelines


### PR DESCRIPTION
**Description of your changes:**
- Path fix for istio-1-11
- Increase sleep time for deployments to 30sec. We are certain 10 sec is not sufficiant at this point and depending on machine there can be many loops with 10 sec sleep(e.g. ec2 with good compute). Giving some time for resources to spin up will reduce the number of loops. (More inclined to make this 60 secs)
- Add clean up steps for cognito deployment. Note: It probably does not clean up everything like webhooks like in other deployments. Hopefully, this can be fixed in all deployments at once in future

**Testing:**
Verified commands do not break

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.