### PR TITLE
Ingress uninstall cognito

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,7 @@ cleanup-ack-req: verify-cluster-variables
 deploy-kubeflow: bootstrap-ack
 	$(eval DEPLOYMENT_OPTION:=vanilla)
 	$(eval INSTALLATION_OPTION:=kustomize)
-	$(eval AWS_TELEMETRY_OPTION:=True)
-	cd tests/e2e && PYTHONPATH=.. python3.8 utils/kubeflow_installation.py --deployment_option $(DEPLOYMENT_OPTION) --installation_option $(INSTALLATION_OPTION) --aws_telemetry $(AWS_TELEMETRY_OPTION) --cluster_name $(CLUSTER_NAME)
+	cd tests/e2e && PYTHONPATH=.. python3.8 utils/kubeflow_installation.py --deployment_option $(DEPLOYMENT_OPTION) --installation_option $(INSTALLATION_OPTION) --cluster_name $(CLUSTER_NAME)
 
 delete-kubeflow:
 	$(eval DEPLOYMENT_OPTION:=vanilla)

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ deploy-kubeflow: bootstrap-ack
 	$(eval DEPLOYMENT_OPTION:=vanilla)
 	$(eval INSTALLATION_OPTION:=kustomize)
 	$(eval AWS_TELEMETRY_OPTION:=True)
-	cd tests/e2e && PYTHONPATH=.. python3.8 utils/kubeflow_installation.py --deployment_option $(DEPLOYMENT_OPTION) --installation_option $(INSTALLATION_OPTION) --aws_telemetry $(AWS_TELEMETRY_OPTION)
+	cd tests/e2e && PYTHONPATH=.. python3.8 utils/kubeflow_installation.py --deployment_option $(DEPLOYMENT_OPTION) --installation_option $(INSTALLATION_OPTION) --aws_telemetry $(AWS_TELEMETRY_OPTION) --cluster_name $(CLUSTER_NAME)
 
 delete-kubeflow:
 	$(eval DEPLOYMENT_OPTION:=vanilla)

--- a/tests/e2e/utils/kubeflow_uninstallation.py
+++ b/tests/e2e/utils/kubeflow_uninstallation.py
@@ -8,6 +8,7 @@ from e2e.utils.utils import (
     load_yaml_file,
 )
 import os
+import subprocess
 
 
 INSTALLATION_PATH_FILE_VANILLA = "./resources/installation_config/vanilla.yaml"
@@ -99,10 +100,15 @@ def delete_component(
         ]
 
         if installation_option == "helm":
-
             if component_name == "kubeflow-namespace":
                 for kustomize_path in path_dic[component_name]["installation_options"]["kustomize"]:
                     delete_kustomize(kustomize_path)
+
+            elif component_name == "ingress":
+                uninstall_helm(component_name, namespace)
+                #Helm doesn't seem to delete ingress during uninstall
+                retcode = subprocess.call(f"kubectl delete ingress -n istio-system istio-ingress".split())
+                assert retcode == 0
             else:
                 uninstall_helm(component_name, namespace)
                 if os.path.isdir(f"{installation_path}/crds"):


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
- Helm doesn't seem to remove ingress when unintalling which cause namespace stuck in termination
 ```
istio-system      Terminating   53m
```
- add temporary workaround to delete ingress after helm uninstall
```
kubectl delete ingress -n istio-system istio-ingress
ingress.networking.k8s.io "istio-ingress" deleted
```





**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.