### PR TITLE
Fix workflow cluster name too long

### DIFF
--- a/.github/workflows/terraform-vanilla-test.yaml
+++ b/.github/workflows/terraform-vanilla-test.yaml
@@ -30,7 +30,7 @@ jobs:
       # needed to checkout repository
       contents: read
     env:
-      TF_VAR_cluster_name: testvanilla-${{ github.run_id }}-${{ github.run_attempt }}
+      TF_VAR_cluster_name: vanilla-${{ github.run_id }}-${{ github.run_attempt }}
       TF_VAR_cluster_region: ${{ github.event_name == 'schedule' && 'us-west-2' || secrets.AWS_REGION }}
     steps:
     - name: Checkout


### PR DESCRIPTION
Fix https://github.com/awslabs/kubeflow-manifests/actions/runs/3086407764

Irsa module uses cluster name as an input when creating the role:
```
│   27:   name        = try(coalesce(var.irsa_iam_role_name, format("%s-%s-%s", var.eks_cluster_id, trim(var.kubernetes_service_account, "-*"), "irsa")), null)
```

Fix shortens cluster name to fit within length requirement.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.