### PR TITLE
Add minioServiceHost var substitution to rds and s3 kustomization

### DIFF
--- a/awsconfigs/apps/pipeline/kustomization.yaml
+++ b/awsconfigs/apps/pipeline/kustomization.yaml
@@ -30,3 +30,12 @@ patchesStrategicMerge:
 # when application is deleted.
 commonLabels:
   application-crd-id: kubeflow-pipelines
+vars:
+- name: kfp-artifact-storage-endpoint
+  objref:
+    kind: ConfigMap
+    name: pipeline-install-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.minioServiceHost
+


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves issue where `endpoint: $(kfp-artifact-storage-endpoint),` was not provided a value to be substituted.

**Description of your changes:**
https://github.com/awslabs/kubeflow-manifests/pull/291


**Testing:**
```
(python3_8) ubuntu@ip-172-31-38-23:~/kubeflow-manifests/tests/e2e$ pytest tests/test_rds_s3.py -s -q --region us-west-2 --accesskey <> --secretkey <>  --keepsuccess --metadata /home/ubuntu/kubeflow-manifests/tests/e2e/.metadata/metadata-1661381417815551432.json

Forwarding from 127.0.0.1:8080 -> 8080
Forwarding from [::1]:8080 -> 8080
{'region': 'us-west-2', 'cluster_name': 'e2e-test-cluster-mv7y7t84ho', 'test_rds_s3_cfn_stack': {'stack_name': 'test-e2e-rds-s3-stack-gp7jb6xgq7', 'params': {'VpcId': 'vpc-0ef7d30ecef95c013', 'Subnets': 'subnet-0743eebb433619d8f,subnet-0a355d9ce4f3fff38,subnet-0a5b4225e3861459a', 'SecurityGroupId': 'sg-0f4550df433104641', 'DBUsername': 'adminew1nzo2wty', 'DBPassword': '<>', 'S3SecretString': '{"accesskey": "<>", "secretkey": "<>"}'}}, 'kustomize_path': '../../deployments/rds-s3/'}
Created metadata file for TestRDSS3 /home/ubuntu/kubeflow-manifests/tests/e2e/.metadata/metadata-1661474968470675726.json
PASSED
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment Handling connection for 8080
Handling connection for 8080

-------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------
INFO     root:_client.py:203 Failed to automatically set namespace.
-------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------
INFO     root:_client.py:452 Creating experiment experiment-9ydc4widnp.
PASSED
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
-------------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------------
INFO     root:_client.py:452 Creating experiment experiment-6o2dk6mxtl.
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
PASSED
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment Handling connection for 8080
PASSED

=============================================================================== warnings summary ===============================================================================
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment
  /home/ubuntu/anaconda3/envs/python3_8/lib/python3.8/site-packages/mysql/connector/connection_cext.py:516: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
    self._cmysql.query(query,

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================== 4 passed, 9 warnings in 510.22s (0:08:30) ===================================================================
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.