### PR TITLE
update RDS MYSQL Version

### DIFF
--- a/tests/e2e/resources/cloudformation-templates/rds-s3.yaml
+++ b/tests/e2e/resources/cloudformation-templates/rds-s3.yaml
@@ -103,7 +103,7 @@ Resources:
       DBInstanceClass:
         Ref: DBClass
       Engine: MySQL
-      EngineVersion: "8.0.17"
+      EngineVersion: "8.0.28"
       MultiAZ:
         Ref: MultiAZ
       MasterUsername:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
RDS MySQL version has been deprecated per RDS document. Update from version 8.0.17 to 8.0.28
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html

Error Message from cfn for older MySQL version:
```
Resource handler returned message: "Cannot find version 8.0.17 for mysql (Service: Rds, Status Code: 400, Request ID:<>)"
```

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

```
pytest tests/test_rds_s3.py -s -q --region eu-west-2  --deployment_option rds-and-s3 --keepsuccess --accesskey <> --secretkey <> --metadata .metadata/metadata-021.json

tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment upstream directory already exists, skipping clone ...

--------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------
INFO     botocore.credentials:credentials.py:1102 Found credentials in environment variables.
2022-09-01 22:37:37 [ℹ]  IAM Open ID Connect provider is already associated with cluster "e2e-test-cluster-nrry0u2y07" in "eu-west-2"
2022-09-01 22:37:44 [ℹ]  1 iamserviceaccount (kubeflow/kubeflow-secrets-manager-sa) was included (based on the include/exclude rules)
2022-09-01 22:37:47 [ℹ]  1 task: { 
    2 sequential sub-tasks: { 
        delete IAM role for serviceaccount "kubeflow/kubeflow-secrets-manager-sa" [async],
        delete serviceaccount "kubeflow/kubeflow-secrets-manager-sa",
    } }2022-09-01 22:37:47 [ℹ]  will delete stack "eksctl-e2e-test-cluster-nrry0u2y07-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-09-01 22:37:49 [ℹ]  deleted serviceaccount "kubeflow/kubeflow-secrets-manager-sa"
2022-09-01 22:37:56 [ℹ]  1 iamserviceaccount (kubeflow/kubeflow-secrets-manager-sa) was included (based on the include/exclude rules)
2022-09-01 22:37:56 [!]  metadata of serviceaccounts that exist in Kubernetes will be updated, as --override-existing-serviceaccounts was set
2022-09-01 22:37:56 [ℹ]  1 task: { 
    2 sequential sub-tasks: { 
        create IAM role for serviceaccount "kubeflow/kubeflow-secrets-manager-sa",
        create serviceaccount "kubeflow/kubeflow-secrets-manager-sa",
    } }2022-09-01 22:37:56 [ℹ]  building iamserviceaccount stack "eksctl-e2e-test-cluster-nrry0u2y07-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-09-01 22:37:57 [ℹ]  deploying stack "eksctl-e2e-test-cluster-nrry0u2y07-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-09-01 22:37:57 [ℹ]  waiting for CloudFormation stack "eksctl-e2e-test-cluster-nrry0u2y07-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-09-01 22:38:29 [ℹ]  waiting for CloudFormation stack "eksctl-e2e-test-cluster-nrry0u2y07-addon-iamserviceaccount-kubeflow-kubeflow-secrets-manager-sa"
2022-09-01 22:38:31 [ℹ]  created serviceaccount "kubeflow/kubeflow-secrets-manager-sa"
serviceaccount/secrets-store-csi-driver created
clusterrole.rbac.authorization.k8s.io/secretproviderclasses-role created
clusterrolebinding.rbac.authorization.k8s.io/secretproviderclasses-rolebinding created
csidriver.storage.k8s.io/secrets-store.csi.k8s.io created
customresourcedefinition.apiextensions.k8s.io/secretproviderclasses.secrets-store.csi.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io created
daemonset.apps/csi-secrets-store created
clusterrole.rbac.authorization.k8s.io/secretprovidersyncing-role created
clusterrolebinding.rbac.authorization.k8s.io/secretprovidersyncing-rolebinding created
serviceaccount/csi-secrets-store-provider-aws created
clusterrole.rbac.authorization.k8s.io/csi-secrets-store-provider-aws-cluster-role created
clusterrolebinding.rbac.authorization.k8s.io/csi-secrets-store-provider-aws-cluster-rolebinding created
daemonset.apps/csi-secrets-store-provider-aws created
Installation Option: kustomize
Deployment Option: rds-and-s3
AWS-telemetry Option: enable
skip installation...
Saved key: installation_path value: ./resources/installation_config/rds-and-s3.yaml in metadata file /Users/jsitu/Dev/Bugbash/kubeflow-manifests/tests/e2e/.metadata/metadata-1662097163086556000.json
Forwarding from 127.0.0.1:8080 -> 8080
Forwarding from [::1]:8080 -> 8080
{'aws_telemetry_option': 'enable', 'deployment_option': 'rds-and-s3', 'region': 'eu-west-2', 'cluster_name': 'e2e-test-cluster-nrry0u2y07', 'test_rds_s3_cfn_stack': {'stack_name': 'test-e2e-rds-s3-stack-vvcjjb1wrj', 'params': {'VpcId': 'vpc-0d2c5f55cf1bc5556', 'Subnets': 'subnet-0b3ed955fa8fded7d,subnet-0edaee2708cb5ab95,subnet-0b7aa0fa582e50a6f', 'SecurityGroupId': 'sg-0d4e458b0c0d53796', 'DBUsername': 'admino2v101h6el', 'DBPassword': 'Kubefl0wml1vc30y41', 'S3SecretString': '{"accesskey": "AKIAVDWKHZGNVBDCTHFT", "secretkey": "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"}'}}, 'installation_option': 'kustomize', 'installation_path': './resources/installation_config/rds-and-s3.yaml'}
Created metadata file for TestRDSS3 /Users/jsitu/Dev/Bugbash/kubeflow-manifests/tests/e2e/.metadata/metadata-1662097174577470000.json
Handling connection for 8080
Handling connection for 8080
---------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------
INFO     root:_client.py:457 Creating experiment experiment-q5g1yoj4r0.
PASSED
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline 
---------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------
INFO     root:_client.py:457 Creating experiment experiment-qp35w56qyb.
PASSED
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment PASSEDkeep Success Option for Installation:
True


========================================================================== warnings summary ===========================================================================
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_kfp_experiment
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_run_pipeline
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment
tests/test_rds_s3.py::TestRDSS3::test_katib_experiment
  /Users/jsitu/.pyenv/versions/3.8.13/lib/python3.8/site-packages/mysql/connector/connection_cext.py:516: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
    self._cmysql.query(query,

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================== 3 passed, 9 warnings in 525.97s (0:08:45) ==============================================================


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.