### PR TITLE
fix notebook-crd with invalid spec

### DIFF
--- a/tests/e2e/resources/custom-resource-templates/notebook-crd.yaml
+++ b/tests/e2e/resources/custom-resource-templates/notebook-crd.yaml
@@ -20,7 +20,6 @@ spec:
           requests:
             cpu: 500m
             memory: 1Gi
-        serviceAccountName: default-editor
         volumeMounts:
         - mountPath: /home/jovyan
           name: ${NOTEBOOK_NAME}
@@ -28,6 +27,7 @@ spec:
           name: ${NOTEBOOK_NAME}-config-map
         - mountPath: /dev/shm
           name: dshm
+      serviceAccountName: default-editor
       volumes:
       - name: ${NOTEBOOK_NAME}
         persistentVolumeClaim:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

- Notebook test failing on eks 1.22 due to notebooks not being created since the yaml file was invalid.

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.