### PR TITLE
update networking-api-version and update crds

### DIFF
--- a/awsconfigs/common/istio-ingress/base/ingress.yaml
+++ b/awsconfigs/common/istio-ingress/base/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -12,6 +12,9 @@ spec:
   - http:
       paths:
       - backend:
-          serviceName: istio-ingressgateway
-          servicePort: 80
+          service:
+            name: istio-ingressgateway
+            port:
+              number: 80
         path: /*
+        pathType: ImplementationSpecific

--- a/awsconfigs/common/istio-ingress/overlays/api/ingress.yaml
+++ b/awsconfigs/common/istio-ingress/overlays/api/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: istio-ingress

--- a/awsconfigs/common/istio-ingress/overlays/api/kustomization.yaml
+++ b/awsconfigs/common/istio-ingress/overlays/api/kustomization.yaml
@@ -5,7 +5,7 @@ patchesStrategicMerge:
 patchesJson6902:
   - target:
       group: networking.k8s.io
-      version: v1beta1
+      version: v1
       kind: Ingress
       name: istio-ingress
     patch: |-

--- a/awsconfigs/common/istio-ingress/overlays/cognito/ingress.yaml
+++ b/awsconfigs/common/istio-ingress/overlays/cognito/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: istio-ingress

--- a/awsconfigs/common/istio-ingress/overlays/https/ingress.yaml
+++ b/awsconfigs/common/istio-ingress/overlays/https/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: istio-ingress

--- a/tests/e2e/utils/custom_resources.py
+++ b/tests/e2e/utils/custom_resources.py
@@ -87,7 +87,7 @@ def get_ingress(cluster, region, name="istio-ingress", namespace="istio-system")
         cluster,
         region,
         group="networking.k8s.io",
-        version="v1beta1",
+        version="v1",
         namespace=namespace,
         plural="ingresses",
         name=name,


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

**Description of your changes:**

- Update for kubernetes verison 1.22 and to support eks 1.22  updates apiVersion and follows the new spec

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.