### PR TITLE
Enable helm values write up in rds-s3 e2e test

### DIFF
--- a/tests/e2e/utils/kubeflow_uninstallation.py
+++ b/tests/e2e/utils/kubeflow_uninstallation.py
@@ -97,16 +97,19 @@ def delete_component(
         ]
 
         if INSTALLATION_OPTION == "helm":
-
-            uninstall_helm(component_name, namespace)
-            if os.path.isdir(f"{installation_path}/crds"):
-                print(f"deleting {component_name} crds ...")
-                kubectl_delete(f"{installation_path}/crds")
-            # delete aws-load-balancer-controller crds for official helm chart
-            if component_name == "aws-load-balancer-controller":
-                kubectl_delete(
-                    "https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/6d3e976e3f60dc4588c01bad036d77c127a68e71/helm/aws-load-balancer-controller/crds/crds.yaml"
-                )
+            if component_name == "kubeflow-namespace":
+                for kustomize_path in path_dic[component_name]["installation_options"]["kustomize"]:
+                    delete_kustomize(kustomize_path)
+            else:
+                uninstall_helm(component_name, namespace)
+                if os.path.isdir(f"{installation_path}/crds"):
+                    print(f"deleting {component_name} crds ...")
+                    kubectl_delete(f"{installation_path}/crds")
+                # delete aws-load-balancer-controller crds for official helm chart
+                if component_name == "aws-load-balancer-controller":
+                    kubectl_delete(
+                        "https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/6d3e976e3f60dc4588c01bad036d77c127a68e71/helm/aws-load-balancer-controller/crds/crds.yaml"
+                    )
         # kustomize
         else:
             installation_path.reverse()


### PR DESCRIPTION


**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

-modify rds-s3 testing script to automatically write rds-s3 values.yaml in pipelines and secrets manager in addition to kustomize params.env

-modify kubeflow uninstallation script to use kustomize to delete kubeflow namespace when helm is specified.

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.