### PR TITLE
Update ml-pipeline api-server image to 2.0.0-alpha.3

### DIFF
--- a/awsconfigs/apps/pipeline/base/kustomization.yaml
+++ b/awsconfigs/apps/pipeline/base/kustomization.yaml
@@ -7,5 +7,5 @@ bases:
 images:
   - name: gcr.io/ml-pipeline/api-server
     newName: public.ecr.aws/c9e4w0g3/ml-pipeline/api-server
-    newTag: dev-2.0.0-alpha.3
+    newTag: 2.0.0-alpha.3
 

--- a/charts/apps/kubeflow-pipelines/rds-only/templates/Deployment/ml-pipeline-kubeflow-Deployment.yaml
+++ b/charts/apps/kubeflow-pipelines/rds-only/templates/Deployment/ml-pipeline-kubeflow-Deployment.yaml
@@ -90,7 +90,7 @@ spec:
         envFrom:
         - configMapRef:
             name: pipeline-api-server-config-f4t72426kt
-        image: public.ecr.aws/c9e4w0g3/ml-pipeline/api-server:dev-2.0.0-alpha.3
+        image: public.ecr.aws/c9e4w0g3/ml-pipeline/api-server:2.0.0-alpha.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/charts/apps/kubeflow-pipelines/rds-s3/templates/Deployment/ml-pipeline-kubeflow-Deployment.yaml
+++ b/charts/apps/kubeflow-pipelines/rds-s3/templates/Deployment/ml-pipeline-kubeflow-Deployment.yaml
@@ -102,7 +102,7 @@ spec:
         envFrom:
         - configMapRef:
             name: pipeline-api-server-config-f4t72426kt
-        image: public.ecr.aws/c9e4w0g3/ml-pipeline/api-server:dev-2.0.0-alpha.3
+        image: public.ecr.aws/c9e4w0g3/ml-pipeline/api-server:2.0.0-alpha.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/charts/apps/kubeflow-pipelines/s3-only/templates/Deployment/ml-pipeline-kubeflow-Deployment.yaml
+++ b/charts/apps/kubeflow-pipelines/s3-only/templates/Deployment/ml-pipeline-kubeflow-Deployment.yaml
@@ -102,7 +102,7 @@ spec:
         envFrom:
         - configMapRef:
             name: pipeline-api-server-config-f4t72426kt
-        image: public.ecr.aws/c9e4w0g3/ml-pipeline/api-server:dev-2.0.0-alpha.3
+        image: public.ecr.aws/c9e4w0g3/ml-pipeline/api-server:2.0.0-alpha.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/charts/apps/kubeflow-pipelines/vanilla/templates/Deployment/ml-pipeline-kubeflow-Deployment.yaml
+++ b/charts/apps/kubeflow-pipelines/vanilla/templates/Deployment/ml-pipeline-kubeflow-Deployment.yaml
@@ -90,7 +90,7 @@ spec:
         envFrom:
         - configMapRef:
             name: pipeline-api-server-config-f4t72426kt
-        image: public.ecr.aws/c9e4w0g3/ml-pipeline/api-server:dev-2.0.0-alpha.3
+        image: public.ecr.aws/c9e4w0g3/ml-pipeline/api-server:2.0.0-alpha.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:


### PR DESCRIPTION
Update ml-pipeline api-server image to 2.0.0-alpha.3


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.