### PR TITLE
Fix terraform labels

### DIFF
--- a/deployments/cognito-rds-s3/terraform/Makefile
+++ b/deployments/cognito-rds-s3/terraform/Makefile
@@ -39,10 +39,6 @@ delete-eks-blueprints-k8s-addons:
 	terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 
 delete-kubeflow-components:
-# hack to handle the automatic deletion of the sa when calling helm delete 
-# which causes deletion of the tf created sa to fail
-# todo: profiles-and-kfam helm chart should accept an optional irsa role annotation
-	terraform state rm "module.kubeflow_components.module.kubeflow_profiles_and_kfam.kubernetes_service_account_v1.profile_controller_sa" || true
 	terraform destroy -target="module.kubeflow_components" -auto-approve
 
 # don't create executables

--- a/deployments/cognito/terraform/Makefile
+++ b/deployments/cognito/terraform/Makefile
@@ -39,10 +39,6 @@ delete-eks-blueprints-k8s-addons:
 	terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 
 delete-kubeflow-components:
-# hack to handle the automatic deletion of the sa when calling helm delete 
-# which causes deletion of the tf created sa to fail
-# todo: profiles-and-kfam helm chart should accept an optional irsa role annotation
-	terraform state rm "module.kubeflow_components.module.kubeflow_profiles_and_kfam.kubernetes_service_account_v1.profile_controller_sa" || true
 	terraform destroy -target="module.kubeflow_components" -auto-approve
 
 # don't create executables

--- a/deployments/rds-s3/terraform/Makefile
+++ b/deployments/rds-s3/terraform/Makefile
@@ -39,10 +39,6 @@ delete-eks-blueprints-k8s-addons:
 	terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 
 delete-kubeflow-components:
-# hack to handle the automatic deletion of the sa when calling helm delete 
-# which causes deletion of the tf created sa to fail
-# todo: profiles-and-kfam helm chart should accept an optional irsa role annotation
-	terraform state rm "module.kubeflow_components.module.kubeflow_profiles_and_kfam.kubernetes_service_account_v1.profile_controller_sa" || true
 	terraform destroy -target="module.kubeflow_components" -auto-approve
 
 # don't create executables

--- a/deployments/vanilla/terraform/Makefile
+++ b/deployments/vanilla/terraform/Makefile
@@ -39,10 +39,6 @@ delete-eks-blueprints-k8s-addons:
 	terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 
 delete-kubeflow-components:
-# hack to handle the automatic deletion of the sa when calling helm delete 
-# which causes deletion of the tf created sa to fail
-# todo: profiles-and-kfam helm chart should accept an optional irsa role annotation
-	terraform state rm "module.kubeflow_components.module.kubeflow_profiles_and_kfam.kubernetes_service_account_v1.profile_controller_sa" || true
 	terraform destroy -target="module.kubeflow_components" -auto-approve
 
 # don't create executables

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -18,27 +18,22 @@ module "irsa" {
   eks_oidc_provider_arn             = var.addon_context.eks_oidc_provider_arn
 }
 
-resource "kubernetes_service_account_v1" "profile_controller_sa" {
-  metadata {
-    name        = module.irsa.service_account
-    namespace   = module.irsa.namespace
-    annotations = { 
-      "eks.amazonaws.com/role-arn" : module.irsa.irsa_iam_role_arn, 
-      "meta.helm.sh/release-name": local.name,
-      "meta.helm.sh/release-namespace": "default"
-    }
-    labels = {
-      "app.kubernetes.io/managed-by": "Helm"
-    }
-  }
-
-  automount_service_account_token = true
-}
-
 module "helm_addon" {
   source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.9.0"
   helm_config       = local.helm_config
   addon_context     = var.addon_context
+}
 
-  depends_on = [kubernetes_service_account_v1.profile_controller_sa]
+resource "kubernetes_annotations" "sa_role_arn" {
+  api_version = "v1"
+  kind        = "ServiceAccount"
+  metadata {
+    name        = module.irsa.service_account
+    namespace   = module.irsa.namespace
+  }
+  annotations = { 
+    "eks.amazonaws.com/role-arn" : module.irsa.irsa_iam_role_arn
+  }
+
+  depends_on = [module.helm_addon]
 }

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -35,3 +35,16 @@ module "helm_addon" {
 
   addon_context     = var.addon_context
 }
+
+resource "kubernetes_labels" "cluster_role_rbac_auth" {
+  api_version = "rbac.authorization.k8s.io/v1"
+  kind        = "ClusterRole"
+  metadata {
+    name = "ack-sagemaker-controller"
+  }
+  labels = {
+    "rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit" = "true"
+  }
+
+  depends_on = [module.helm_addon]
+}


### PR DESCRIPTION
**Description of your changes:**
- Creates an IRSA role annotation for the profiles controller sa instead of creating the entire sa (the sa is normally created by the helm chart)
- Creates a required label for the ack sagemaker controller cluster role

**Testing:**
```
ubuntu@ip-172-31-41-215:~$ kubectl describe sa profiles-controller-service-account -n kubeflow
Name:                profiles-controller-service-account
Namespace:           kubeflow
Labels:              app.kubernetes.io/managed-by=Helm
                     kustomize.component=profiles
Annotations:         eks.amazonaws.com/role-arn: arn:aws:iam::556017915589:role/profiles-controller-irsa-tf-labels-us-east-1
                     meta.helm.sh/release-name: profiles-and-kfam
                     meta.helm.sh/release-namespace: default
Image pull secrets:  <none>
Mountable secrets:   profiles-controller-service-account-token-tcldj
Tokens:              profiles-controller-service-account-token-tcldj
Events:              <none>
```

