### PR TITLE
Cleanup Execution Role in KFP canary test

### DIFF
--- a/tests/e2e/tests/test_sanity_portforward.py
+++ b/tests/e2e/tests/test_sanity_portforward.py
@@ -91,26 +91,45 @@ def wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id):
 
     return wait_for(callback, timeout=600)
 
-def create_execution_role(
-    role_name, region,
-):
 
-    trust_policy = {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Principal": {"Service": "sagemaker.amazonaws.com"},
-                "Action": "sts:AssumeRole",
-            }
-        ],
-    }
-
+@pytest.fixture(scope="class")
+def sagemaker_execution_role(region, metadata, request):
+    sagemaker_execution_role_name = "role-" + RANDOM_PREFIX
     managed_policies = ["AmazonS3FullAccess", "AmazonSageMakerFullAccess"]
+    role = IAMRole(name=sagemaker_execution_role_name, region=region, policies=managed_policies)
+    metadata_key = "sagemaker_execution_role"
 
-    role = IAMRole(name=role_name, region=region, policies=managed_policies)
-    return role.create(
-        policy_document=json.dumps(trust_policy)
+    resource_details = {}
+
+    def on_create():
+        trust_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "sagemaker.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+
+        sagemaker_execution_role_arn = role.create(
+            policy_document=json.dumps(trust_policy)
+        )
+
+        resource_details["name"] = sagemaker_execution_role_name
+        resource_details["arn"] = sagemaker_execution_role_arn
+
+    def on_delete():
+        role.delete()
+
+    return configure_resource_fixture(
+        metadata=metadata,
+        request=request,
+        resource_details=resource_details,
+        metadata_key=metadata_key,
+        on_create=on_create,
+        on_delete=on_delete,
     )
 
 @pytest.fixture(scope="class")
@@ -254,20 +273,19 @@ class TestSanity:
         assert expected_output in output or "training-job-" in output
     
     def test_run_kfp_sagemaker_pipeline(
-        self, region, metadata, s3_bucket_with_data, kfp_client,
+        self, region, metadata, s3_bucket_with_data, sagemaker_execution_role, kfp_client,
     ):
 
         experiment_name = "experiment-" + RANDOM_PREFIX
         experiment_description = "description-" + RANDOM_PREFIX
         sagemaker_execution_role_name = "role-" + RANDOM_PREFIX
         bucket_name = "s3-" + RANDOM_PREFIX
-        
         job_name = "kfp-run-" + RANDOM_PREFIX
 
-        sagemaker_execution_role_arn = create_execution_role(
-            sagemaker_execution_role_name, region
-        )
+        sagemaker_execution_role_details = metadata.get("sagemaker_execution_role")
+        sagemaker_execution_role_arn = sagemaker_execution_role_details["arn"]
 
+        
         experiment = kfp_client.create_experiment(
             experiment_name,
             description=experiment_description,

--- a/tests/e2e/tests/test_sanity_portforward.py
+++ b/tests/e2e/tests/test_sanity_portforward.py
@@ -95,8 +95,8 @@ def wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id):
 @pytest.fixture(scope="class")
 def sagemaker_execution_role(region, metadata, request):
     sagemaker_execution_role_name = "role-" + RANDOM_PREFIX
-    managed_policies = ["AmazonS3FullAccess", "AmazonSageMakerFullAccess"]
-    role = IAMRole(name=sagemaker_execution_role_name, region=region, policies=managed_policies)
+    managed_policies = ["arn:aws:iam::aws:policy/AmazonS3FullAccess", "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"]
+    role = IAMRole(name=sagemaker_execution_role_name, region=region, policy_arns=managed_policies)
     metadata_key = "sagemaker_execution_role"
 
     resource_details = {}

--- a/tests/e2e/utils/aws/iam.py
+++ b/tests/e2e/utils/aws/iam.py
@@ -113,7 +113,7 @@ class IAMRole:
         try:
             for policy in self.policies:
                 self.iam_client.detach_role_policy(
-                PolicyArn=policy, RoleName=self.name,
+                PolicyArn=f"arn:aws:iam::aws:policy/{policy}", RoleName=self.name,
                 )
             self.iam_client.delete_role(RoleName=self.name)
             logger.info(f"deleted iam role {self.arn}")

--- a/tests/e2e/utils/aws/iam.py
+++ b/tests/e2e/utils/aws/iam.py
@@ -80,13 +80,13 @@ class IAMRole:
         name: str = None,
         region: str = "us-east-1",
         iam_client: Any = None,
-        policies: list = None,
+        policy_arns: list = None,
         arn: str = None,
     ):
         self.region = region
         self.iam_client = iam_client or boto3.client("iam", region_name=region)
         self.name = name
-        self.policies = policies
+        self.policy_arns = policy_arns
         self.arn = arn
         if not name and not arn:
             raise ValueError("Either role name or arn should be defined")
@@ -97,9 +97,9 @@ class IAMRole:
                 RoleName=self.name, AssumeRolePolicyDocument=policy_document
             )
 
-            for policy in self.policies:
+            for policy in self.policy_arns:
                 self.iam_client.attach_role_policy(
-                    RoleName=self.name, PolicyArn=f"arn:aws:iam::aws:policy/{policy}"
+                    RoleName=self.name, PolicyArn=policy
                 )
         except ClientError:
             logger.exception(f"failed to create IAM Role {self.name}")
@@ -111,9 +111,9 @@ class IAMRole:
 
     def delete(self):
         try:
-            for policy in self.policies:
+            for policy in self.policy_arns:
                 self.iam_client.detach_role_policy(
-                PolicyArn=f"arn:aws:iam::aws:policy/{policy}", RoleName=self.name,
+                PolicyArn=policy, RoleName=self.name,
                 )
             self.iam_client.delete_role(RoleName=self.name)
             logger.info(f"deleted iam role {self.arn}")


### PR DESCRIPTION
**Description of your changes:**
Convert role creation to fixture and ensure cleanup. Policy deletion bugfix. 


**Testing:**
Logs - 
```
--------------------------------------------------------------------------------------------------------------------- live log teardown ----------------------------------------------------------------------------------------------------------------------
INFO     e2e.utils.aws.iam:iam.py:119 deleted iam role arn:aws:iam::xxx:role/role-kfp-xxx
INFO     e2e.utils.s3_for_training.data_bucket:data_bucket.py:22 deleting s3 bucket s3-kfp-xxxx
INFO     e2e.utils.s3_for_training.data_bucket:data_bucket.py:70 deleted s3 bucket s3-kfp-xxxx
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.