### PR TITLE
Fix efs and fsx auto script OIDC detection. 

### DIFF
--- a/tests/e2e/utils/auto-efs-setup.py
+++ b/tests/e2e/utils/auto-efs-setup.py
@@ -49,27 +49,11 @@ def verify_oidc_provider_prerequisite():
 
 
 def is_oidc_provider_present() -> bool:
-    iam_client = get_iam_client()
-    oidc_providers = iam_client.list_open_id_connect_providers()[
-        "OpenIDConnectProviderList"
-    ]
-
-    if len(oidc_providers) == 0:
-        return False
-
-    for oidc_provider in oidc_providers:
-        oidc_provider_tags = iam_client.get_open_id_connect_provider(
-            OpenIDConnectProviderArn=oidc_provider["Arn"]
-        )["Tags"]
-
-        if any(
-            tag["Key"] == "alpha.eksctl.io/cluster-name"
-            and tag["Value"] == CLUSTER_NAME
-            for tag in oidc_provider_tags
-        ):
-            return True
-
-    return False
+    eks_client = get_eks_client()
+    https_oidc_provider = eks_client.describe_cluster(
+        name=CLUSTER_NAME,
+    ).get('cluster').get('identity').get('oidc').get('issuer')
+    return True if "oidc" in https_oidc_provider else False
 
 
 def get_iam_client():

--- a/tests/e2e/utils/auto-efs-setup.py
+++ b/tests/e2e/utils/auto-efs-setup.py
@@ -50,10 +50,13 @@ def verify_oidc_provider_prerequisite():
 
 def is_oidc_provider_present() -> bool:
     eks_client = get_eks_client()
-    https_oidc_provider = eks_client.describe_cluster(
-        name=CLUSTER_NAME,
-    ).get('cluster').get('identity').get('oidc').get('issuer')
-    return True if "oidc" in https_oidc_provider else False
+    try:
+        https_oidc_provider = eks_client.describe_cluster(
+            name=CLUSTER_NAME,
+        ).get('cluster').get('identity').get('oidc').get('issuer')
+        return True if "oidc" in https_oidc_provider else False
+    except:
+        return False
 
 
 def get_iam_client():

--- a/tests/e2e/utils/auto-fsx-setup.py
+++ b/tests/e2e/utils/auto-fsx-setup.py
@@ -60,27 +60,11 @@ def verify_oidc_provider_prerequisite():
 
 
 def is_oidc_provider_present() -> bool:
-    iam_client = get_iam_client(CLUSTER_REGION)
-    oidc_providers = iam_client.list_open_id_connect_providers()[
-        "OpenIDConnectProviderList"
-    ]
-
-    if len(oidc_providers) == 0:
-        return False
-
-    for oidc_provider in oidc_providers:
-        oidc_provider_tags = iam_client.get_open_id_connect_provider(
-            OpenIDConnectProviderArn=oidc_provider["Arn"]
-        )["Tags"]
-
-        if any(
-            tag["Key"] == "alpha.eksctl.io/cluster-name"
-            and tag["Value"] == CLUSTER_NAME
-            for tag in oidc_provider_tags
-        ):
-            return True
-
-    return False
+    eks_client = get_eks_client(CLUSTER_REGION)
+    https_oidc_provider = eks_client.describe_cluster(
+        name=CLUSTER_NAME,
+    ).get('cluster').get('identity').get('oidc').get('issuer')
+    return True if "oidc" in https_oidc_provider else False
 
 
 def verify_eksctl_is_installed():

--- a/tests/e2e/utils/auto-fsx-setup.py
+++ b/tests/e2e/utils/auto-fsx-setup.py
@@ -61,10 +61,14 @@ def verify_oidc_provider_prerequisite():
 
 def is_oidc_provider_present() -> bool:
     eks_client = get_eks_client(CLUSTER_REGION)
-    https_oidc_provider = eks_client.describe_cluster(
-        name=CLUSTER_NAME,
-    ).get('cluster').get('identity').get('oidc').get('issuer')
-    return True if "oidc" in https_oidc_provider else False
+    try:
+        https_oidc_provider = eks_client.describe_cluster(
+            name=CLUSTER_NAME,
+        ).get('cluster').get('identity').get('oidc').get('issuer')
+        return True if "oidc" in https_oidc_provider else False
+    except:
+        print("returning False")
+        return False
 
 
 def verify_eksctl_is_installed():


### PR DESCRIPTION
**Description of your changes:**
Fix efs and fsx auto script OIDC detection. The existing code was failing to scan the Tags on the providers returned. One issue was that the existing code would scan each Provider in the account and check the tag attached to it. If the tag matched the cluster name we are looking for the method returned a True. However, one edge case this missed was in case some provided were created differently and simply do not have a Tag attached. Though this could be solved easily by putting the code into a try catch block, a better check is to directly query the cluster and see if it has an oidc attached. 
Thus made the change to both the EFS and FSx autoscripts. 

Ran both the EFS and FSx tests and they pass. 


**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.