### PR TITLE
change cert-manager helm chart version from 1.9.1 to 1.5.0

### DIFF
--- a/tests/e2e/utils/kubeflow_installation.py
+++ b/tests/e2e/utils/kubeflow_installation.py
@@ -142,7 +142,7 @@ def build_certmanager():
     cmd = f"helm install cert-manager jetstack/cert-manager \
                         --namespace cert-manager \
                         --create-namespace \
-                        --version v1.9.1 \
+                        --version v1.5.0 \
                         --set installCRDs=true".split()
     return subprocess.call(cmd)
 


### PR DESCRIPTION

**Which issue is resolved by this Pull Request:**
Resolves #
-change cert-manager helm chart version to match version used by kustomize
**Description of your changes:**


**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.