### PR TITLE
Copy button workaround

### DIFF
--- a/website/assets/js/copy-code-button.js
+++ b/website/assets/js/copy-code-button.js
@@ -17,7 +17,7 @@ function createCopyButton(highlightDiv) {
   
   document.querySelectorAll(".highlight").forEach((highlightDiv) => createCopyButton(highlightDiv));
   async function copyCodeToClipboard(button, highlightDiv) {
-    const codeToCopy = highlightDiv.querySelector(":last-child > .chroma > code").innerText;
+    const codeToCopy = highlightDiv.querySelector(":last-child > .chroma > code").innerText.replace(/\n\n/g,"\n");
     try {
       var result = await navigator.permissions.query({ name: "clipboard-write" });
       if (result.state == "granted" || result.state == "prompt") {


### PR DESCRIPTION
`innerText` is not working as expected and is adding one extra new line

Temporary workaround to replace double new line characters with only one 

---------------

Website has been deployed on my fork for verification : https://akartsky.github.io/kubeflow-manifests/docs/deployment/prerequisites/