### PR TITLE
add cdk support for private subnets detection

### DIFF
--- a/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
+++ b/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
@@ -232,8 +232,13 @@ def get_cluster_private_subnet_ids(eks_client, ec2_client):
     private_subnets = []
     for subnet in subnets:
         for tags in subnet["Tags"]:
+            # eksctl generated clusters
             if "SubnetPrivate" in tags["Value"]:
                 private_subnets.append(subnet)
+            # cdk generated clusters
+            if "aws-cdk:subnet-type" in tags["Key"]:
+                if "Private" in tags["Value"]:
+                    private_subnets.append(subnet)
 
     def get_subnet_id(subnet):
         return subnet["SubnetId"]


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #277

**Description of your changes:**
CDK generated EKS clusters have a different tag than eksctl generated ones, so with this change we also cover that RDS will have a subnet group of the private subnets and not fail.

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.