### PR TITLE
remove extra cloudwatch-agent from pre-req command

### DIFF
--- a/website/content/en/docs/deployment/add-ons/cloudwatch/guide.md
+++ b/website/content/en/docs/deployment/add-ons/cloudwatch/guide.md
@@ -11,7 +11,7 @@ export CLUSTER_NAME=<>
 export CLUSTER_REGION=<>
 
 eksctl utils associate-iam-oidc-provider --region=$CLUSTER_REGION --cluster=$CLUSTER_NAME --approve
-eksctl create iamserviceaccount --name cloudwatch-agent --namespace amazon-cloudwatch --cluster $CLUSTER_NAME --region $CLUSTER_REGION cloudwatch-agent --approve --override-existing-serviceaccounts --attach-policy-arn arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+eksctl create iamserviceaccount --name cloudwatch-agent --namespace amazon-cloudwatch --cluster $CLUSTER_NAME --region $CLUSTER_REGION --approve --override-existing-serviceaccounts --attach-policy-arn arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
 eksctl create iamserviceaccount --name fluent-bit --namespace amazon-cloudwatch --cluster $CLUSTER_NAME --region $CLUSTER_REGION --approve --override-existing-serviceaccounts --attach-policy-arn arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
 ```
 ## Install


### PR DESCRIPTION
**Description of your changes:**

- Fixes `Error: --name=cloudwatch-agent and argument cloudwatch-agent cannot be used at the same time` where cloudwatch-agent was in the command twice.
- @jsitu777  thanks for finding this.

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.