```
ubuntu@ip-172-31-41-215:~$ kubectl describe clusterroles ack-sagemaker-controller
Name:         ack-sagemaker-controller
Labels:       app.kubernetes.io/managed-by=Helm
              rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit=true
Annotations:  meta.helm.sh/release-name: ack-sagemaker-controller
              meta.helm.sh/release-namespace: ack-system
PolicyRule:
  Resources                                                            Non-Resource URLs  Resource Names  Verbs
  ---------                                                            -----------------  --------------  -----
  apps.sagemaker.services.k8s.aws                                      []                 []              [create delete get list patch update watch]
  dataqualityjobdefinitions.sagemaker.services.k8s.aws                 []                 []              [create delete get list patch update watch]
  domains.sagemaker.services.k8s.aws                                   []                 []              [create delete get list patch update watch]
  endpointconfigs.sagemaker.services.k8s.aws                           []                 []              [create delete get list patch update watch]
  endpoints.sagemaker.services.k8s.aws                                 []                 []              [create delete get list patch update watch]
  featuregroups.sagemaker.services.k8s.aws                             []                 []              [create delete get list patch update watch]
  hyperparametertuningjobs.sagemaker.services.k8s.aws                  []                 []              [create delete get list patch update watch]
  modelbiasjobdefinitions.sagemaker.services.k8s.aws                   []                 []              [create delete get list patch update watch]
  modelexplainabilityjobdefinitions.sagemaker.services.k8s.aws         []                 []              [create delete get list patch update watch]
  modelpackagegroups.sagemaker.services.k8s.aws                        []                 []              [create delete get list patch update watch]
  modelpackages.sagemaker.services.k8s.aws                             []                 []              [create delete get list patch update watch]
  modelqualityjobdefinitions.sagemaker.services.k8s.aws                []                 []              [create delete get list patch update watch]
  models.sagemaker.services.k8s.aws                                    []                 []              [create delete get list patch update watch]
  monitoringschedules.sagemaker.services.k8s.aws                       []                 []              [create delete get list patch update watch]
  notebookinstancelifecycleconfigs.sagemaker.services.k8s.aws          []                 []              [create delete get list patch update watch]
  notebookinstances.sagemaker.services.k8s.aws                         []                 []              [create delete get list patch update watch]
  processingjobs.sagemaker.services.k8s.aws                            []                 []              [create delete get list patch update watch]
  trainingjobs.sagemaker.services.k8s.aws                              []                 []              [create delete get list patch update watch]
  transformjobs.sagemaker.services.k8s.aws                             []                 []              [create delete get list patch update watch]
  userprofiles.sagemaker.services.k8s.aws                              []                 []              [create delete get list patch update watch]
  adoptedresources.services.k8s.aws                                    []                 []              [create delete get list patch update watch]
  fieldexports.services.k8s.aws                                        []                 []              [create delete get list patch update watch]
  configmaps                                                           []                 []              [get list patch watch]
  secrets                                                              []                 []              [get list patch watch]
  namespaces                                                           []                 []              [get list watch]
  apps.sagemaker.services.k8s.aws/status                               []                 []              [get patch update]
  dataqualityjobdefinitions.sagemaker.services.k8s.aws/status          []                 []              [get patch update]
  domains.sagemaker.services.k8s.aws/status                            []                 []              [get patch update]
  endpointconfigs.sagemaker.services.k8s.aws/status                    []                 []              [get patch update]
  endpoints.sagemaker.services.k8s.aws/status                          []                 []              [get patch update]
  featuregroups.sagemaker.services.k8s.aws/status                      []                 []              [get patch update]
  hyperparametertuningjobs.sagemaker.services.k8s.aws/status           []                 []              [get patch update]
  modelbiasjobdefinitions.sagemaker.services.k8s.aws/status            []                 []              [get patch update]
  modelexplainabilityjobdefinitions.sagemaker.services.k8s.aws/status  []                 []              [get patch update]
  modelpackagegroups.sagemaker.services.k8s.aws/status                 []                 []              [get patch update]
  modelpackages.sagemaker.services.k8s.aws/status                      []                 []              [get patch update]
  modelqualityjobdefinitions.sagemaker.services.k8s.aws/status         []                 []              [get patch update]
  models.sagemaker.services.k8s.aws/status                             []                 []              [get patch update]
  monitoringschedules.sagemaker.services.k8s.aws/status                []                 []              [get patch update]
  notebookinstancelifecycleconfigs.sagemaker.services.k8s.aws/status   []                 []              [get patch update]
  notebookinstances.sagemaker.services.k8s.aws/status                  []                 []              [get patch update]
  processingjobs.sagemaker.services.k8s.aws/status                     []                 []              [get patch update]
  trainingjobs.sagemaker.services.k8s.aws/status                       []                 []              [get patch update]
  transformjobs.sagemaker.services.k8s.aws/status                      []                 []              [get patch update]
  userprofiles.sagemaker.services.k8s.aws/status                       []                 []              [get patch update]
  adoptedresources.services.k8s.aws/status                             []                 []              [get patch update]
  fieldexports.services.k8s.aws/status                                 []                 []              [get patch update]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.