### PR TITLE
[Kubeflow on AWS] Added Blog menu to 1.4 and sent blog to latest docs

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -31,6 +31,11 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     pre = "<i class='fas fa-book pr-2'></i>"
     url = "./docs/"
   [[menu.main]]
+    name = "Blog"
+    weight = -100
+    pre = "<i class='fas fa-blog pr-2'></i>"
+    url = "../blog/"    
+  [[menu.main]]
     name = "GitHub"
     weight = -99
     pre = "<i class='fab fa-github pr-2'></i>"

--- a/website/docker-compose.yaml
+++ b/website/docker-compose.yaml
@@ -9,5 +9,6 @@ services:
     command: server
     ports:
       - "1313:1313"
+    working_dir: /src/website
     volumes:
-      - .:/src
+      - ..:/src


### PR DESCRIPTION
Added the Blog to the top menu and directed the link to the latest blog.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.