### PR TITLE
Fix notebook helm chart value

### DIFF
--- a/charts/apps/notebook-controller/templates/ConfigMap/notebook-controller-config-9675dd2fhk-kubeflow-ConfigMap.yaml
+++ b/charts/apps/notebook-controller/templates/ConfigMap/notebook-controller-config-9675dd2fhk-kubeflow-ConfigMap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 data:
-  cullIdleTime: {{ .Values.cullingPolicy.cullIdleTime }}
-  enableCulling: {{ .Values.cullingPolicy.enableCulling }}
-  idlenessCheckPeriod: {{ .Values.cullingPolicy.idlenessCheckPeriod }}
+  cullIdleTime: '{{ .Values.cullingPolicy.cullIdleTime }}'
+  enableCulling: '{{ .Values.cullingPolicy.enableCulling }}'
+  idlenessCheckPeriod: '{{ .Values.cullingPolicy.idlenessCheckPeriod }}'
   ISTIO_GATEWAY: kubeflow/kubeflow-gateway
   USE_ISTIO: 'true'
 kind: ConfigMap


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
-make values to be string to fix the error message

```
==========Installing notebook-controller==========
Error: UPGRADE FAILED: failed to create resource: ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects " or n, but found 3, error found in #10 byte of ...|LE_TIME":30,"ENABLE_|..., bigger context ...|{"apiVersion":"v1","data":{"CULL_IDLE_TIME":30,"ENABLE_CULLING":false,"IDLENESS_CHECK_PERIOD":5|...
Traceback (most recent call last):
  File "utils/kubeflow_installation.py", line 280, in <module>
    install_kubeflow(
  File "utils/kubeflow_installation.py", line 79, in install_kubeflow
    install_component(
  File "utils/kubeflow_installation.py", line 120, in install_component
    install_helm(component_name, installation_paths)
  File "/home/ubuntu/terraform/kubeflow-manifests/tests/e2e/utils/utils.py", line 223, in install_helm
    assert install_retcode == 0
AssertionError
Makefile:102: recipe for target 'deploy-kubeflow' failed
make: *** [deploy-kubeflow] Error 1
```

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.