### PR TITLE
Change storage class gp2 to gp3

### DIFF
--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/variables.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/variables.tf
@@ -102,8 +102,8 @@ variable "backup_retention_period" {
 
 variable "storage_type" {
   type        = string
-  description = "Instance storage type: standard, gp2, or io1"
-  default = "gp2"
+  description = "Instance storage type: standard, gp3, or io1"
+  default = "gp3"
 }
 
 variable "deletion_protection" {

--- a/deployments/cognito-rds-s3/terraform/variables.tf
+++ b/deployments/cognito-rds-s3/terraform/variables.tf
@@ -100,8 +100,8 @@ variable "backup_retention_period" {
 
 variable "storage_type" {
   type        = string
-  description = "Instance storage type: standard, gp2, or io1"
-  default = "gp2"
+  description = "Instance storage type: standard, gp3, or io1"
+  default = "gp3"
 }
 
 variable "deletion_protection" {

--- a/deployments/rds-s3/terraform/rds-s3-components/variables.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/variables.tf
@@ -95,8 +95,8 @@ variable "backup_retention_period" {
 
 variable "storage_type" {
   type        = string
-  description = "Instance storage type: standard, gp2, or io1"
-  default = "gp2"
+  description = "Instance storage type: standard, gp3, or io1"
+  default = "gp3"
 }
 
 variable "deletion_protection" {

--- a/deployments/rds-s3/terraform/variables.tf
+++ b/deployments/rds-s3/terraform/variables.tf
@@ -87,8 +87,8 @@ variable "backup_retention_period" {
 
 variable "storage_type" {
   type        = string
-  description = "Instance storage type: standard, gp2, or io1"
-  default = "gp2"
+  description = "Instance storage type: standard, gp3, or io1"
+  default = "gp3"
 }
 
 variable "deletion_protection" {

--- a/iaac/terraform/aws-infra/rds/variables.tf
+++ b/iaac/terraform/aws-infra/rds/variables.tf
@@ -56,8 +56,8 @@ variable "backup_retention_period" {
 
 variable "storage_type" {
   type        = string
-  description = "Instance storage type: standard, gp2, or io1"
-  default = "gp2"
+  description = "Instance storage type: standard, gp3, or io1"
+  default = "gp3"
 }
 
 variable "deletion_protection" {

--- a/tests/e2e/resources/custom-resource-templates/notebook-pvc.yaml
+++ b/tests/e2e/resources/custom-resource-templates/notebook-pvc.yaml
@@ -9,5 +9,5 @@ spec:
   resources:
     requests:
       storage: 5Gi
-  storageClassName: gp2
+  storageClassName: gp3
   volumeMode: Filesystem

--- a/tests/e2e/resources/custom-resource-templates/profile-irsa-notebook-pvc.yaml
+++ b/tests/e2e/resources/custom-resource-templates/profile-irsa-notebook-pvc.yaml
@@ -9,5 +9,5 @@ spec:
   resources:
     requests:
       storage: 5Gi
-  storageClassName: gp2
+  storageClassName: gp3
   volumeMode: Filesystem

--- a/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
+++ b/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
@@ -593,7 +593,7 @@ parser.add_argument(
     help=f"Default is set to {DB_BACKUP_RETENTION_PERIOD_DEFAULT}",
     required=False,
 )
-DB_STORAGE_TYPE_DEFAULT = "gp2"
+DB_STORAGE_TYPE_DEFAULT = "gp3"
 parser.add_argument(
     "--db_storage_type",
     type=str,

--- a/website/content/en/docs/add-ons/storage/efs/guide.md
+++ b/website/content/en/docs/add-ons/storage/efs/guide.md
@@ -210,16 +210,16 @@ Once you have everything setup, Port Forward as needed and Login to the Kubeflow
 For more details on how to access your Kubeflow dashboard, refer to one of the [deployment option guides]({{< ref "/docs/deployment" >}}) based on your setup. If you used the vanilla deployment, see [Connect to your Kubeflow cluster]({{< ref "/docs/deployment/vanilla/guide.md#connect-to-your-kubeflow-cluster" >}}).
 
 ### 3.2 Changing the default Storage Class
-After installing Kubeflow, you can change the default Storage Class from `gp2` to the efs storage class you created during the setup. For instance, if you followed the automatic or manual steps, you should have a storage class named `efs-sc`. You can check your storage classes by running `kubectl get sc`.  
+After installing Kubeflow, you can change the default Storage Class from `gp3` to the efs storage class you created during the setup. For instance, if you followed the automatic or manual steps, you should have a storage class named `efs-sc`. You can check your storage classes by running `kubectl get sc`.  
   
-This is can be useful if your notebook configuration is set to use the default storage class (it is the case by default). By changing the default storage class, when creating workspace volumes for your notebooks, it will use your EFS storage class automatically. This is not mandatory as you can also manually create a PVC and select the `efs-sc` class via the Volume UI but can facilitate the notebook creation process and automatically select this class when creating volume in the UI. You can also decide to keep using `gp2` for workspace volumes and keep the EFS storage class for datasets/data volumes only.
+This is can be useful if your notebook configuration is set to use the default storage class (it is the case by default). By changing the default storage class, when creating workspace volumes for your notebooks, it will use your EFS storage class automatically. This is not mandatory as you can also manually create a PVC and select the `efs-sc` class via the Volume UI but can facilitate the notebook creation process and automatically select this class when creating volume in the UI. You can also decide to keep using `gp3` for workspace volumes and keep the EFS storage class for datasets/data volumes only.
   
 To learn more about how to change the default Storage Class, you can refer to the [official Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/#changing-the-default-storageclass).  
   
-For instance, if you have a default class set to `gp2` and another class `efs-sc`, then you would need to do the following : 
-1. Remove `gp2` as your default storage class
+For instance, if you have a default class set to `gp3` and another class `efs-sc`, then you would need to do the following : 
+1. Remove `gp3` as your default storage class
 ```bash
-kubectl patch storageclass gp2 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+kubectl patch storageclass gp3 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 ```
 2. Set `efs-sc` as your default storage class
 ```bash


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves # no issue

**Description of your changes:**
I changed the default storage class from gp2 to gp3. As far as I know it doesn't make sense to use gp2.
https://aws.amazon.com/blogs/storage/migrate-your-amazon-ebs-volumes-from-gp2-to-gp3-and-save-up-to-20-on-costs/

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.