### PR TITLE
Use EKS 1.22 in make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ verify-cluster-variables:
 create-eks-cluster: verify-cluster-variables
 	eksctl create cluster \
 	--name $(CLUSTER_NAME) \
-	--version 1.23 \
+	--version 1.22 \
 	--region $(CLUSTER_REGION) \
 	--nodegroup-name linux-nodes \
 	--node-type m5.xlarge \


### PR DESCRIPTION
Use EKS 1.22 in make commands
because EKS 1.23 stopped installing EBS driver by default and the user has to install it. 