### PR TITLE
[Kubeflow on AWS] Added Blog menu to 1.5 and sent blog to main branch

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -31,6 +31,11 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     pre = "<i class='fas fa-book pr-2'></i>"
     url = "./docs/"
   [[menu.main]]
+    name = "Blog"
+    weight = -100
+    pre = "<i class='fas fa-blog pr-2'></i>"
+    url = "../main/blog/"
+  [[menu.main]]
     name = "GitHub"
     weight = -99
     pre = "<i class='fab fa-github pr-2'></i>"

--- a/website/config.toml
+++ b/website/config.toml
@@ -34,7 +34,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     name = "Blog"
     weight = -100
     pre = "<i class='fas fa-blog pr-2'></i>"
-    url = "../main/blog/"
+    url = "../blog/"
   [[menu.main]]
     name = "GitHub"
     weight = -99

--- a/website/docker-compose.yaml
+++ b/website/docker-compose.yaml
@@ -9,5 +9,6 @@ services:
     command: server
     ports:
       - "1313:1313"
+    working_dir: /src/website
     volumes:
-      - .:/src
+      - ..:/src


### PR DESCRIPTION
Workaround to Blog being tied to a particular branch: Added a Blog menu to the branch 1.5 and directed the link to the blog on the main branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.