### PR TITLE
terraform integ tests

### DIFF
--- a/.github/workflows/terraform-cognito-test.yaml
+++ b/.github/workflows/terraform-cognito-test.yaml
@@ -30,11 +30,8 @@ jobs:
       # needed to checkout repository
       contents: read
     env:
-      TF_VAR_cognito_user_pool_name: ${{ github.run_id }}-${{ github.run_attempt }}-testpool
-      TF_VAR_aws_route53_root_zone_name: ${{ secrets.ROOT_HOSTED_ZONE_NAME }}
-      TF_VAR_aws_route53_subdomain_zone_name: ${{ github.run_id }}-${{ github.run_attempt }}.${{ secrets.ROOT_HOSTED_ZONE_NAME }}
-      TF_VAR_cluster_name: cognito-${{ github.run_id }}-${{ github.run_attempt }}
-      TF_VAR_cluster_region: ${{ github.event_name == 'schedule' && 'us-west-2' || secrets.AWS_REGION }}
+      ROOT_DOMAIN_NAME: ${{ secrets.ROOT_HOSTED_ZONE_NAME }}
+      CLUSTER_REGION: ${{ github.event_name == 'schedule' && 'us-west-2' || secrets.AWS_REGION }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -52,13 +49,20 @@ jobs:
       with:
         terraform_version: 1.2.7
     
+    - name: Install Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8' 
+
     - name: Plan and apply terraform
       run: |
-        cd deployments/cognito/terraform
-        make deploy
+        cd tests/e2e
+        pip install -r requirements.txt
+        pytest tests/terraform/test_cognito.py -s -q --region $CLUSTER_REGION --root-domain-name $ROOT_DOMAIN_NAME
+
     - name: Clean up terraform
-      if: success() || failure()
+      if: failure()
       # retry delete if flakiness present
       run: |
-        cd deployments/cognito/terraform
+        cd ../../deployments/cognito/terraform
         make delete || make delete || make delete

--- a/.github/workflows/terraform-vanilla-test.yaml
+++ b/.github/workflows/terraform-vanilla-test.yaml
@@ -30,8 +30,7 @@ jobs:
       # needed to checkout repository
       contents: read
     env:
-      TF_VAR_cluster_name: vanilla-${{ github.run_id }}-${{ github.run_attempt }}
-      TF_VAR_cluster_region: ${{ github.event_name == 'schedule' && 'us-west-2' || secrets.AWS_REGION }}
+      CLUSTER_REGION: ${{ github.event_name == 'schedule' && 'us-west-2' || secrets.AWS_REGION }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -49,13 +48,20 @@ jobs:
       with:
         terraform_version: 1.2.7
     
+    - name: Install Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8' 
+    
     - name: Plan and apply terraform
       run: |
-        cd deployments/vanilla/terraform
-        make deploy
+        cd tests/e2e
+        pip install -r requirements.txt
+        pytest tests/terraform/test_vanilla.py -s -q --region $CLUSTER_REGION
+
     - name: Clean up terraform
-      if: success() || failure()
+      if: failure()
       # retry delete if flakiness present
       run: |
-        cd deployments/vanilla/terraform
+        cd ../../deployments/vanilla/terraform
         make delete || make delete || make delete

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ upstream
 
 .terraform*
 terraform.tfstate*
+test-generated.auto.tfvars

--- a/deployments/cognito-rds-s3/terraform/Makefile
+++ b/deployments/cognito-rds-s3/terraform/Makefile
@@ -21,6 +21,7 @@ create-vpc:
 
 create-eks-cluster:
 	terraform apply -target="module.eks_blueprints" -auto-approve
+	terraform output -raw configure_kubectl | bash
 
 deploy-eks-blueprints-k8s-addons:
 	terraform apply -target="module.eks_blueprints_kubernetes_addons" -auto-approve

--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
@@ -50,7 +50,7 @@ resource "kubernetes_namespace" "kubeflow" {
 
 module "kubeflow_secrets_manager_irsa" {
   source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.0"
-  kubernetes_namespace = "kubeflow"
+  kubernetes_namespace = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace = false
   create_kubernetes_service_account = true
   kubernetes_service_account        = "kubeflow-secrets-manager-sa"
@@ -77,7 +77,7 @@ module "rds" {
   security_group_id = var.security_group_id
   db_name = var.db_name
   db_username = var.db_username
-  db_password = coalesce(var.db_password, random_password.db_password[0].result)
+  db_password = coalesce(var.db_password, try(random_password.db_password[0].result, null))
   db_class = var.db_class
   db_allocated_storage = var.db_allocated_storage
   backup_retention_period = var.backup_retention_period

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -200,12 +200,13 @@ module "kubeflow_components" {
   # rds
   use_rds = var.use_rds
   vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.private_subnets
+  subnet_ids = var.publicly_accessible ? module.vpc.public_subnets : module.vpc.private_subnets
   security_group_id = module.eks_blueprints.cluster_primary_security_group_id
   db_name = var.db_name
   db_username = var.db_username
   db_password = var.db_password
   db_class = var.db_class
+  mlmdb_name = var.mlmdb_name
   db_allocated_storage = var.db_allocated_storage
   mysql_engine_version = var.mysql_engine_version
   backup_retention_period = var.backup_retention_period

--- a/deployments/cognito-rds-s3/terraform/outputs.tf
+++ b/deployments/cognito-rds-s3/terraform/outputs.tf
@@ -48,7 +48,6 @@ output "configure_kubectl" {
   value       = module.eks_blueprints.configure_kubectl
 }
 
-# Region used for Terratest
 output "region" {
   value       = local.region
   description = "AWS region"
@@ -56,4 +55,14 @@ output "region" {
 
 output "kubelow_platform_domain" {
     value = module.kubeflow_components.kubelow_platform_domain
+}
+
+output "rds_endpoint" {
+  value       = try(module.kubeflow_components.rds_endpoint, null)
+  description = "The address of the RDS endpoint"
+}
+
+output "s3_bucket_name" {
+  value       = try(module.kubeflow_components.s3_bucket_name, null)
+  description = "The name of the created S3 bucket"
 }

--- a/deployments/cognito/terraform/Makefile
+++ b/deployments/cognito/terraform/Makefile
@@ -21,6 +21,7 @@ create-vpc:
 
 create-eks-cluster:
 	terraform apply -target="module.eks_blueprints" -auto-approve
+	terraform output -raw configure_kubectl | bash
 
 deploy-eks-blueprints-k8s-addons:
 	terraform apply -target="module.eks_blueprints_kubernetes_addons" -auto-approve

--- a/deployments/rds-s3/terraform/Makefile
+++ b/deployments/rds-s3/terraform/Makefile
@@ -21,6 +21,7 @@ create-vpc:
 
 create-eks-cluster:
 	terraform apply -target="module.eks_blueprints" -auto-approve
+	terraform output -raw configure_kubectl | bash
 
 deploy-eks-blueprints-k8s-addons:
 	terraform apply -target="module.eks_blueprints_kubernetes_addons" -auto-approve

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -193,12 +193,13 @@ module "kubeflow_components" {
   use_s3 = var.use_s3
 
   vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.private_subnets
+  subnet_ids = var.publicly_accessible ? module.vpc.public_subnets : module.vpc.private_subnets
   security_group_id = module.eks_blueprints.cluster_primary_security_group_id
   db_name = var.db_name
   db_username = var.db_username
   db_password = var.db_password
   db_class = var.db_class
+  mlmdb_name = var.mlmdb_name
   db_allocated_storage = var.db_allocated_storage
   mysql_engine_version = var.mysql_engine_version
   backup_retention_period = var.backup_retention_period

--- a/deployments/rds-s3/terraform/outputs.tf
+++ b/deployments/rds-s3/terraform/outputs.tf
@@ -52,3 +52,13 @@ output "region" {
   value       = local.region
   description = "AWS region"
 }
+
+output "rds_endpoint" {
+  value       = try(module.kubeflow_components.rds_endpoint, null)
+  description = "The address of the RDS endpoint"
+}
+
+output "s3_bucket_name" {
+  value       = try(module.kubeflow_components.s3_bucket_name, null)
+  description = "The name of the created S3 bucket"
+}

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -42,7 +42,7 @@ resource "kubernetes_namespace" "kubeflow" {
 
 module "kubeflow_secrets_manager_irsa" {
   source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.0"
-  kubernetes_namespace = "kubeflow"
+  kubernetes_namespace = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace = false
   create_kubernetes_service_account = true
   kubernetes_service_account        = "kubeflow-secrets-manager-sa"
@@ -69,7 +69,7 @@ module "rds" {
   security_group_id = var.security_group_id
   db_name = var.db_name
   db_username = var.db_username
-  db_password = coalesce(var.db_password, random_password.db_password[0].result)
+  db_password = coalesce(var.db_password, try(random_password.db_password[0].result, null))
   db_class = var.db_class
   db_allocated_storage = var.db_allocated_storage
   backup_retention_period = var.backup_retention_period

--- a/deployments/rds-s3/terraform/rds-s3-components/outputs.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/outputs.tf
@@ -1,7 +1,3 @@
-output "kubelow_platform_domain" {
-    value = module.ingress_cognito[0].kubelow_platform_domain
-}
-
 output "rds_endpoint" {
   value       = try(module.rds[0].rds_endpoint, null)
   description = "The address of the RDS endpoint"

--- a/deployments/vanilla/terraform/Makefile
+++ b/deployments/vanilla/terraform/Makefile
@@ -21,6 +21,7 @@ create-vpc:
 
 create-eks-cluster:
 	terraform apply -target="module.eks_blueprints" -auto-approve
+	terraform output -raw configure_kubectl | bash
 
 deploy-eks-blueprints-k8s-addons:
 	terraform apply -target="module.eks_blueprints_kubernetes_addons" -auto-approve

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -34,6 +34,8 @@ module "helm_addon" {
   ]
 
   addon_context     = var.addon_context
+
+  depends_on = [module.irsa]
 }
 
 resource "kubernetes_labels" "cluster_role_rbac_auth" {

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -35,6 +35,31 @@ Resume from a previous run using the resources that were previous created
 pytest --metadata .metadata/metadata-1638939746471968000.json --keepsuccess ...<other arguments>...
 ```
 
+## Test specific commands
+
+### Terraform
+
+Vanilla
+```
+pytest tests/terraform/test_vanilla.py -s -q --region <aws region>
+```
+
+RDS-S3
+```
+pytest tests/terraform/test_rds_s3.py -s -q --region <aws region> --accesskey <accesskey> --secretkey <secretkey>
+```
+
+Cognito
+```
+pytest tests/terraform/test_cognito.py -s -q --region <aws region> --root-domain-name <root domain, e.g. example.com>
+```
+
+Cognito-RDS-S3
+```
+pytest tests/terraform/test_cognito_rds_s3.py -s -q --region <aws region> --root-domain-name <root domain, e.g. example.com> --accesskey <accesskey> --secretkey <secretkey>
+```
+
+
 ### About metadata
 When using the helper method `configure_resource_fixture` a metadata file is generated with the following output:
 ```

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -95,6 +95,8 @@ def get_deployment_option(request):
         deployment_option = "vanilla"
     return deployment_option
 
+def get_root_domain_name(request):
+    return request.config.getoption("--root-domain-name")
 
 
 @pytest.fixture(scope="class")
@@ -149,7 +151,7 @@ def root_domain_name(metadata, request):
     if cognito_deps:
         return cognito_deps["route53"]["rootDomain"]["name"]
 
-    return request.config.getoption("--root-domain-name")
+    return get_root_domain_name(request)
 
 
 @pytest.fixture(scope="class")

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -3,7 +3,7 @@ kfp==1.8.9
 kubernetes==12.0.1
 pytest==6.2.5
 PyYAML==5.4
-black==21.12b0
+black==22.8.0
 mysql-connector-python==8.0.27
 retrying==1.3.3
 requests==2.28.1

--- a/tests/e2e/test_methods/cognito.py
+++ b/tests/e2e/test_methods/cognito.py
@@ -1,11 +1,12 @@
 import requests
 import time
 
+
 def test_url_is_up(subdomain_name):
     kubeflow_endpoint = "https://kubeflow." + subdomain_name
     print("kubeflow_endpoint:")
     print(kubeflow_endpoint)
-    #wait a bit till website is accessible
+    # wait a bit till website is accessible
     print("Wait for 60s for website to be available...")
     time.sleep(60)
     response = requests.get(kubeflow_endpoint)
@@ -14,6 +15,7 @@ def test_url_is_up(subdomain_name):
     assert len(response.history) > 0
     # redirection was to cognito domain
     assert "auth." + subdomain_name in response.url
+
 
 # Kubeflow sdk client need cookies provided by ALB. Currently it is not possible to programmatically fetch these cookies using tokens provided by cognito
 # See - https://stackoverflow.com/questions/62572327/how-to-pass-cookies-when-calling-authentication-enabled-aws-application-loadbala

--- a/tests/e2e/test_methods/cognito.py
+++ b/tests/e2e/test_methods/cognito.py
@@ -1,0 +1,23 @@
+import requests
+import time
+
+def test_url_is_up(subdomain_name):
+    kubeflow_endpoint = "https://kubeflow." + subdomain_name
+    print("kubeflow_endpoint:")
+    print(kubeflow_endpoint)
+    #wait a bit till website is accessible
+    print("Wait for 60s for website to be available...")
+    time.sleep(60)
+    response = requests.get(kubeflow_endpoint)
+    assert response.status_code == 200
+    # request was redirected
+    assert len(response.history) > 0
+    # redirection was to cognito domain
+    assert "auth." + subdomain_name in response.url
+
+# Kubeflow sdk client need cookies provided by ALB. Currently it is not possible to programmatically fetch these cookies using tokens provided by cognito
+# See - https://stackoverflow.com/questions/62572327/how-to-pass-cookies-when-calling-authentication-enabled-aws-application-loadbala
+# The other way to test multiuser kfp is by using selenium and creating a session using a real browser. There are drivers which can be used via Selenium webdriver to programmatically control a browser
+# e.g. https://chromedriver.chromium.org/getting-started
+# This is a hack and has been implemented in this PR - https://github.com/kubeflow/pipelines/pull/4182
+# TODO: explore if this will work in codebuild since there is an option to run headless i.e. without GUI

--- a/tests/e2e/test_methods/rds_s3.py
+++ b/tests/e2e/test_methods/rds_s3.py
@@ -212,6 +212,7 @@ def test_run_pipeline(
         database="mlpipeline",
     )
 
+    # todo: also add assert for other tables, https://github.com/awslabs/kubeflow-manifests/issues/327
     resp = mysql_utils.query(
         mysql_client, f"select * from run_details where UUID='{run.id}'"
     )

--- a/tests/e2e/test_methods/rds_s3.py
+++ b/tests/e2e/test_methods/rds_s3.py
@@ -1,0 +1,305 @@
+
+import os
+import json
+
+import pytest
+
+
+from e2e.utils.constants import DEFAULT_USER_NAMESPACE
+from e2e.utils.utils import (
+    wait_for,
+    rand_name,
+    WaitForCircuitBreakerError,
+    unmarshal_yaml,
+    get_mysql_client,
+    get_s3_client,
+)
+from e2e.utils.config import metadata
+
+from e2e.conftest import (
+    region,
+)
+
+from e2e.fixtures.clients import (
+    create_k8s_admission_registration_api_client,
+)
+from e2e.utils import mysql_utils
+
+from e2e.utils.custom_resources import (
+    create_katib_experiment_from_yaml,
+    get_katib_experiment,
+    delete_katib_experiment,
+)
+
+from kfp_server_api.exceptions import ApiException as KFPApiException
+from kubernetes.client.exceptions import ApiException as K8sApiException
+
+TO_ROOT = "../../"
+CUSTOM_RESOURCE_TEMPLATES_FOLDER = TO_ROOT + "tests/e2e/resources/custom-resource-templates/"
+DISABLE_PIPELINE_CACHING_PATCH_FILE = CUSTOM_RESOURCE_TEMPLATES_FOLDER + "patch-disable-pipeline-caching.yaml"
+
+KATIB_EXPERIMENT_FILE = "katib-experiment-random.yaml"
+PIPELINE_NAME = "[Demo] XGBoost - Iterative model training"
+MLMDB_NAME = "metadata_db"
+
+def wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id):
+    def callback():
+        resp = kfp_client.get_run(run.id)
+
+        assert resp.run.name == job_name
+        assert resp.run.pipeline_spec.pipeline_id == pipeline_id
+
+        if "Failed" == resp.run.status:
+            print(resp.run)
+            raise WaitForCircuitBreakerError("Pipeline run Failed")
+
+        assert resp.run.status == "Succeeded"
+
+        return resp
+
+    return wait_for(callback, timeout=600)
+
+def wait_for_katib_experiment_succeeded(cluster, region, namespace, name):
+    def callback():
+        resp = get_katib_experiment(cluster, region, namespace, name)
+
+        assert resp["kind"] == "Experiment"
+        assert resp["metadata"]["name"] == name
+        assert resp["metadata"]["namespace"] == namespace
+
+        assert resp["status"]["completionTime"] != None
+        condition_types = {
+            condition["type"] for condition in resp["status"]["conditions"]
+        }
+
+        if "Failed" in condition_types:
+            print(resp)
+            raise WaitForCircuitBreakerError("Katib experiment Failed")
+
+        assert "Succeeded" in condition_types
+
+    wait_for(callback)
+
+# Disable caching in KFP
+# By default KFP will cache previous pipeline runs and subsequent runs will skip cached steps
+# This prevents artifacts from being uploaded to s3 for subsequent runs
+def disable_kfp_caching(cluster, region):
+    patch_body = unmarshal_yaml(DISABLE_PIPELINE_CACHING_PATCH_FILE)
+    k8s_admission_registration_api_client = (
+        create_k8s_admission_registration_api_client(cluster, region)
+    )
+    k8s_admission_registration_api_client.patch_mutating_webhook_configuration(
+        "cache-webhook-kubeflow", patch_body
+    )
+
+def test_kfp_experiment(kfp_client, db_username, db_password, rds_endpoint, user_namespace=DEFAULT_USER_NAMESPACE):
+    name = rand_name("experiment-")
+    description = rand_name("description-")
+    experiment = kfp_client.create_experiment(
+        name, description=description, namespace=user_namespace
+    )
+
+    assert name == experiment.name
+    assert description == experiment.description
+    assert user_namespace == experiment.resource_references[0].key.id
+
+    mysql_client = get_mysql_client(
+        user=db_username,
+        password=db_password,
+        host=rds_endpoint,
+        database="mlpipeline",
+    )
+
+    resp = mysql_utils.query(
+        mysql_client, f"select * from experiments where Name='{name}'"
+    )
+    assert len(resp) == 1
+    assert resp[0]["Name"] == experiment.name
+    assert resp[0]["Description"] == experiment.description
+    assert resp[0]["Namespace"] == experiment.resource_references[0].key.id
+
+    resp = kfp_client.get_experiment(
+        experiment_id=experiment.id, namespace=user_namespace
+    )
+
+    assert name == resp.name
+    assert description == resp.description
+    assert user_namespace == resp.resource_references[0].key.id
+
+    kfp_client.delete_experiment(experiment.id)
+
+    resp = mysql_utils.query(
+        mysql_client, f"select * from experiments where Name='{name}'"
+    )
+    assert len(resp) == 0
+
+    try:
+        kfp_client.get_experiment(
+            experiment_id=experiment.id, namespace=user_namespace
+        )
+        raise AssertionError("Expected KFPApiException Not Found")
+    except KFPApiException as e:
+        assert "Not Found" == e.reason
+
+    mysql_client.close()
+
+def test_run_pipeline(kfp_client, s3_bucket_name, db_username, db_password, rds_endpoint, region, user_namespace=DEFAULT_USER_NAMESPACE, pipeline_name=PIPELINE_NAME):
+    s3_client = get_s3_client(region)
+
+    experiment_name = rand_name("experiment-")
+    experiment_description = rand_name("description-")
+    experiment = kfp_client.create_experiment(
+        experiment_name,
+        description=experiment_description,
+        namespace=user_namespace,
+    )
+
+    pipeline_id = kfp_client.get_pipeline_id(pipeline_name)
+    job_name = rand_name("run-")
+
+    run = kfp_client.run_pipeline(
+        experiment.id, job_name=job_name, pipeline_id=pipeline_id
+    )
+
+    assert run.name == job_name
+    assert run.pipeline_spec.pipeline_id == pipeline_id
+
+    resp = wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id)
+
+    workflow_manifest_json = resp.pipeline_runtime.workflow_manifest
+    workflow_manifest = json.loads(workflow_manifest_json)
+
+    s3_artifact_keys = []
+    for _, node in workflow_manifest["status"]["nodes"].items():
+        if "outputs" not in node:
+            continue
+        if "artifacts" not in node["outputs"]:
+            continue
+
+        for artifact in node["outputs"]["artifacts"]:
+            if "s3" not in artifact:
+                continue
+            s3_artifact_keys.append(artifact["s3"]["key"])
+
+    bucket_objects = s3_client.list_objects_v2(Bucket=s3_bucket_name)
+    content_keys = {content["Key"] for content in bucket_objects["Contents"]}
+
+    assert f"pipelines/{pipeline_id}" in content_keys
+    for key in s3_artifact_keys:
+        assert key in content_keys
+
+    mysql_client = get_mysql_client(
+        user=db_username,
+        password=db_password,
+        host=rds_endpoint,
+        database="mlpipeline",
+    )
+
+    resp = mysql_utils.query(
+        mysql_client, f"select * from run_details where UUID='{run.id}'"
+    )
+
+    assert len(resp) == 1
+    assert resp[0]["DisplayName"] == job_name
+    assert resp[0]["PipelineId"] == pipeline_id
+    assert resp[0]["Conditions"] == "Succeeded"
+
+    kfp_client.delete_experiment(experiment.id)
+
+def test_katib_experiment(cluster, region, db_username, db_password, rds_endpoint, custom_resource_templates_folder=CUSTOM_RESOURCE_TEMPLATES_FOLDER, katib_experiment_file=KATIB_EXPERIMENT_FILE, user_namespace=DEFAULT_USER_NAMESPACE):
+    filepath = os.path.abspath(
+        os.path.join(custom_resource_templates_folder, katib_experiment_file)
+    )
+
+    name = rand_name("katib-random-")
+    namespace = user_namespace
+    replacements = {"NAME": name, "NAMESPACE": namespace}
+
+    resp = create_katib_experiment_from_yaml(
+        cluster, region, filepath, namespace, replacements
+    )
+
+    assert resp["kind"] == "Experiment"
+    assert resp["metadata"]["name"] == name
+    assert resp["metadata"]["namespace"] == namespace
+
+    wait_for_katib_experiment_succeeded(cluster, region, namespace, name)
+
+    mysql_client = get_mysql_client(
+        user=db_username,
+        password=db_password,
+        host=rds_endpoint,
+        database="kubeflow",
+    )
+
+    resp = mysql_utils.query(
+        mysql_client,
+        f"select count(*) as count from observation_logs where trial_name like '{name}%'",
+    )
+
+    assert resp[0]["count"] > 0
+
+    resp = delete_katib_experiment(cluster, region, namespace, name)
+
+    assert resp["kind"] == "Experiment"
+    assert resp["metadata"]["name"] == name
+    assert resp["metadata"]["namespace"] == namespace
+
+    try:
+        get_katib_experiment(cluster, region, namespace, name)
+        raise AssertionError("Expected K8sApiException Not Found")
+    except K8sApiException as e:
+        assert "Not Found" == e.reason
+    
+def test_database_exists(db_username, db_password, rds_endpoint, database_name):
+    # will throw exception on connection error (e.g. if DB doesn't exist)
+    return get_mysql_client(
+        user=db_username,
+        password=db_password,
+        host=rds_endpoint,
+        database=database_name,
+    )
+    
+def test_verify_kubeflow_db(db_username, db_password, rds_endpoint):
+    mysql_client = test_database_exists(db_username, db_password, rds_endpoint, "kubeflow")
+
+    resp = mysql_utils.query(
+        mysql_client, f"show tables"
+    )
+    tables_in_kubeflow_db = {t['Tables_in_kubeflow'] for t in resp}
+    expected_tables_in_kubeflow_db = {'observation_logs'}
+    assert expected_tables_in_kubeflow_db == tables_in_kubeflow_db
+
+def test_verify_mlpipeline_db(db_username, db_password, rds_endpoint):
+    mysql_client = test_database_exists(db_username, db_password, rds_endpoint, "mlpipeline")
+
+    resp = mysql_utils.query(
+        mysql_client, f"show tables"
+    )
+    tables_in_mlpipeline = {t['Tables_in_mlpipeline'] for t in resp}
+    expected_tables_in_mlpipeline = {'pipelines', 'resource_references', 'db_statuses', 'default_experiments', 'jobs', 'tasks', 'experiments', 'run_details', 'run_metrics', 'pipeline_versions'}
+    assert expected_tables_in_mlpipeline == tables_in_mlpipeline
+
+def test_verify_mlmdb(db_username, db_password, rds_endpoint, mlmdb_name):
+    mysql_client = test_database_exists(db_username, db_password, rds_endpoint, mlmdb_name)
+
+    resp = mysql_utils.query(
+        mysql_client, f"show tables"
+    )
+    tables_in_mlmdb = {t[f"Tables_in_{mlmdb_name}"] for t in resp}
+    expected_tables_in_mlmdb = {'ContextProperty', 'Execution', 'ParentType', 'Type', 'ParentContext', 'ArtifactProperty', 'Event', 'ExecutionProperty', 'Context', 'EventPath', 'Artifact', 'MLMDEnv', 'Association', 'TypeProperty', 'Attribution'}
+    assert expected_tables_in_mlmdb == tables_in_mlmdb
+
+def test_s3_bucket_is_being_used_as_metadata_store(s3_bucket_name, region):
+    s3_client = get_s3_client(region)
+
+    bucket_objects = s3_client.list_objects_v2(Bucket=s3_bucket_name)
+    content_keys = {content["Key"] for content in bucket_objects["Contents"]}
+
+    found_uploaded_pipelines = False
+    for key in content_keys:
+        if "pipelines/" in key:
+            found_uploaded_pipelines = True
+
+    assert found_uploaded_pipelines == True
+

--- a/tests/e2e/test_methods/rds_s3.py
+++ b/tests/e2e/test_methods/rds_s3.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 
-from e2e.utils.constants import DEFAULT_USER_NAMESPACE
+from e2e.utils.constants import DEFAULT_USER_NAMESPACE, TO_ROOT, CUSTOM_RESOURCE_TEMPLATES_FOLDER, DISABLE_PIPELINE_CACHING_PATCH_FILE, KATIB_EXPERIMENT_FILE, PIPELINE_XG_BOOST, ALTERNATE_MLMDB_NAME
 from e2e.utils.utils import (
     wait_for,
     rand_name,
@@ -33,14 +33,6 @@ from e2e.utils.custom_resources import (
 
 from kfp_server_api.exceptions import ApiException as KFPApiException
 from kubernetes.client.exceptions import ApiException as K8sApiException
-
-TO_ROOT = "../../"
-CUSTOM_RESOURCE_TEMPLATES_FOLDER = TO_ROOT + "tests/e2e/resources/custom-resource-templates/"
-DISABLE_PIPELINE_CACHING_PATCH_FILE = CUSTOM_RESOURCE_TEMPLATES_FOLDER + "patch-disable-pipeline-caching.yaml"
-
-KATIB_EXPERIMENT_FILE = "katib-experiment-random.yaml"
-PIPELINE_NAME = "[Demo] XGBoost - Iterative model training"
-MLMDB_NAME = "metadata_db"
 
 def wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id):
     def callback():
@@ -143,7 +135,7 @@ def test_kfp_experiment(kfp_client, db_username, db_password, rds_endpoint, user
 
     mysql_client.close()
 
-def test_run_pipeline(kfp_client, s3_bucket_name, db_username, db_password, rds_endpoint, region, user_namespace=DEFAULT_USER_NAMESPACE, pipeline_name=PIPELINE_NAME):
+def test_run_pipeline(kfp_client, s3_bucket_name, db_username, db_password, rds_endpoint, region, user_namespace=DEFAULT_USER_NAMESPACE, pipeline_name=PIPELINE_XG_BOOST):
     s3_client = get_s3_client(region)
 
     experiment_name = rand_name("experiment-")

--- a/tests/e2e/test_methods/rds_s3.py
+++ b/tests/e2e/test_methods/rds_s3.py
@@ -9,7 +9,7 @@ from e2e.utils.constants import (
     TO_ROOT,
     CUSTOM_RESOURCE_TEMPLATES_FOLDER,
     DISABLE_PIPELINE_CACHING_PATCH_FILE,
-    KATIB_EXPERIMENT_FILE,
+    KATIB_EXPERIMENT_RANDOM_FILE,
     PIPELINE_XG_BOOST,
     ALTERNATE_MLMDB_NAME,
 )
@@ -231,7 +231,7 @@ def test_katib_experiment(
     db_password,
     rds_endpoint,
     custom_resource_templates_folder=CUSTOM_RESOURCE_TEMPLATES_FOLDER,
-    katib_experiment_file=KATIB_EXPERIMENT_FILE,
+    katib_experiment_file=KATIB_EXPERIMENT_RANDOM_FILE,
     user_namespace=DEFAULT_USER_NAMESPACE,
 ):
     filepath = os.path.abspath(

--- a/tests/e2e/test_methods/vanilla.py
+++ b/tests/e2e/test_methods/vanilla.py
@@ -47,7 +47,7 @@ def sagemaker_execution_role(region):
         ],
     }
 
-    managed_policies = ["AmazonS3FullAccess", "AmazonSageMakerFullAccess"]
+    managed_policies = ["arn:aws:iam::aws:policy/AmazonS3FullAccess", "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"]
 
     role = IAMRole(name=role_name, region=region, policies=managed_policies)
     role.create(

--- a/tests/e2e/test_methods/vanilla.py
+++ b/tests/e2e/test_methods/vanilla.py
@@ -7,7 +7,7 @@ from e2e.utils.constants import (
     DEFAULT_USER_NAMESPACE,
     TO_ROOT,
     CUSTOM_RESOURCE_TEMPLATES_FOLDER,
-    KATIB_EXPERIMENT_FILE,
+    KATIB_EXPERIMENT_RANDOM_FILE,
     PIPELINE_DATA_PASSING,
     PIPELINE_SAGEMAKER_TRAINING,
     NOTEBOOK_IMAGE_TF_CPU,
@@ -61,7 +61,7 @@ def sagemaker_execution_role(region):
         "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
     ]
 
-    role = IAMRole(name=role_name, region=region, policies=managed_policies)
+    role = IAMRole(name=role_name, region=region, policy_arns=managed_policies)
     role.create(policy_document=json.dumps(trust_policy))
 
     yield role
@@ -153,7 +153,7 @@ def test_katib_experiment(
     cluster,
     region,
     custom_resource_templates_folder=CUSTOM_RESOURCE_TEMPLATES_FOLDER,
-    katib_experiment_file=KATIB_EXPERIMENT_FILE,
+    katib_experiment_file=KATIB_EXPERIMENT_RANDOM_FILE,
     user_namespace=DEFAULT_USER_NAMESPACE,
 ):
     filepath = os.path.abspath(

--- a/tests/e2e/test_methods/vanilla.py
+++ b/tests/e2e/test_methods/vanilla.py
@@ -3,7 +3,7 @@ import subprocess
 import os
 import json
 
-from e2e.utils.constants import DEFAULT_USER_NAMESPACE
+from e2e.utils.constants import DEFAULT_USER_NAMESPACE, TO_ROOT, CUSTOM_RESOURCE_TEMPLATES_FOLDER, KATIB_EXPERIMENT_FILE, PIPELINE_DATA_PASSING, PIPELINE_SAGEMAKER_TRAINING, NOTEBOOK_IMAGE_TF_CPU
 
 from e2e.utils.utils import (
     wait_for,
@@ -23,21 +23,10 @@ from kubernetes.client.exceptions import ApiException as K8sApiException
 from e2e.utils.aws.iam import IAMRole
 from e2e.utils.s3_for_training.data_bucket import S3BucketWithTrainingData
 
-TO_ROOT = "../../"
-CUSTOM_RESOURCE_TEMPLATES_FOLDER = TO_ROOT + "tests/e2e/resources/custom-resource-templates"
-KATIB_EXPERIMENT_FILE = "katib-experiment-random.yaml"
-
-PIPELINE_NAME_KFP = "[Tutorial] SageMaker Training"
-PIPELINE_NAME = "[Tutorial] Data passing in python components"
-
-NOTEBOOK_IMAGES = [
-    "public.ecr.aws/c9e4w0g3/notebook-servers/jupyter-tensorflow:2.6.3-cpu-py38-ubuntu20.04-v1.8",
-]
-
 TEST_ACK_CRDS_PARAMS = [
     (
         "ack",
-        NOTEBOOK_IMAGES[0],
+        NOTEBOOK_IMAGE_TF_CPU,
         "verify_ack_integration.ipynb",
         "No resources found in kubeflow-user-example-com namespace",
     ),
@@ -120,7 +109,7 @@ def test_kfp_experiment(kfp_client, user_namespace=DEFAULT_USER_NAMESPACE):
     except KFPApiException as e:
         assert "Not Found" == e.reason
 
-def test_run_pipeline(kfp_client, user_namespace=DEFAULT_USER_NAMESPACE, pipeline_name=PIPELINE_NAME):
+def test_run_pipeline(kfp_client, user_namespace=DEFAULT_USER_NAMESPACE, pipeline_name=PIPELINE_DATA_PASSING):
     experiment_name = rand_name("experiment-")
     experiment_description = rand_name("description-")
     experiment = kfp_client.create_experiment(
@@ -225,7 +214,7 @@ def test_run_kfp_sagemaker_pipeline(
         namespace=user_namespace,
     )
 
-    pipeline_id = kfp_client.get_pipeline_id(PIPELINE_NAME_KFP)
+    pipeline_id = kfp_client.get_pipeline_id(PIPELINE_SAGEMAKER_TRAINING)
 
     params = {
         "sagemaker_role_arn": sagemaker_execution_role_arn,

--- a/tests/e2e/test_methods/vanilla.py
+++ b/tests/e2e/test_methods/vanilla.py
@@ -1,0 +1,248 @@
+import pytest
+import subprocess
+import os
+import json
+
+from e2e.utils.constants import DEFAULT_USER_NAMESPACE
+
+from e2e.utils.utils import (
+    wait_for,
+    rand_name,
+    WaitForCircuitBreakerError,
+)
+
+from e2e.utils.custom_resources import (
+    create_katib_experiment_from_yaml,
+    get_katib_experiment,
+    delete_katib_experiment,
+)
+
+from kfp_server_api.exceptions import ApiException as KFPApiException
+from kubernetes.client.exceptions import ApiException as K8sApiException
+
+from e2e.utils.aws.iam import IAMRole
+from e2e.utils.s3_for_training.data_bucket import S3BucketWithTrainingData
+
+TO_ROOT = "../../"
+CUSTOM_RESOURCE_TEMPLATES_FOLDER = TO_ROOT + "tests/e2e/resources/custom-resource-templates"
+KATIB_EXPERIMENT_FILE = "katib-experiment-random.yaml"
+
+PIPELINE_NAME_KFP = "[Tutorial] SageMaker Training"
+PIPELINE_NAME = "[Tutorial] Data passing in python components"
+
+NOTEBOOK_IMAGES = [
+    "public.ecr.aws/c9e4w0g3/notebook-servers/jupyter-tensorflow:2.6.3-cpu-py38-ubuntu20.04-v1.8",
+]
+
+TEST_ACK_CRDS_PARAMS = [
+    (
+        "ack",
+        NOTEBOOK_IMAGES[0],
+        "verify_ack_integration.ipynb",
+        "No resources found in kubeflow-user-example-com namespace",
+    ),
+]
+
+@pytest.fixture(scope="class")
+def sagemaker_execution_role(region):
+    role_name = rand_name("sm-exec-role-")
+
+    trust_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": "sagemaker.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+
+    managed_policies = ["AmazonS3FullAccess", "AmazonSageMakerFullAccess"]
+
+    role = IAMRole(name=role_name, region=region, policies=managed_policies)
+    role.create(
+        policy_document=json.dumps(trust_policy)
+    )
+
+    yield role
+
+    role.delete()
+
+@pytest.fixture(scope="class")
+def s3_bucket_with_data():
+    bucket_name = rand_name("kfp-sm-training-data-")
+
+    bucket = S3BucketWithTrainingData(name=bucket_name)
+    bucket.create()
+
+    yield bucket
+
+    bucket.delete()
+
+def wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id):
+    def callback():
+        resp = kfp_client.get_run(run.id).run
+
+        assert resp.name == job_name
+        assert resp.pipeline_spec.pipeline_id == pipeline_id
+        assert resp.status == "Succeeded"
+
+    wait_for(callback, 600)
+
+
+def test_kfp_experiment(kfp_client, user_namespace=DEFAULT_USER_NAMESPACE):
+    name = rand_name("experiment-")
+    description = rand_name("description-")
+    experiment = kfp_client.create_experiment(
+        name, description=description, namespace=user_namespace
+    )
+
+    assert name == experiment.name
+    assert description == experiment.description
+    assert user_namespace == experiment.resource_references[0].key.id
+
+    resp = kfp_client.get_experiment(
+        experiment_id=experiment.id, namespace=user_namespace
+    )
+
+    assert name == resp.name
+    assert description == resp.description
+    assert user_namespace == resp.resource_references[0].key.id
+
+    kfp_client.delete_experiment(experiment.id)
+
+    try:
+        kfp_client.get_experiment(
+            experiment_id=experiment.id, namespace=user_namespace
+        )
+        raise AssertionError("Expected KFPApiException Not Found")
+    except KFPApiException as e:
+        assert "Not Found" == e.reason
+
+def test_run_pipeline(kfp_client, user_namespace=DEFAULT_USER_NAMESPACE, pipeline_name=PIPELINE_NAME):
+    experiment_name = rand_name("experiment-")
+    experiment_description = rand_name("description-")
+    experiment = kfp_client.create_experiment(
+        experiment_name,
+        description=experiment_description,
+        namespace=user_namespace,
+    )
+
+    pipeline_id = kfp_client.get_pipeline_id(pipeline_name)
+    job_name = rand_name("run-")
+
+    run = kfp_client.run_pipeline(
+        experiment.id, job_name=job_name, pipeline_id=pipeline_id
+    )
+
+    assert run.name == job_name
+    assert run.pipeline_spec.pipeline_id == pipeline_id
+    assert run.status == None
+
+    wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id)
+
+    kfp_client.delete_experiment(experiment.id)
+
+def test_katib_experiment(cluster, region, custom_resource_templates_folder=CUSTOM_RESOURCE_TEMPLATES_FOLDER, katib_experiment_file=KATIB_EXPERIMENT_FILE, user_namespace=DEFAULT_USER_NAMESPACE):
+    filepath = os.path.abspath(
+        os.path.join(custom_resource_templates_folder, katib_experiment_file)
+    )
+
+    name = rand_name("katib-random-")
+    namespace = user_namespace
+    replacements = {"NAME": name, "NAMESPACE": namespace}
+
+    resp = create_katib_experiment_from_yaml(
+        cluster, region, filepath, namespace, replacements
+    )
+
+    assert resp["kind"] == "Experiment"
+    assert resp["metadata"]["name"] == name
+    assert resp["metadata"]["namespace"] == namespace
+
+    resp = get_katib_experiment(cluster, region, namespace, name)
+
+    assert resp["kind"] == "Experiment"
+    assert resp["metadata"]["name"] == name
+    assert resp["metadata"]["namespace"] == namespace
+
+    resp = delete_katib_experiment(cluster, region, namespace, name)
+
+    assert resp["kind"] == "Experiment"
+    assert resp["metadata"]["name"] == name
+    assert resp["metadata"]["namespace"] == namespace
+
+    try:
+        get_katib_experiment(cluster, region, namespace, name)
+        raise AssertionError("Expected K8sApiException Not Found")
+    except K8sApiException as e:
+        assert "Not Found" == e.reason
+
+def test_ack_crds(
+    notebook_server,
+    framework_name,
+    ipynb_notebook_file,
+    expected_output,
+    user_namespace=DEFAULT_USER_NAMESPACE,
+):
+    """
+    Spins up a DLC Notebook and checks that the basic ACK CRD is installed. 
+    """
+    nb_list = subprocess.check_output(
+        f"kubectl get notebooks -n {user_namespace}".split()
+    ).decode()
+
+    metadata_key = f"{framework_name}-notebook_server"
+    notebook_name = notebook_server["NOTEBOOK_NAME"]
+    assert notebook_name is not None
+    assert notebook_name in nb_list
+    print(notebook_name)
+
+    sub_cmd = f"jupyter nbconvert --to notebook --execute ../uploaded/{ipynb_notebook_file} --stdout"
+    cmd = f"kubectl -n kubeflow-user-example-com exec -it {notebook_name}-0 -- /bin/bash -c".split()
+    cmd.append(sub_cmd)
+
+    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode()
+    print(output)
+    # The second condition is now required in case the kfp test runs before this one.
+    assert expected_output in output or "training-job-" in output
+    
+def test_run_kfp_sagemaker_pipeline(
+    kfp_client, s3_bucket_with_data, sagemaker_execution_role_arn, user_namespace=DEFAULT_USER_NAMESPACE
+):
+    random_prefix = rand_name("kfp-")
+
+    experiment_name = "experiment-" + random_prefix
+    experiment_description = "description-" + random_prefix
+    bucket_name = s3_bucket_with_data
+        
+    job_name = "kfp-run-" + random_prefix
+
+    experiment = kfp_client.create_experiment(
+        experiment_name,
+        description=experiment_description,
+        namespace=user_namespace,
+    )
+
+    pipeline_id = kfp_client.get_pipeline_id(PIPELINE_NAME_KFP)
+
+    params = {
+        "sagemaker_role_arn": sagemaker_execution_role_arn,
+        "s3_bucket_name": bucket_name,
+    }
+
+    run = kfp_client.run_pipeline(
+        experiment.id, job_name=job_name, pipeline_id=pipeline_id, params=params
+    )
+
+    assert run.name == job_name
+    assert run.pipeline_spec.pipeline_id == pipeline_id
+    assert run.status == None
+
+    wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id)
+
+    kfp_client.delete_experiment(experiment.id)
+        
+    cmd = "kubectl delete trainingjobs --all -n kubeflow-user-example-com".split()
+    subprocess.Popen(cmd)

--- a/tests/e2e/tests/terraform/test_cognito.py
+++ b/tests/e2e/tests/terraform/test_cognito.py
@@ -1,5 +1,6 @@
 import pytest
 
+from e2e.utils.constants import TO_ROOT
 from e2e.utils.config import metadata
 from e2e.utils.utils import rand_name
 from e2e.conftest import region, get_root_domain_name
@@ -8,7 +9,6 @@ from e2e.utils.terraform_utils import terraform_installation
 from e2e.test_methods import cognito
 
 TEST_SUITE_NAME = "tf-cognito"
-TO_ROOT = "../../"
 TF_FOLDER = TO_ROOT + "deployments/cognito/terraform/"
 
 

--- a/tests/e2e/tests/terraform/test_cognito.py
+++ b/tests/e2e/tests/terraform/test_cognito.py
@@ -1,0 +1,43 @@
+import pytest
+
+from e2e.utils.config import metadata
+from e2e.utils.utils import rand_name
+from e2e.conftest import region, get_root_domain_name
+    
+from e2e.utils.terraform_utils import terraform_installation
+from e2e.test_methods import cognito
+
+TEST_SUITE_NAME = "tf-cognito"
+TO_ROOT = "../../"
+TF_FOLDER = TO_ROOT + "deployments/cognito/terraform/"
+
+
+@pytest.fixture(scope="class")
+def installation(region, metadata, request):
+    cluster_name = rand_name(TEST_SUITE_NAME+"-")
+    subdomain_name = rand_name("sub") + "." + get_root_domain_name(request)
+    cognito_user_pool_name = rand_name("up-")
+
+    input_variables = {
+        "cluster_name": cluster_name,
+        "cluster_region": region,
+        "aws_route53_root_zone_name": get_root_domain_name(request),
+        "aws_route53_subdomain_zone_name": subdomain_name,
+        "cognito_user_pool_name": cognito_user_pool_name,
+    }
+    
+    return terraform_installation(input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request)
+
+class TestCognitoTerraform:
+
+    @pytest.fixture(scope="class")
+    def setup(self, installation):
+        metadata_file = metadata.to_file()
+        print(metadata.params)
+        print("Created metadata file for TestCognitoTerraform", metadata_file)
+    
+
+    def test_url_is_up(self, installation):
+        subdomain_name = installation["aws_route53_subdomain_zone_name"]
+
+        cognito.test_url_is_up(subdomain_name)

--- a/tests/e2e/tests/terraform/test_cognito.py
+++ b/tests/e2e/tests/terraform/test_cognito.py
@@ -33,12 +33,12 @@ def installation(region, metadata, request):
 
 class TestCognitoTerraform:
     @pytest.fixture(scope="class")
-    def setup(self, installation):
+    def setup(self, metadata, installation):
         metadata_file = metadata.to_file()
         print(metadata.params)
         print("Created metadata file for TestCognitoTerraform", metadata_file)
 
-    def test_url_is_up(self, installation):
+    def test_url_is_up(self, setup, installation):
         subdomain_name = installation["aws_route53_subdomain_zone_name"]
 
         cognito.test_url_is_up(subdomain_name)

--- a/tests/e2e/tests/terraform/test_cognito.py
+++ b/tests/e2e/tests/terraform/test_cognito.py
@@ -4,7 +4,7 @@ from e2e.utils.constants import TO_ROOT
 from e2e.utils.config import metadata
 from e2e.utils.utils import rand_name
 from e2e.conftest import region, get_root_domain_name
-    
+
 from e2e.utils.terraform_utils import terraform_installation
 from e2e.test_methods import cognito
 
@@ -14,7 +14,7 @@ TF_FOLDER = TO_ROOT + "deployments/cognito/terraform/"
 
 @pytest.fixture(scope="class")
 def installation(region, metadata, request):
-    cluster_name = rand_name(TEST_SUITE_NAME+"-")
+    cluster_name = rand_name(TEST_SUITE_NAME + "-")
     subdomain_name = rand_name("sub") + "." + get_root_domain_name(request)
     cognito_user_pool_name = rand_name("up-")
 
@@ -25,17 +25,18 @@ def installation(region, metadata, request):
         "aws_route53_subdomain_zone_name": subdomain_name,
         "cognito_user_pool_name": cognito_user_pool_name,
     }
-    
-    return terraform_installation(input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request)
+
+    return terraform_installation(
+        input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request
+    )
+
 
 class TestCognitoTerraform:
-
     @pytest.fixture(scope="class")
     def setup(self, installation):
         metadata_file = metadata.to_file()
         print(metadata.params)
         print("Created metadata file for TestCognitoTerraform", metadata_file)
-    
 
     def test_url_is_up(self, installation):
         subdomain_name = installation["aws_route53_subdomain_zone_name"]

--- a/tests/e2e/tests/terraform/test_cognito_rds_s3.py
+++ b/tests/e2e/tests/terraform/test_cognito_rds_s3.py
@@ -4,7 +4,7 @@ from e2e.utils.constants import TO_ROOT, ALTERNATE_MLMDB_NAME
 from e2e.utils.config import metadata
 from e2e.utils.utils import rand_name
 from e2e.conftest import region, get_accesskey, get_secretkey, get_root_domain_name
-    
+
 from e2e.utils.terraform_utils import terraform_installation, get_stack_output
 from e2e.test_methods import cognito, rds_s3
 
@@ -14,7 +14,7 @@ TF_FOLDER = TO_ROOT + "deployments/cognito-rds-s3/terraform/"
 
 @pytest.fixture(scope="class")
 def installation(region, metadata, request):
-    cluster_name = rand_name(TEST_SUITE_NAME+"-")
+    cluster_name = rand_name(TEST_SUITE_NAME + "-")
     db_username = rand_name("user")
     db_password = rand_name("pw")
     subdomain_name = rand_name("sub") + "." + get_root_domain_name(request)
@@ -36,24 +36,28 @@ def installation(region, metadata, request):
         "aws_route53_subdomain_zone_name": subdomain_name,
         "cognito_user_pool_name": cognito_user_pool_name,
     }
-    
-    return terraform_installation(input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request)
+
+    return terraform_installation(
+        input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request
+    )
+
 
 class TestCognitoRDSS3Terraform:
-
     @pytest.fixture(scope="class")
     def setup(self, installation):
-        rds_s3.disable_kfp_caching(installation["cluster_name"], installation["cluster_region"])
+        rds_s3.disable_kfp_caching(
+            installation["cluster_name"], installation["cluster_region"]
+        )
 
         metadata_file = metadata.to_file()
         print(metadata.params)
         print("Created metadata file for TestCognitoRDSS3Terraform", metadata_file)
-    
+
     def test_url_is_up(self, installation):
         subdomain_name = installation["aws_route53_subdomain_zone_name"]
 
         cognito.test_url_is_up(subdomain_name)
-    
+
     def test_verify_kubeflow_db(self, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
@@ -67,7 +71,7 @@ class TestCognitoRDSS3Terraform:
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
 
         rds_s3.test_verify_mlpipeline_db(db_username, db_password, rds_endpoint)
-    
+
     def test_verify_mlmdb(self, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
@@ -75,7 +79,7 @@ class TestCognitoRDSS3Terraform:
         mlmdb_name = installation["mlmdb_name"]
 
         rds_s3.test_verify_mlmdb(db_username, db_password, rds_endpoint, mlmdb_name)
-    
+
     def test_s3_bucket_is_being_used_as_metadata_store(self, installation):
         region = installation["cluster_region"]
         s3_bucket_name = get_stack_output("s3_bucket_name", TF_FOLDER)
@@ -89,5 +93,6 @@ class TestCognitoRDSS3Terraform:
         cluster_name = installation["cluster_name"]
         region = installation["cluster_region"]
 
-        rds_s3.test_katib_experiment(cluster_name, region, db_username, db_password, rds_endpoint)
-    
+        rds_s3.test_katib_experiment(
+            cluster_name, region, db_username, db_password, rds_endpoint
+        )

--- a/tests/e2e/tests/terraform/test_cognito_rds_s3.py
+++ b/tests/e2e/tests/terraform/test_cognito_rds_s3.py
@@ -1,5 +1,6 @@
 import pytest
 
+from e2e.utils.constants import TO_ROOT, ALTERNATE_MLMDB_NAME
 from e2e.utils.config import metadata
 from e2e.utils.utils import rand_name
 from e2e.conftest import region, get_accesskey, get_secretkey, get_root_domain_name
@@ -8,7 +9,6 @@ from e2e.utils.terraform_utils import terraform_installation, get_stack_output
 from e2e.test_methods import cognito, rds_s3
 
 TEST_SUITE_NAME = "tf-cgo-rds-s3"
-TO_ROOT = "../../"
 TF_FOLDER = TO_ROOT + "deployments/cognito-rds-s3/terraform/"
 
 
@@ -27,7 +27,7 @@ def installation(region, metadata, request):
         "db_password": db_password,
         "minio_aws_access_key_id": get_accesskey(request),
         "minio_aws_secret_access_key": get_secretkey(request),
-        "mlmdb_name": rds_s3.MLMDB_NAME,
+        "mlmdb_name": ALTERNATE_MLMDB_NAME,
         "publicly_accessible": "true",
         "deletion_protection": "false",
         "secret_recovery_window_in_days": "0",

--- a/tests/e2e/tests/terraform/test_cognito_rds_s3.py
+++ b/tests/e2e/tests/terraform/test_cognito_rds_s3.py
@@ -44,7 +44,7 @@ def installation(region, metadata, request):
 
 class TestCognitoRDSS3Terraform:
     @pytest.fixture(scope="class")
-    def setup(self, installation):
+    def setup(self, metadata, installation):
         rds_s3.disable_kfp_caching(
             installation["cluster_name"], installation["cluster_region"]
         )
@@ -53,26 +53,26 @@ class TestCognitoRDSS3Terraform:
         print(metadata.params)
         print("Created metadata file for TestCognitoRDSS3Terraform", metadata_file)
 
-    def test_url_is_up(self, installation):
+    def test_url_is_up(self, setup, installation):
         subdomain_name = installation["aws_route53_subdomain_zone_name"]
 
         cognito.test_url_is_up(subdomain_name)
 
-    def test_verify_kubeflow_db(self, installation):
+    def test_verify_kubeflow_db(self, setup, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
 
         rds_s3.test_verify_kubeflow_db(db_username, db_password, rds_endpoint)
 
-    def test_verify_mlpipeline_db(self, installation):
+    def test_verify_mlpipeline_db(self, setup, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
 
         rds_s3.test_verify_mlpipeline_db(db_username, db_password, rds_endpoint)
 
-    def test_verify_mlmdb(self, installation):
+    def test_verify_mlmdb(self, setup, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
@@ -80,13 +80,13 @@ class TestCognitoRDSS3Terraform:
 
         rds_s3.test_verify_mlmdb(db_username, db_password, rds_endpoint, mlmdb_name)
 
-    def test_s3_bucket_is_being_used_as_metadata_store(self, installation):
+    def test_s3_bucket_is_being_used_as_metadata_store(self, setup, installation):
         region = installation["cluster_region"]
         s3_bucket_name = get_stack_output("s3_bucket_name", TF_FOLDER)
 
         rds_s3.test_s3_bucket_is_being_used_as_metadata_store(s3_bucket_name, region)
 
-    def test_katib_experiment(self, installation):
+    def test_katib_experiment(self, setup, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)

--- a/tests/e2e/tests/terraform/test_cognito_rds_s3.py
+++ b/tests/e2e/tests/terraform/test_cognito_rds_s3.py
@@ -1,0 +1,93 @@
+import pytest
+
+from e2e.utils.config import metadata
+from e2e.utils.utils import rand_name
+from e2e.conftest import region, get_accesskey, get_secretkey, get_root_domain_name
+    
+from e2e.utils.terraform_utils import terraform_installation, get_stack_output
+from e2e.test_methods import cognito, rds_s3
+
+TEST_SUITE_NAME = "tf-cgo-rds-s3"
+TO_ROOT = "../../"
+TF_FOLDER = TO_ROOT + "deployments/cognito-rds-s3/terraform/"
+
+
+@pytest.fixture(scope="class")
+def installation(region, metadata, request):
+    cluster_name = rand_name(TEST_SUITE_NAME+"-")
+    db_username = rand_name("user")
+    db_password = rand_name("pw")
+    subdomain_name = rand_name("sub") + "." + get_root_domain_name(request)
+    cognito_user_pool_name = rand_name("up-")
+
+    input_variables = {
+        "cluster_name": cluster_name,
+        "cluster_region": region,
+        "db_username": db_username,
+        "db_password": db_password,
+        "minio_aws_access_key_id": get_accesskey(request),
+        "minio_aws_secret_access_key": get_secretkey(request),
+        "mlmdb_name": rds_s3.MLMDB_NAME,
+        "publicly_accessible": "true",
+        "deletion_protection": "false",
+        "secret_recovery_window_in_days": "0",
+        "force_destroy_s3_bucket": "true",
+        "aws_route53_root_zone_name": get_root_domain_name(request),
+        "aws_route53_subdomain_zone_name": subdomain_name,
+        "cognito_user_pool_name": cognito_user_pool_name,
+    }
+    
+    return terraform_installation(input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request)
+
+class TestCognitoRDSS3Terraform:
+
+    @pytest.fixture(scope="class")
+    def setup(self, installation):
+        rds_s3.disable_kfp_caching(installation["cluster_name"], installation["cluster_region"])
+
+        metadata_file = metadata.to_file()
+        print(metadata.params)
+        print("Created metadata file for TestCognitoRDSS3Terraform", metadata_file)
+    
+    def test_url_is_up(self, installation):
+        subdomain_name = installation["aws_route53_subdomain_zone_name"]
+
+        cognito.test_url_is_up(subdomain_name)
+    
+    def test_verify_kubeflow_db(self, installation):
+        db_username = installation["db_username"]
+        db_password = installation["db_password"]
+        rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
+
+        rds_s3.test_verify_kubeflow_db(db_username, db_password, rds_endpoint)
+
+    def test_verify_mlpipeline_db(self, installation):
+        db_username = installation["db_username"]
+        db_password = installation["db_password"]
+        rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
+
+        rds_s3.test_verify_mlpipeline_db(db_username, db_password, rds_endpoint)
+    
+    def test_verify_mlmdb(self, installation):
+        db_username = installation["db_username"]
+        db_password = installation["db_password"]
+        rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
+        mlmdb_name = installation["mlmdb_name"]
+
+        rds_s3.test_verify_mlmdb(db_username, db_password, rds_endpoint, mlmdb_name)
+    
+    def test_s3_bucket_is_being_used_as_metadata_store(self, installation):
+        region = installation["cluster_region"]
+        s3_bucket_name = get_stack_output("s3_bucket_name", TF_FOLDER)
+
+        rds_s3.test_s3_bucket_is_being_used_as_metadata_store(s3_bucket_name, region)
+
+    def test_katib_experiment(self, installation):
+        db_username = installation["db_username"]
+        db_password = installation["db_password"]
+        rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
+        cluster_name = installation["cluster_name"]
+        region = installation["cluster_region"]
+
+        rds_s3.test_katib_experiment(cluster_name, region, db_username, db_password, rds_endpoint)
+    

--- a/tests/e2e/tests/terraform/test_rds_s3.py
+++ b/tests/e2e/tests/terraform/test_rds_s3.py
@@ -4,7 +4,7 @@ from e2e.utils.constants import TO_ROOT, ALTERNATE_MLMDB_NAME
 from e2e.utils.config import metadata
 from e2e.utils.utils import rand_name
 from e2e.conftest import region, get_accesskey, get_secretkey
-    
+
 from e2e.fixtures.clients import (
     kfp_client,
     port_forward,
@@ -24,7 +24,7 @@ TF_FOLDER = TO_ROOT + "deployments/rds-s3/terraform/"
 
 @pytest.fixture(scope="class")
 def installation(region, metadata, request):
-    cluster_name = rand_name(TEST_SUITE_NAME+"-")
+    cluster_name = rand_name(TEST_SUITE_NAME + "-")
     db_username = rand_name("user")
     db_password = rand_name("pw")
 
@@ -41,19 +41,23 @@ def installation(region, metadata, request):
         "secret_recovery_window_in_days": "0",
         "force_destroy_s3_bucket": "true",
     }
-    
-    return terraform_installation(input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request)
+
+    return terraform_installation(
+        input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request
+    )
+
 
 class TestRDSS3Terraform:
-
     @pytest.fixture(scope="class")
     def setup(self, installation):
-        rds_s3.disable_kfp_caching(installation["cluster_name"], installation["cluster_region"])
+        rds_s3.disable_kfp_caching(
+            installation["cluster_name"], installation["cluster_region"]
+        )
 
         metadata_file = metadata.to_file()
         print(metadata.params)
         print("Created metadata file for TestRDSS3Terraform", metadata_file)
-    
+
     def test_verify_kubeflow_db(self, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
@@ -67,7 +71,7 @@ class TestRDSS3Terraform:
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
 
         rds_s3.test_verify_mlpipeline_db(db_username, db_password, rds_endpoint)
-    
+
     def test_verify_mlmdb(self, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
@@ -75,7 +79,7 @@ class TestRDSS3Terraform:
         mlmdb_name = installation["mlmdb_name"]
 
         rds_s3.test_verify_mlmdb(db_username, db_password, rds_endpoint, mlmdb_name)
-    
+
     def test_s3_bucket_is_being_used_as_metadata_store(self, installation):
         region = installation["cluster_region"]
         s3_bucket_name = get_stack_output("s3_bucket_name", TF_FOLDER)
@@ -88,7 +92,7 @@ class TestRDSS3Terraform:
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
 
         rds_s3.test_kfp_experiment(kfp_client, db_username, db_password, rds_endpoint)
-    
+
     def test_run_pipeline(self, kfp_client, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
@@ -96,8 +100,10 @@ class TestRDSS3Terraform:
         s3_bucket_name = get_stack_output("s3_bucket_name", TF_FOLDER)
         region = installation["cluster_region"]
 
-        rds_s3.test_run_pipeline(kfp_client, s3_bucket_name, db_username, db_password, rds_endpoint, region)
-    
+        rds_s3.test_run_pipeline(
+            kfp_client, s3_bucket_name, db_username, db_password, rds_endpoint, region
+        )
+
     def test_katib_experiment(self, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
@@ -105,9 +111,9 @@ class TestRDSS3Terraform:
         cluster_name = installation["cluster_name"]
         region = installation["cluster_region"]
 
-        rds_s3.test_katib_experiment(cluster_name, region, db_username, db_password, rds_endpoint)
+        rds_s3.test_katib_experiment(
+            cluster_name, region, db_username, db_password, rds_endpoint
+        )
 
     def test_works(cluster, region):
         cloudwatch.test_works(cluster, region)
-
-    

--- a/tests/e2e/tests/terraform/test_rds_s3.py
+++ b/tests/e2e/tests/terraform/test_rds_s3.py
@@ -49,7 +49,7 @@ def installation(region, metadata, request):
 
 class TestRDSS3Terraform:
     @pytest.fixture(scope="class")
-    def setup(self, installation):
+    def setup(self, metadata, installation):
         rds_s3.disable_kfp_caching(
             installation["cluster_name"], installation["cluster_region"]
         )
@@ -58,21 +58,21 @@ class TestRDSS3Terraform:
         print(metadata.params)
         print("Created metadata file for TestRDSS3Terraform", metadata_file)
 
-    def test_verify_kubeflow_db(self, installation):
+    def test_verify_kubeflow_db(self, setup, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
 
         rds_s3.test_verify_kubeflow_db(db_username, db_password, rds_endpoint)
 
-    def test_verify_mlpipeline_db(self, installation):
+    def test_verify_mlpipeline_db(self, setup, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
 
         rds_s3.test_verify_mlpipeline_db(db_username, db_password, rds_endpoint)
 
-    def test_verify_mlmdb(self, installation):
+    def test_verify_mlmdb(self, setup, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
@@ -80,20 +80,20 @@ class TestRDSS3Terraform:
 
         rds_s3.test_verify_mlmdb(db_username, db_password, rds_endpoint, mlmdb_name)
 
-    def test_s3_bucket_is_being_used_as_metadata_store(self, installation):
+    def test_s3_bucket_is_being_used_as_metadata_store(self, setup, installation):
         region = installation["cluster_region"]
         s3_bucket_name = get_stack_output("s3_bucket_name", TF_FOLDER)
 
         rds_s3.test_s3_bucket_is_being_used_as_metadata_store(s3_bucket_name, region)
 
-    def test_kfp_experiment(self, kfp_client, installation):
+    def test_kfp_experiment(self, setup, kfp_client, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
 
         rds_s3.test_kfp_experiment(kfp_client, db_username, db_password, rds_endpoint)
 
-    def test_run_pipeline(self, kfp_client, installation):
+    def test_run_pipeline(self, setup, kfp_client, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
@@ -104,7 +104,7 @@ class TestRDSS3Terraform:
             kfp_client, s3_bucket_name, db_username, db_password, rds_endpoint, region
         )
 
-    def test_katib_experiment(self, installation):
+    def test_katib_experiment(self, setup, installation):
         db_username = installation["db_username"]
         db_password = installation["db_password"]
         rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
@@ -114,6 +114,3 @@ class TestRDSS3Terraform:
         rds_s3.test_katib_experiment(
             cluster_name, region, db_username, db_password, rds_endpoint
         )
-
-    def test_works(cluster, region):
-        cloudwatch.test_works(cluster, region)

--- a/tests/e2e/tests/terraform/test_rds_s3.py
+++ b/tests/e2e/tests/terraform/test_rds_s3.py
@@ -1,5 +1,6 @@
 import pytest
 
+from e2e.utils.constants import TO_ROOT, ALTERNATE_MLMDB_NAME
 from e2e.utils.config import metadata
 from e2e.utils.utils import rand_name
 from e2e.conftest import region, get_accesskey, get_secretkey
@@ -18,7 +19,6 @@ from e2e.utils.terraform_utils import terraform_installation, get_stack_output
 from e2e.test_methods import rds_s3
 
 TEST_SUITE_NAME = "tf-rds-s3"
-TO_ROOT = "../../"
 TF_FOLDER = TO_ROOT + "deployments/rds-s3/terraform/"
 
 
@@ -35,7 +35,7 @@ def installation(region, metadata, request):
         "db_password": db_password,
         "minio_aws_access_key_id": get_accesskey(request),
         "minio_aws_secret_access_key": get_secretkey(request),
-        "mlmdb_name": rds_s3.MLMDB_NAME,
+        "mlmdb_name": ALTERNATE_MLMDB_NAME,
         "publicly_accessible": "true",
         "deletion_protection": "false",
         "secret_recovery_window_in_days": "0",
@@ -106,5 +106,8 @@ class TestRDSS3Terraform:
         region = installation["cluster_region"]
 
         rds_s3.test_katib_experiment(cluster_name, region, db_username, db_password, rds_endpoint)
+
+    def test_works(cluster, region):
+        cloudwatch.test_works(cluster, region)
 
     

--- a/tests/e2e/tests/terraform/test_rds_s3.py
+++ b/tests/e2e/tests/terraform/test_rds_s3.py
@@ -1,0 +1,110 @@
+import pytest
+
+from e2e.utils.config import metadata
+from e2e.utils.utils import rand_name
+from e2e.conftest import region, get_accesskey, get_secretkey
+    
+from e2e.fixtures.clients import (
+    kfp_client,
+    port_forward,
+    session_cookie,
+    host,
+    login,
+    password,
+    client_namespace,
+)
+
+from e2e.utils.terraform_utils import terraform_installation, get_stack_output
+from e2e.test_methods import rds_s3
+
+TEST_SUITE_NAME = "tf-rds-s3"
+TO_ROOT = "../../"
+TF_FOLDER = TO_ROOT + "deployments/rds-s3/terraform/"
+
+
+@pytest.fixture(scope="class")
+def installation(region, metadata, request):
+    cluster_name = rand_name(TEST_SUITE_NAME+"-")
+    db_username = rand_name("user")
+    db_password = rand_name("pw")
+
+    input_variables = {
+        "cluster_name": cluster_name,
+        "cluster_region": region,
+        "db_username": db_username,
+        "db_password": db_password,
+        "minio_aws_access_key_id": get_accesskey(request),
+        "minio_aws_secret_access_key": get_secretkey(request),
+        "mlmdb_name": rds_s3.MLMDB_NAME,
+        "publicly_accessible": "true",
+        "deletion_protection": "false",
+        "secret_recovery_window_in_days": "0",
+        "force_destroy_s3_bucket": "true",
+    }
+    
+    return terraform_installation(input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request)
+
+class TestRDSS3Terraform:
+
+    @pytest.fixture(scope="class")
+    def setup(self, installation):
+        rds_s3.disable_kfp_caching(installation["cluster_name"], installation["cluster_region"])
+
+        metadata_file = metadata.to_file()
+        print(metadata.params)
+        print("Created metadata file for TestRDSS3Terraform", metadata_file)
+    
+    def test_verify_kubeflow_db(self, installation):
+        db_username = installation["db_username"]
+        db_password = installation["db_password"]
+        rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
+
+        rds_s3.test_verify_kubeflow_db(db_username, db_password, rds_endpoint)
+
+    def test_verify_mlpipeline_db(self, installation):
+        db_username = installation["db_username"]
+        db_password = installation["db_password"]
+        rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
+
+        rds_s3.test_verify_mlpipeline_db(db_username, db_password, rds_endpoint)
+    
+    def test_verify_mlmdb(self, installation):
+        db_username = installation["db_username"]
+        db_password = installation["db_password"]
+        rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
+        mlmdb_name = installation["mlmdb_name"]
+
+        rds_s3.test_verify_mlmdb(db_username, db_password, rds_endpoint, mlmdb_name)
+    
+    def test_s3_bucket_is_being_used_as_metadata_store(self, installation):
+        region = installation["cluster_region"]
+        s3_bucket_name = get_stack_output("s3_bucket_name", TF_FOLDER)
+
+        rds_s3.test_s3_bucket_is_being_used_as_metadata_store(s3_bucket_name, region)
+
+    def test_kfp_experiment(self, kfp_client, installation):
+        db_username = installation["db_username"]
+        db_password = installation["db_password"]
+        rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
+
+        rds_s3.test_kfp_experiment(kfp_client, db_username, db_password, rds_endpoint)
+    
+    def test_run_pipeline(self, kfp_client, installation):
+        db_username = installation["db_username"]
+        db_password = installation["db_password"]
+        rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
+        s3_bucket_name = get_stack_output("s3_bucket_name", TF_FOLDER)
+        region = installation["cluster_region"]
+
+        rds_s3.test_run_pipeline(kfp_client, s3_bucket_name, db_username, db_password, rds_endpoint, region)
+    
+    def test_katib_experiment(self, installation):
+        db_username = installation["db_username"]
+        db_password = installation["db_password"]
+        rds_endpoint = get_stack_output("rds_endpoint", TF_FOLDER)
+        cluster_name = installation["cluster_name"]
+        region = installation["cluster_region"]
+
+        rds_s3.test_katib_experiment(cluster_name, region, db_username, db_password, rds_endpoint)
+
+    

--- a/tests/e2e/tests/terraform/test_vanilla.py
+++ b/tests/e2e/tests/terraform/test_vanilla.py
@@ -1,0 +1,77 @@
+import pytest
+
+from e2e.utils.config import metadata
+from e2e.utils.utils import rand_name
+from e2e.conftest import region
+    
+from e2e.fixtures.clients import (
+    kfp_client,
+    port_forward,
+    session_cookie,
+    host,
+    login,
+    password,
+    client_namespace,
+)
+
+from e2e.fixtures.notebook_dependencies import notebook_server
+
+from e2e.utils.terraform_utils import terraform_installation
+from e2e.test_methods import vanilla
+from e2e.test_methods.vanilla import sagemaker_execution_role, s3_bucket_with_data
+
+TEST_SUITE_NAME = "tf-vanilla"
+TO_ROOT = "../../"
+TF_FOLDER = TO_ROOT + "deployments/vanilla/terraform/"
+
+
+@pytest.fixture(scope="class")
+def installation(region, metadata, request):
+    cluster_name = rand_name(TEST_SUITE_NAME+"-")
+
+    input_variables = {
+        "cluster_name": cluster_name,
+        "cluster_region": region,
+    }
+    
+    return terraform_installation(input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request)
+
+class TestVanillaTerraform:
+
+    @pytest.fixture(scope="class")
+    def setup(self, installation):
+        metadata_file = metadata.to_file()
+        print(metadata.params)
+        print("Created metadata file for TestVanillaTerraform", metadata_file)
+    
+    def test_kfp_experiment(self, kfp_client):
+        vanilla.test_kfp_experiment(kfp_client)
+
+    def test_run_pipeline(self, kfp_client):
+        vanilla.test_run_pipeline(kfp_client)
+
+    def test_katib_experiment(self, installation):
+        cluster = installation["cluster_name"]
+        region = installation["cluster_region"]
+
+        vanilla.test_katib_experiment(cluster, region)
+        
+    @pytest.mark.parametrize(
+        "framework_name, image_name, ipynb_notebook_file, expected_output", vanilla.TEST_ACK_CRDS_PARAMS
+    )
+    def test_ack_crds(
+        self,
+        region,
+        metadata,
+        notebook_server,
+        framework_name,
+        image_name,
+        ipynb_notebook_file,
+        expected_output,
+    ):
+        vanilla.test_ack_crds(notebook_server, framework_name, ipynb_notebook_file, expected_output)
+
+    def test_run_kfp_sagemaker_pipeline(
+        self, kfp_client, sagemaker_execution_role, s3_bucket_with_data
+    ):
+        vanilla.test_run_kfp_sagemaker_pipeline(kfp_client, s3_bucket_with_data.name, sagemaker_execution_role.arn)

--- a/tests/e2e/tests/terraform/test_vanilla.py
+++ b/tests/e2e/tests/terraform/test_vanilla.py
@@ -41,18 +41,18 @@ def installation(region, metadata, request):
 
 class TestVanillaTerraform:
     @pytest.fixture(scope="class")
-    def setup(self, installation):
+    def setup(self, metadata, installation):
         metadata_file = metadata.to_file()
         print(metadata.params)
         print("Created metadata file for TestVanillaTerraform", metadata_file)
 
-    def test_kfp_experiment(self, kfp_client):
+    def test_kfp_experiment(self, setup, kfp_client):
         vanilla.test_kfp_experiment(kfp_client)
 
-    def test_run_pipeline(self, kfp_client):
+    def test_run_pipeline(self, setup, kfp_client):
         vanilla.test_run_pipeline(kfp_client)
 
-    def test_katib_experiment(self, installation):
+    def test_katib_experiment(self, setup, installation):
         cluster = installation["cluster_name"]
         region = installation["cluster_region"]
 
@@ -64,6 +64,7 @@ class TestVanillaTerraform:
     )
     def test_ack_crds(
         self,
+        setup,
         region,
         metadata,
         notebook_server,
@@ -77,7 +78,7 @@ class TestVanillaTerraform:
         )
 
     def test_run_kfp_sagemaker_pipeline(
-        self, kfp_client, sagemaker_execution_role, s3_bucket_with_data
+        self, setup, kfp_client, sagemaker_execution_role, s3_bucket_with_data
     ):
         vanilla.test_run_kfp_sagemaker_pipeline(
             kfp_client, s3_bucket_with_data.name, sagemaker_execution_role.arn

--- a/tests/e2e/tests/terraform/test_vanilla.py
+++ b/tests/e2e/tests/terraform/test_vanilla.py
@@ -19,7 +19,7 @@ from e2e.fixtures.notebook_dependencies import notebook_server
 
 from e2e.utils.terraform_utils import terraform_installation
 from e2e.test_methods import vanilla
-from e2e.test_methods.vanilla import sagemaker_execution_role, s3_bucket_with_data
+from e2e.test_methods.vanilla import sagemaker_execution_role, s3_bucket_with_data, clean_up_training_jobs_in_user_ns
 
 TEST_SUITE_NAME = "tf-vanilla"
 TF_FOLDER = TO_ROOT + "deployments/vanilla/terraform/"
@@ -77,9 +77,13 @@ class TestVanillaTerraform:
             notebook_server, framework_name, ipynb_notebook_file, expected_output
         )
 
+    @pytest.mark.parametrize(
+        "user_namespace", 
+        vanilla.TEST_KFP_SM_PARAMS,
+    )
     def test_run_kfp_sagemaker_pipeline(
-        self, setup, kfp_client, sagemaker_execution_role, s3_bucket_with_data
+        self, setup, kfp_client, sagemaker_execution_role, s3_bucket_with_data, clean_up_training_jobs_in_user_ns, user_namespace
     ):
         vanilla.test_run_kfp_sagemaker_pipeline(
-            kfp_client, s3_bucket_with_data.name, sagemaker_execution_role.arn
+            kfp_client, s3_bucket_with_data.name, sagemaker_execution_role.arn, clean_up_training_jobs_in_user_ns, user_namespace
         )

--- a/tests/e2e/tests/terraform/test_vanilla.py
+++ b/tests/e2e/tests/terraform/test_vanilla.py
@@ -4,7 +4,7 @@ from e2e.utils.constants import TO_ROOT
 from e2e.utils.config import metadata
 from e2e.utils.utils import rand_name
 from e2e.conftest import region
-    
+
 from e2e.fixtures.clients import (
     kfp_client,
     port_forward,
@@ -27,23 +27,25 @@ TF_FOLDER = TO_ROOT + "deployments/vanilla/terraform/"
 
 @pytest.fixture(scope="class")
 def installation(region, metadata, request):
-    cluster_name = rand_name(TEST_SUITE_NAME+"-")
+    cluster_name = rand_name(TEST_SUITE_NAME + "-")
 
     input_variables = {
         "cluster_name": cluster_name,
         "cluster_region": region,
     }
-    
-    return terraform_installation(input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request)
+
+    return terraform_installation(
+        input_variables, TF_FOLDER, TEST_SUITE_NAME, metadata, request
+    )
+
 
 class TestVanillaTerraform:
-
     @pytest.fixture(scope="class")
     def setup(self, installation):
         metadata_file = metadata.to_file()
         print(metadata.params)
         print("Created metadata file for TestVanillaTerraform", metadata_file)
-    
+
     def test_kfp_experiment(self, kfp_client):
         vanilla.test_kfp_experiment(kfp_client)
 
@@ -55,9 +57,10 @@ class TestVanillaTerraform:
         region = installation["cluster_region"]
 
         vanilla.test_katib_experiment(cluster, region)
-        
+
     @pytest.mark.parametrize(
-        "framework_name, image_name, ipynb_notebook_file, expected_output", vanilla.TEST_ACK_CRDS_PARAMS
+        "framework_name, image_name, ipynb_notebook_file, expected_output",
+        vanilla.TEST_ACK_CRDS_PARAMS,
     )
     def test_ack_crds(
         self,
@@ -69,9 +72,13 @@ class TestVanillaTerraform:
         ipynb_notebook_file,
         expected_output,
     ):
-        vanilla.test_ack_crds(notebook_server, framework_name, ipynb_notebook_file, expected_output)
+        vanilla.test_ack_crds(
+            notebook_server, framework_name, ipynb_notebook_file, expected_output
+        )
 
     def test_run_kfp_sagemaker_pipeline(
         self, kfp_client, sagemaker_execution_role, s3_bucket_with_data
     ):
-        vanilla.test_run_kfp_sagemaker_pipeline(kfp_client, s3_bucket_with_data.name, sagemaker_execution_role.arn)
+        vanilla.test_run_kfp_sagemaker_pipeline(
+            kfp_client, s3_bucket_with_data.name, sagemaker_execution_role.arn
+        )

--- a/tests/e2e/tests/terraform/test_vanilla.py
+++ b/tests/e2e/tests/terraform/test_vanilla.py
@@ -1,5 +1,6 @@
 import pytest
 
+from e2e.utils.constants import TO_ROOT
 from e2e.utils.config import metadata
 from e2e.utils.utils import rand_name
 from e2e.conftest import region
@@ -21,7 +22,6 @@ from e2e.test_methods import vanilla
 from e2e.test_methods.vanilla import sagemaker_execution_role, s3_bucket_with_data
 
 TEST_SUITE_NAME = "tf-vanilla"
-TO_ROOT = "../../"
 TF_FOLDER = TO_ROOT + "deployments/vanilla/terraform/"
 
 

--- a/tests/e2e/tests/test_sanity_portforward.py
+++ b/tests/e2e/tests/test_sanity_portforward.py
@@ -141,6 +141,12 @@ def s3_bucket_with_data():
     yield
     bucket.delete()
 
+@pytest.fixture(scope="class")
+def clean_up_training_jobs_in_user_ns():
+    yield 
+
+    cmd = f"kubectl delete trainingjobs --all -n {DEFAULT_USER_NAMESPACE}".split()
+    subprocess.Popen(cmd)
 
 class TestSanity:
     @pytest.fixture(scope="class")
@@ -273,7 +279,7 @@ class TestSanity:
         assert expected_output in output or "training-job-" in output
     
     def test_run_kfp_sagemaker_pipeline(
-        self, region, metadata, s3_bucket_with_data, sagemaker_execution_role, kfp_client,
+        self, region, metadata, s3_bucket_with_data, sagemaker_execution_role, kfp_client, clean_up_training_jobs_in_user_ns
     ):
 
         experiment_name = "experiment-" + RANDOM_PREFIX

--- a/tests/e2e/utils/aws/iam.py
+++ b/tests/e2e/utils/aws/iam.py
@@ -113,10 +113,10 @@ class IAMRole:
         try:
             for policy in self.policy_arns:
                 self.iam_client.detach_role_policy(
-                PolicyArn=f"arn:aws:iam::aws:policy/{policy}", RoleName=self.name,
+                PolicyArn=policy, RoleName=self.name,
                 )
             self.iam_client.delete_role(RoleName=self.name)
             logger.info(f"deleted iam role {self.arn}")
         except ClientError:
-            logger.exception(f"failed to delete iam policy {self.arn}")
+            logger.exception(f"failed to delete iam role {self.arn}")
             raise

--- a/tests/e2e/utils/aws/iam.py
+++ b/tests/e2e/utils/aws/iam.py
@@ -113,7 +113,7 @@ class IAMRole:
         try:
             for policy in self.policy_arns:
                 self.iam_client.detach_role_policy(
-                PolicyArn=policy, RoleName=self.name,
+                PolicyArn=f"arn:aws:iam::aws:policy/{policy}", RoleName=self.name,
                 )
             self.iam_client.delete_role(RoleName=self.name)
             logger.info(f"deleted iam role {self.arn}")

--- a/tests/e2e/utils/constants.py
+++ b/tests/e2e/utils/constants.py
@@ -10,3 +10,20 @@ DEFAULT_PASSWORD = "12341234"
 KUBEFLOW_GROUP = "kubeflow.org"
 KUBEFLOW_NAMESPACE = "kubeflow"
 KUBEFLOW_VERSION = "v1.6.1-rc.0"
+ALTERNATE_MLMDB_NAME = "metadata_db"
+
+TO_ROOT = "../../"  # As of this commit, tests are run from the tests/e2e folder
+CUSTOM_RESOURCE_TEMPLATES_FOLDER = TO_ROOT + "tests/e2e/resources/custom-resource-templates/"
+
+DISABLE_PIPELINE_CACHING_PATCH_FILE = CUSTOM_RESOURCE_TEMPLATES_FOLDER + "patch-disable-pipeline-caching.yaml"
+
+# Katib experiment file names
+KATIB_EXPERIMENT_RANDOM_FILE = "katib-experiment-random.yaml"
+
+# Pipeline names
+PIPELINE_XG_BOOST = "[Demo] XGBoost - Iterative model training"
+PIPELINE_DATA_PASSING = "[Tutorial] Data passing in python components"
+PIPELINE_SAGEMAKER_TRAINING = "[Tutorial] SageMaker Training"
+
+# Notebook images
+NOTEBOOK_IMAGE_TF_CPU = "public.ecr.aws/c9e4w0g3/notebook-servers/jupyter-tensorflow:2.6.3-cpu-py38-ubuntu20.04-v1.8"

--- a/tests/e2e/utils/constants.py
+++ b/tests/e2e/utils/constants.py
@@ -13,9 +13,13 @@ KUBEFLOW_VERSION = "v1.6.1-rc.0"
 ALTERNATE_MLMDB_NAME = "metadata_db"
 
 TO_ROOT = "../../"  # As of this commit, tests are run from the tests/e2e folder
-CUSTOM_RESOURCE_TEMPLATES_FOLDER = TO_ROOT + "tests/e2e/resources/custom-resource-templates/"
+CUSTOM_RESOURCE_TEMPLATES_FOLDER = (
+    TO_ROOT + "tests/e2e/resources/custom-resource-templates/"
+)
 
-DISABLE_PIPELINE_CACHING_PATCH_FILE = CUSTOM_RESOURCE_TEMPLATES_FOLDER + "patch-disable-pipeline-caching.yaml"
+DISABLE_PIPELINE_CACHING_PATCH_FILE = (
+    CUSTOM_RESOURCE_TEMPLATES_FOLDER + "patch-disable-pipeline-caching.yaml"
+)
 
 # Katib experiment file names
 KATIB_EXPERIMENT_RANDOM_FILE = "katib-experiment-random.yaml"

--- a/tests/e2e/utils/terraform_utils.py
+++ b/tests/e2e/utils/terraform_utils.py
@@ -1,0 +1,56 @@
+import subprocess
+import os
+
+from e2e.utils.config import configure_resource_fixture
+
+def create_test_tfvars_file(input_variables, tf_folder, filename="test-generated.auto.tfvars"):
+    file_path = os.path.join(tf_folder, filename)
+    if os.path.exists(file_path):
+        raise Exception(f"make delete failed in a previous installation. successfully delete the resources and delete {file_path}")
+
+    with open(file_path, "w") as file:
+        for k, v in input_variables.items():
+            file.write(f"{k}=\"{v}\"\n")
+
+def delete_test_tfvars_file(tf_folder, filename="test-generated.auto.tfvars"):
+    file_path = os.path.join(tf_folder, filename)
+    os.remove(file_path)
+
+def terraform_installation(input_variables, tf_folder, installation_name, metadata, request):
+
+    initial_dir = os.getcwd()
+
+    def on_create():
+        create_test_tfvars_file(input_variables, tf_folder)
+
+        os.chdir(tf_folder)
+        retcode = subprocess.call("make deploy".split())
+        os.chdir(initial_dir)
+        assert retcode == 0
+
+    def on_delete():
+        os.chdir(initial_dir)
+        os.chdir(tf_folder)
+        retcode = subprocess.call("make delete".split())
+        if retcode == 0:
+            # keep tfvars file to retry delete manually
+            delete_test_tfvars_file(tf_folder)
+        os.chdir(initial_dir)
+        assert retcode == 0
+    
+    return configure_resource_fixture(
+        metadata_key=installation_name,
+        resource_details=input_variables,
+        on_create=on_create,
+        on_delete=on_delete,
+        metadata=metadata,
+        request=request,
+    )
+
+def get_stack_output(output_name, tf_folder):
+    initial_dir = os.getcwd()
+    os.chdir(tf_folder)
+    output = subprocess.check_output(f"terraform output -raw {output_name}".split()).decode()
+    os.chdir(initial_dir)
+
+    return output

--- a/tests/e2e/utils/terraform_utils.py
+++ b/tests/e2e/utils/terraform_utils.py
@@ -3,20 +3,29 @@ import os
 
 from e2e.utils.config import configure_resource_fixture
 
-def create_test_tfvars_file(input_variables, tf_folder, filename="test-generated.auto.tfvars"):
+
+def create_test_tfvars_file(
+    input_variables, tf_folder, filename="test-generated.auto.tfvars"
+):
     file_path = os.path.join(tf_folder, filename)
     if os.path.exists(file_path):
-        raise Exception(f"make delete failed in a previous installation. successfully delete the resources and delete {file_path}")
+        raise Exception(
+            f"make delete failed in a previous installation. successfully delete the resources and delete {file_path}"
+        )
 
     with open(file_path, "w") as file:
         for k, v in input_variables.items():
-            file.write(f"{k}=\"{v}\"\n")
+            file.write(f'{k}="{v}"\n')
+
 
 def delete_test_tfvars_file(tf_folder, filename="test-generated.auto.tfvars"):
     file_path = os.path.join(tf_folder, filename)
     os.remove(file_path)
 
-def terraform_installation(input_variables, tf_folder, installation_name, metadata, request):
+
+def terraform_installation(
+    input_variables, tf_folder, installation_name, metadata, request
+):
 
     initial_dir = os.getcwd()
 
@@ -37,7 +46,7 @@ def terraform_installation(input_variables, tf_folder, installation_name, metada
             delete_test_tfvars_file(tf_folder)
         os.chdir(initial_dir)
         assert retcode == 0
-    
+
     return configure_resource_fixture(
         metadata_key=installation_name,
         resource_details=input_variables,
@@ -47,10 +56,13 @@ def terraform_installation(input_variables, tf_folder, installation_name, metada
         request=request,
     )
 
+
 def get_stack_output(output_name, tf_folder):
     initial_dir = os.getcwd()
     os.chdir(tf_folder)
-    output = subprocess.check_output(f"terraform output -raw {output_name}".split()).decode()
+    output = subprocess.check_output(
+        f"terraform output -raw {output_name}".split()
+    ).decode()
     os.chdir(initial_dir)
 
     return output

--- a/tests/e2e/utils/terraform_utils.py
+++ b/tests/e2e/utils/terraform_utils.py
@@ -41,10 +41,10 @@ def terraform_installation(
         os.chdir(initial_dir)
         os.chdir(tf_folder)
         retcode = subprocess.call("make delete".split())
+        os.chdir(initial_dir)
         if retcode == 0:
             # keep tfvars file to retry delete manually
             delete_test_tfvars_file(tf_folder)
-        os.chdir(initial_dir)
         assert retcode == 0
 
     return configure_resource_fixture(
@@ -66,3 +66,4 @@ def get_stack_output(output_name, tf_folder):
     os.chdir(initial_dir)
 
     return output
+


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Added integration tests for Terraform

**Description of your changes:**
- Added re-usable test methods package
- Added integ tests for vanilla, rds-s3, cognito, cognito-rds-s3
- Changed makefile to configure eks with kubectl after cluster is created
- Added RDS endpoint and S3 bucket name to TF outputs
- TF bug fixes
  - Fix failing delete due to ACK namespace being deleted during helm chart deletion
  - Fixed issue where metadb name variable was not being used
  - Fixed issue where passing in a DB password resulted in an error
  - Fixed issue where RDS was using private subnets even when set to publicly accessible

**Testing:**
- Ran added tests 

Vanilla
```
pytest tests/terraform/test_vanilla.py -s -q --region <aws region>
```

RDS-S3
```
pytest tests/terraform/test_rds_s3.py -s -q --region <aws region> --accesskey <accesskey> --secretkey <secretkey>
```

Cognito
```
pytest tests/terraform/test_cognito.py -s -q --region <aws region> --root-domain-name <root domain, e.g. example.com>
```

Cognito-RDS-S3
```
pytest tests/terraform/test_cognito_rds_s3.py -s -q --region <aws region> --root-domain-name <root domain, e.g. example.com> --accesskey <accesskey> --secretkey <secretkey>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.