### PR TITLE
Fixed docker-compose.yaml 

### DIFF
--- a/website/docker-compose.yaml
+++ b/website/docker-compose.yaml
@@ -9,5 +9,7 @@ services:
     command: server
     ports:
       - "1313:1313"
+    working_dir: /src/website
     volumes:
-      - .:/src
+      - ..:/src
+


### PR DESCRIPTION
Changed the docker-compose.yaml to allow Docker users to serve the docs locally running a simple `docker-compose up site` command provided that they have cloned the submodules by running `git submodule update --init --recursive --depth 1` .
