### PR TITLE
Remove terraform wait conditions

### DIFF
--- a/iaac/terraform/apps/kubeflow-pipelines/main.tf
+++ b/iaac/terraform/apps/kubeflow-pipelines/main.tf
@@ -3,15 +3,3 @@ module "helm_addon" {
   helm_config       = local.helm_config
   addon_context     = var.addon_context
 }
-
-# Wait 30 seconds after helm chart deployment
-resource "time_sleep" "wait_30_seconds" {
-  create_duration = "30s"
-  destroy_duration = "30s"
-
-  depends_on = [module.helm_addon]
-}
-
-resource "null_resource" "next" {
-  depends_on = [time_sleep.wait_30_seconds]
-}

--- a/iaac/terraform/apps/models-web-app/main.tf
+++ b/iaac/terraform/apps/models-web-app/main.tf
@@ -3,13 +3,3 @@ module "helm_addon" {
   helm_config       = local.helm_config
   addon_context     = var.addon_context
 }
-
-# Wait 30 seconds after helm chart deployment
-resource "time_sleep" "wait_30_seconds" {
-  depends_on = [module.helm_addon]
-
-  create_duration = "30s"
-}
-resource "null_resource" "next" {
-  depends_on = [time_sleep.wait_30_seconds]
-}

--- a/iaac/terraform/common/aws-authservice/main.tf
+++ b/iaac/terraform/common/aws-authservice/main.tf
@@ -3,13 +3,3 @@ module "helm_addon" {
   helm_config       = local.helm_config
   addon_context     = var.addon_context
 }
-
-# Wait 30 seconds after helm chart deployment
-resource "time_sleep" "wait_30_seconds" {
-  depends_on = [module.helm_addon]
-
-  create_duration = "30s"
-}
-resource "null_resource" "next" {
-  depends_on = [time_sleep.wait_30_seconds]
-}

--- a/iaac/terraform/common/cluster-local-gateway/main.tf
+++ b/iaac/terraform/common/cluster-local-gateway/main.tf
@@ -3,14 +3,3 @@ module "helm_addon" {
   helm_config       = local.helm_config
   addon_context     = var.addon_context
 }
-
-# todo: replace w deterministic
-# Wait 60 seconds after helm chart deployment
-resource "time_sleep" "wait_60_seconds" {
-  depends_on = [module.helm_addon]
-
-  create_duration = "60s"
-}
-resource "null_resource" "next" {
-  depends_on = [time_sleep.wait_60_seconds]
-}

--- a/iaac/terraform/common/dex/main.tf
+++ b/iaac/terraform/common/dex/main.tf
@@ -3,13 +3,3 @@ module "helm_addon" {
   helm_config       = local.helm_config
   addon_context     = var.addon_context
 }
-
-# Wait 30 seconds after helm chart deployment
-resource "time_sleep" "wait_30_seconds" {
-  depends_on = [module.helm_addon]
-
-  create_duration = "30s"
-}
-resource "null_resource" "next" {
-  depends_on = [time_sleep.wait_30_seconds]
-}

--- a/iaac/terraform/common/kubeflow-istio-resources/main.tf
+++ b/iaac/terraform/common/kubeflow-istio-resources/main.tf
@@ -3,13 +3,3 @@ module "helm_addon" {
   helm_config       = local.helm_config
   addon_context     = var.addon_context
 }
-
-# Wait 60 seconds after helm chart deployment
-resource "time_sleep" "wait_60_seconds" {
-  depends_on = [module.helm_addon]
-
-  create_duration = "60s"
-}
-resource "null_resource" "next" {
-  depends_on = [time_sleep.wait_60_seconds]
-}

--- a/iaac/terraform/common/oidc-authservice/main.tf
+++ b/iaac/terraform/common/oidc-authservice/main.tf
@@ -3,13 +3,3 @@ module "helm_addon" {
   helm_config       = local.helm_config
   addon_context     = var.addon_context
 }
-
-# Wait 30 seconds after helm chart deployment
-resource "time_sleep" "wait_30_seconds" {
-  depends_on = [module.helm_addon]
-
-  create_duration = "30s"
-}
-resource "null_resource" "next" {
-  depends_on = [time_sleep.wait_30_seconds]
-}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Removes the wait conditions from Terraform helm chart deployments are these are not necessary for helm chart components to be ready.


**Testing:**
- Tested vanilla, rds-s3, cognito, and cognito-rds-s3 deployment options and did not get any deployment/deletion failures 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.