### PR TITLE
Update prerequisites.md

### DIFF
--- a/website/content/en/docs/deployment/prerequisites.md
+++ b/website/content/en/docs/deployment/prerequisites.md
@@ -55,7 +55,7 @@ Clone the [`awslabs/kubeflow-manifests`](https://github.com/awslabs/kubeflow-man
 
 Substitute the value for `KUBEFLOW_RELEASE_VERSION`(e.g. v1.5.1) and `AWS_RELEASE_VERSION`(e.g. v1.5.1-aws-b1.0.1) with the tag or branch you want to use below. Read more about [releases and versioning]({{< ref "/docs/about/releases.md" >}}) if you are unsure about what these values should be.
 ```bash
-export KUBEFLOW_RELEASE_VERSION=v1.5.1
+export KUBEFLOW_RELEASE_VERSION=v1.6.0-rc.3
 export AWS_RELEASE_VERSION=v1.5.1-aws-b1.0.1
 git clone https://github.com/awslabs/kubeflow-manifests.git && cd kubeflow-manifests
 git checkout ${AWS_RELEASE_VERSION}


### PR DESCRIPTION
Version 1.5.1  doesn't work - kustomize is looking for istio-1-14  which isn't present at v1.5.1.
Currently works with v1.6.0-rc.3

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
tried to deploy and got errors from kustomize about missing folder istio-1-14 in the upstream/common/
when checked out "master" or tag "v1.6.0-rc.3" worked fine.

finished deploying and kubeflow works in a vpc on eks with s3 and rds :) 

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.