### PR TITLE
shorten irsa role names

### DIFF
--- a/.github/workflows/terraform-vanilla-test.yaml
+++ b/.github/workflows/terraform-vanilla-test.yaml
@@ -30,7 +30,7 @@ jobs:
       # needed to checkout repository
       contents: read
     env:
-      TF_VAR_cluster_name: testvanilla-${{ github.run_id }}-${{ github.run_attempt }}
+      TF_VAR_cluster_name: vanilla-${{ github.run_id }}-${{ github.run_attempt }}
       TF_VAR_cluster_region: ${{ github.event_name == 'schedule' && 'us-west-2' || secrets.AWS_REGION }}
     steps:
     - name: Checkout

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -46,6 +46,7 @@ module "kubeflow_secrets_manager_irsa" {
   create_kubernetes_namespace = false
   create_kubernetes_service_account = true
   kubernetes_service_account        = "kubeflow-secrets-manager-sa"
+  irsa_iam_role_name = format("%s-%s-%s", var.eks_cluster_id, "kf-secrets-manager", "irsa")
   irsa_iam_policies                 = ["arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess", "arn:aws:iam::aws:policy/SecretsManagerReadWrite"]
   irsa_iam_role_path                = var.addon_context.irsa_iam_role_path
   irsa_iam_permissions_boundary     = var.addon_context.irsa_iam_permissions_boundary

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -46,7 +46,7 @@ module "kubeflow_secrets_manager_irsa" {
   create_kubernetes_namespace = false
   create_kubernetes_service_account = true
   kubernetes_service_account        = "kubeflow-secrets-manager-sa"
-  irsa_iam_role_name = format("%s-%s-%s", var.eks_cluster_id, "kf-secrets-manager", "irsa")
+  irsa_iam_role_name = format("%s-%s-%s-%s", "kf-secrets-manager", "irsa", var.eks_cluster_id, var.addon_context.aws_region_name)
   irsa_iam_policies                 = ["arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess", "arn:aws:iam::aws:policy/SecretsManagerReadWrite"]
   irsa_iam_role_path                = var.addon_context.irsa_iam_role_path
   irsa_iam_permissions_boundary     = var.addon_context.irsa_iam_permissions_boundary

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -10,6 +10,7 @@ module "irsa" {
   create_kubernetes_namespace = false
   create_kubernetes_service_account = false
   kubernetes_service_account = "profiles-controller-service-account"
+  irsa_iam_role_name = format("%s-%s-%s", var.eks_cluster_id, "profiles-controller", "irsa")
   irsa_iam_policies = [aws_iam_policy.profile_controller_policy.arn]
   irsa_iam_role_path                = var.addon_context.irsa_iam_role_path
   irsa_iam_permissions_boundary     = var.addon_context.irsa_iam_permissions_boundary

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -10,7 +10,7 @@ module "irsa" {
   create_kubernetes_namespace = false
   create_kubernetes_service_account = false
   kubernetes_service_account = "profiles-controller-service-account"
-  irsa_iam_role_name = format("%s-%s-%s", var.eks_cluster_id, "profiles-controller", "irsa")
+  irsa_iam_role_name = format("%s-%s-%s-%s", "profiles-controller", "irsa", var.eks_cluster_id, var.addon_context.aws_region_name)
   irsa_iam_policies = [aws_iam_policy.profile_controller_policy.arn]
   irsa_iam_role_path                = var.addon_context.irsa_iam_role_path
   irsa_iam_permissions_boundary     = var.addon_context.irsa_iam_permissions_boundary

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -10,7 +10,7 @@ module "irsa" {
   create_kubernetes_namespace = true
   create_kubernetes_service_account = false
   kubernetes_service_account = local.name
-  irsa_iam_role_name = format("%s-%s-%s", var.eks_cluster_id, "ack-sagemaker-controller", "irsa")
+  irsa_iam_role_name = format("%s-%s-%s-%s", "ack-sagemaker-controller", "irsa", var.eks_cluster_id, var.addon_context.aws_region_name)
   irsa_iam_policies = ["arn:aws:iam::aws:policy/AmazonSageMakerFullAccess", aws_iam_policy.sagemaker_ack_controller_studio_access.arn]
   irsa_iam_role_path                = var.addon_context.irsa_iam_role_path
   irsa_iam_permissions_boundary     = var.addon_context.irsa_iam_permissions_boundary

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -10,6 +10,7 @@ module "irsa" {
   create_kubernetes_namespace = true
   create_kubernetes_service_account = false
   kubernetes_service_account = local.name
+  irsa_iam_role_name = format("%s-%s-%s", var.eks_cluster_id, "ack-sagemaker-controller", "irsa")
   irsa_iam_policies = ["arn:aws:iam::aws:policy/AmazonSageMakerFullAccess", aws_iam_policy.sagemaker_ack_controller_studio_access.arn]
   irsa_iam_role_path                = var.addon_context.irsa_iam_role_path
   irsa_iam_permissions_boundary     = var.addon_context.irsa_iam_permissions_boundary


### PR DESCRIPTION


Fix https://github.com/awslabs/kubeflow-manifests/actions/runs/3086407764

Irsa module uses cluster name as an input when creating the role:

│   27:   name        = try(coalesce(var.irsa_iam_role_name, format("%s-%s-%s", var.eks_cluster_id, trim(var.kubernetes_service_account, "-*"), "irsa")), null)

Fix shortens role names to fit within length requirement.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
