### PR TITLE
updated kubeflow installation script so that the helm command is idempotent

### DIFF
--- a/tests/e2e/utils/kubeflow_installation.py
+++ b/tests/e2e/utils/kubeflow_installation.py
@@ -168,7 +168,7 @@ def build_certmanager():
     assert retcode == 0
     retcode = subprocess.call(f"helm repo update".split())
     assert retcode == 0
-    cmd = f"helm install cert-manager jetstack/cert-manager \
+    cmd = f"helm upgrade --install cert-manager jetstack/cert-manager \
                         --namespace cert-manager \
                         --create-namespace \
                         --version v1.5.0 \
@@ -183,7 +183,7 @@ def build_alb_controller(cluster_name):
     assert retcode == 0
     retcode = subprocess.call(f"helm repo update".split())
     assert retcode == 0
-    cmd = f"helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+    cmd = f"helm upgrade --install aws-load-balancer-controller eks/aws-load-balancer-controller \
             -n kube-system \
             --set clusterName={cluster_name} \
             --set serviceAccount.create=false \
@@ -212,7 +212,7 @@ def build_ack_controller():
         f"-i {CHART_EXPORT_PATH}/{SERVICE}-chart/values.yaml")
     find_and_replace_in_file(f"{CHART_EXPORT_PATH}/{SERVICE}-chart/templates/cluster-role-controller.yaml",
         "metadata:", f"metadata:\n  labels:\n    {LABEL_STRING}")
-    exec_shell(f"helm install -n {ACK_K8S_NAMESPACE} --create-namespace ack-{SERVICE}-controller "
+    exec_shell(f"helm upgrade --install -n {ACK_K8S_NAMESPACE} --create-namespace ack-{SERVICE}-controller "
         f"{CHART_EXPORT_PATH}/{SERVICE}-chart")
 
 if __name__ == "__main__":

--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -209,16 +209,16 @@ def install_helm(chart_name, path, namespace=None):
     """
     Equivalent to:
 
-    helm install <chart_name> <path>
+    helm upgrade --install <chart_name> <path>
 
     """
 
     if namespace:
         install_retcode = subprocess.call(
-            f"helm install {chart_name} {path} -n {namespace}".split()
+            f"helm upgrade --install {chart_name} {path} -n {namespace}".split()
         )
     else:
-        install_retcode = subprocess.call(f"helm install {chart_name} {path}".split())
+        install_retcode = subprocess.call(f"helm upgrade --install {chart_name} {path}".split())
     assert install_retcode == 0
 
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

running `make deploy-kubeflow` sometimes fails due to various reasons. After fixing whatever issue that cause the failure, I am unable to run the script again.

```
Error: INSTALLATION FAILED: cannot re-use a name that is still in use
Traceback (most recent call last):
  File "utils/kubeflow_installation.py", line 256, in <module>
    install_kubeflow(
  File "utils/kubeflow_installation.py", line 79, in install_kubeflow
    build_component(
  File "utils/kubeflow_installation.py", line 132, in build_component
    install_helm(component_name, installation_path, namespace)
  File "/Volumes/workplace/kubeflow/kubeflow-manifests/tests/e2e/utils/utils.py", line 222, in install_helm
    assert install_retcode == 0
AssertionError
make: *** [deploy-kubeflow] Error 1
```

**Description of your changes:**

Updated the helm command from `helm install` to `helm upgrade --install`, which would run an install if a release by this name doesn't already exist.

https://helm.sh/docs/helm/helm_upgrade/

**Testing:**
- [N.A] Unit tests pass
- [N.A] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

Manually tested by running `deploy-kubeflow`. Observed that installation is successful without `Error: INSTALLATION FAILED: cannot re-use a name that is still in use`.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.