### PR TITLE
Katib S3-only Helm Path cherrypick

### DIFF
--- a/tests/e2e/resources/installation_config/s3-only.yaml
+++ b/tests/e2e/resources/installation_config/s3-only.yaml
@@ -294,7 +294,7 @@ katib:
       paths:
         - ../../upstream/apps/katib/upstream/installs/katib-with-kubeflow
     helm: 
-      paths: ../../charts/apps/katib
+      paths: ../../charts/apps/katib/vanilla
   validations:
     pods: 
       namespace: kubeflow


### PR DESCRIPTION
Cherry pick the helm path installation config fix for s3-only deployment.