### PR TITLE
fixed katib installation helm path

### DIFF
--- a/tests/e2e/resources/installation_config/s3-only.yaml
+++ b/tests/e2e/resources/installation_config/s3-only.yaml
@@ -294,7 +294,7 @@ katib:
       paths:
         - ../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
     helm: 
-      paths: ../../charts/apps/katib
+      paths: ../../charts/apps/katib/vanilla
   validations:
     pods: 
       namespace: kubeflow


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
N.A

**Description of your changes:**
helm installation path is incorrect, results in `Chart.yaml` not found error.
```
==========Installing katib==========
Error: Chart.yaml file is missing
Traceback (most recent call last):
  File "utils/kubeflow_installation.py", line 249, in <module>
    install_kubeflow(
```

**Testing:**
- [ N.A] Unit tests pass
- [ N.A] e2e tests pass

`make deploy-kubeflow INSTALLATION_OPTION=helm DEPLOYMENT_OPTION=s3-only` runs without errors now.

```
Waiting for katib pods to be ready ...
running command: kubectl wait --for=condition=ready pod -l 'katib.kubeflow.org/component in (controller, db-manager, ui)' --timeout=240s -n kubeflow
pod/katib-controller-75b988dccc-4r5j8 condition met
pod/katib-db-manager-5d46869758-4lvvp condition met
pod/katib-ui-766d5dc8ff-47md2 condition met
All katib pods are running!
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.