### PR TITLE
Fix tf cognito logout fail

### DIFF
--- a/iaac/terraform/aws-infra/cognito/outputs.tf
+++ b/iaac/terraform/aws-infra/cognito/outputs.tf
@@ -15,5 +15,5 @@ output "user_pool_domain" {
 
 output "logout_url" {
   description = "Logout URL"
-  value       = "${aws_cognito_user_pool_domain.platform.domain}/logout?client_id=${aws_cognito_user_pool_client.platform.id}&logout_uri=https://kubeflow.${data.aws_route53_zone.platform.name}"
+  value       = "https://${aws_cognito_user_pool_domain.platform.domain}/logout?client_id=${aws_cognito_user_pool_client.platform.id}&logout_uri=https://kubeflow.${data.aws_route53_zone.platform.name}"
 }


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Fixes an issue where logging out of the central dashboard failed due to re-routing to an invalid logout URL for cognito configured kubeflow installations deployed through terraform.

**Description of your changes:**
Added the `https://` prefix to the existing output logout URL, e.g.

`auth.cgologo.rkharse.people.aws.dev/logout?client_id=i7sh1712rdh3d3cv9h8r40h32&logout_uri=https://kubeflow.cgologo.rkharse.people.aws.dev` 
-->
 `https://auth.cgologo.rkharse.people.aws.dev/logout?client_id=i7sh1712rdh3d3cv9h8r40h32&logout_uri=https://kubeflow.cgologo.rkharse.people.aws.dev`

**Testing:**
Deployed a cognito kubeflow cluster using the terraform and verified login and logout.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.