### PR TITLE
Add Github workflow for terraform Cognito and filter website build branch

### DIFF
--- a/.github/workflows/build_push_website_folder.yml
+++ b/.github/workflows/build_push_website_folder.yml
@@ -3,6 +3,9 @@ name: hugo-build-push-folder
 on:
   # Trigger the workflow on git push to a branch where this workflow file exists 
   push:
+    branches:
+      - main
+      - 'release-v[0-9].[0-9]+.[0-9]+-aws-b[0-9].[0-9]+.[0-9]+'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/terraform-cognito-test.yaml
+++ b/.github/workflows/terraform-cognito-test.yaml
@@ -1,7 +1,7 @@
 name: Terraform Cognito Test
 on:
   # Run on PR configuration
-  pull_request:
+  push:
     paths:
       - deployments/cognito/terraform/**
       - iaac/terraform/aws-infra/cognito/**
@@ -26,7 +26,7 @@ jobs:
       contents: read
     env:
       TF_VAR_cognito_user_pool_name: testpool-${{ github.run_id }}-${{ github.run_attempt }}
-      TF_VAR_aws_route53_zone_id: Z0185628O2NTXJM8CTCR
+      TF_VAR_aws_route53_zone_id: {{ secrets.HOSTED_ZONE_ID }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -34,9 +34,9 @@ jobs:
     - name: Configure AWS credentials from Test account
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        role-to-assume: arn:aws:iam::976195024272:role/github-pr-builds
+        role-to-assume: {{ secrets.PR_BUILD_ROLE }}
         role-session-name: prrolesession-${{ github.run_id }}-${{ github.run_attempt }}
-        aws-region: us-east-1
+        aws-region: {{ secrets.AWS_REGION }}
 
     - name: Install Terraform
       uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/terraform-cognito-test.yaml
+++ b/.github/workflows/terraform-cognito-test.yaml
@@ -1,0 +1,55 @@
+name: Terraform Cognito Test
+on:
+  # Run on PR configuration
+  pull_request:
+    paths:
+      - deployments/cognito/terraform/**
+      - iaac/terraform/aws-infra/cognito/**
+      # TODO: Add relevant helm chart path
+    branches:
+      - main
+
+  workflow_dispatch:
+
+# Ensure that only a single workflow which deploy cognito related stack will be run at a time. TODO: enable parallel runs by creating separate hosted zones
+concurrency: cognito
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # environment enables protection rules and secrets (e.g. need approval to run the workflow)
+    environment: gh-actions-test
+    permissions:
+      # needed to interact with GitHub's OIDC Token endpoint
+      id-token: write
+      # needed to checkout repository
+      contents: read
+    env:
+      TF_VAR_cognito_user_pool_name: testpool-${{ github.run_id }}-${{ github.run_attempt }}
+      TF_VAR_aws_route53_zone_id: ${{ secrets.HOSTED_ZONE_ID }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure AWS credentials from Test account
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ secrets.PR_BUILD_ROLE }}
+        role-session-name: prrolesession-${{ github.run_id }}-${{ github.run_attempt }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v2
+    
+    - name: Plan and apply terraform
+      run: |
+        cd iaac/terraform/aws-infra/cognito
+        terraform init
+        terraform plan
+        terraform apply -auto-approve
+        terraform state list
+    - name: Clean up terraform
+      if: success() || failure()
+      run: |
+        cd iaac/terraform/aws-infra/cognito
+        terraform destroy -auto-approve

--- a/.github/workflows/terraform-cognito-test.yaml
+++ b/.github/workflows/terraform-cognito-test.yaml
@@ -17,7 +17,7 @@ concurrency: cognito
 jobs:
   build:
     runs-on: ubuntu-latest
-    # environment enables protection rules and secrets (e.g. need approval to run the workflow)
+    # environment enables protection rules (e.g. need approval to run the workflow)
     environment: gh-actions-test
     permissions:
       # needed to interact with GitHub's OIDC Token endpoint
@@ -26,7 +26,7 @@ jobs:
       contents: read
     env:
       TF_VAR_cognito_user_pool_name: testpool-${{ github.run_id }}-${{ github.run_attempt }}
-      TF_VAR_aws_route53_zone_id: ${{ secrets.HOSTED_ZONE_ID }}
+      TF_VAR_aws_route53_zone_id: Z0185628O2NTXJM8CTCR
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -34,9 +34,9 @@ jobs:
     - name: Configure AWS credentials from Test account
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        role-to-assume: ${{ secrets.PR_BUILD_ROLE }}
+        role-to-assume: arn:aws:iam::976195024272:role/github-pr-builds
         role-session-name: prrolesession-${{ github.run_id }}-${{ github.run_attempt }}
-        aws-region: ${{ secrets.AWS_REGION }}
+        aws-region: us-east-1
 
     - name: Install Terraform
       uses: hashicorp/setup-terraform@v2

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 __pycache__
 
 upstream
+
+.terraform*


### PR DESCRIPTION
**Description of your changes:**
- Adds a Github action to test the cognito terraform module as well. We hope to use a test driver approach for all terraform code moving forward because we have multiplied our test matrix*3.
    - The IAM role is configured to only be able to assume role only from within the Github action from this repository
- Filter branches for website build. Everytime someone creates a branch in this repo it pushes website to gh-pages branch see istio and knative folders for example.

PR test cannot be configured to run on pull request from fork for 2 limitations related to security:
1. OIDC cannot be accessed in forks: https://github.com/aws-actions/configure-aws-credentials/issues/373
1. Secrets are also not passed to actions triggered from forks. We are not really storing secrets but using it to just for abstraction https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
   > Note: Workflow runs triggered by Dependabot pull requests run as if they are from a forked repository, and therefore use a read-only GITHUB_TOKEN. These workflow runs cannot access any secrets. See ["Keeping your GitHub Actions and workflows secure: Preventing pwn requests"](https://securitylab.github.com/research/github-actions-preventing-pwn-requests) for strategies to keep these workflows secure.
 
Will merge #357 after this

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.