### PR TITLE
Fix TF GHA workflow failures

### DIFF
--- a/.github/workflows/terraform-cognito-test.yaml
+++ b/.github/workflows/terraform-cognito-test.yaml
@@ -65,5 +65,5 @@ jobs:
       if: failure()
       # retry delete if flakiness present
       run: |
-        cd ../../deployments/cognito/terraform
+        cd deployments/cognito/terraform
         make delete || make delete || make delete

--- a/.github/workflows/terraform-cognito-test.yaml
+++ b/.github/workflows/terraform-cognito-test.yaml
@@ -48,6 +48,7 @@ jobs:
       uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: 1.2.7
+        terraform_wrapper: false
     
     - name: Install Python
       uses: actions/setup-python@v4

--- a/.github/workflows/terraform-vanilla-test.yaml
+++ b/.github/workflows/terraform-vanilla-test.yaml
@@ -64,5 +64,5 @@ jobs:
       if: failure()
       # retry delete if flakiness present
       run: |
-        cd ../../deployments/vanilla/terraform
+        cd deployments/vanilla/terraform
         make delete || make delete || make delete

--- a/.github/workflows/terraform-vanilla-test.yaml
+++ b/.github/workflows/terraform-vanilla-test.yaml
@@ -47,6 +47,7 @@ jobs:
       uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: 1.2.7
+        terraform_wrapper: false
     
     - name: Install Python
       uses: actions/setup-python@v4


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

### Issue 1
The Terraform github actions plugin uses a wrapper that by default prints out [additional details ](https://github.com/hashicorp/setup-terraform#outputs). 

This additional output interferes with the `terraform output -raw configure_kubectl | bash` step in the makefiles and causes the installation to fail.

This PR disables the terraform wrapper in GHA to get the standard output produced by the terraform CLI.

Note: this issue only affects GHA workflows

### Issue 2
The cleanup step doesn't require to cd out of the test folder as it starts in the repo root by default. Therefore changed the cd path to be `deployments/<option>/terraform`

**Testing:**
https://github.com/rrrkharse/kubeflow-manifests/actions/runs/3222209284/jobs/5271032565

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.