### PR TITLE
Enable SSE-s3 encryption on S3 buckets by default

### DIFF
--- a/iaac/terraform/aws-infra/s3/main.tf
+++ b/iaac/terraform/aws-infra/s3/main.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket" "artifact_store" {
   force_destroy = var.force_destroy_bucket
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
+resource "aws_s3_bucket_server_side_encryption_configuration" "artifact_store_encryption" {
   bucket = aws_s3_bucket.artifact_store.bucket
 
   rule {

--- a/iaac/terraform/aws-infra/s3/main.tf
+++ b/iaac/terraform/aws-infra/s3/main.tf
@@ -6,6 +6,16 @@ resource "aws_s3_bucket" "artifact_store" {
   force_destroy = var.force_destroy_bucket
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
+  bucket = aws_s3_bucket.artifact_store.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "AES256"
+    }
+  }
+}
+
 resource "aws_secretsmanager_secret" "s3_secret" {
   name_prefix = "s3-secret-"
   recovery_window_in_days = var.secret_recovery_window_in_days

--- a/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
+++ b/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
@@ -126,6 +126,19 @@ def create_s3_bucket(s3_client):
     s3_client.create_bucket(**args)
     print("S3 bucket created!")
 
+    s3_client.put_bucket_encryption(
+        Bucket=S3_BUCKET_NAME,
+        ServerSideEncryptionConfiguration={
+            'Rules': [
+                {
+                    'ApplyServerSideEncryptionByDefault': {
+                        'SSEAlgorithm': 'AES256'
+                    }
+                },
+            ]
+        }
+    )
+
 
 def setup_s3_secrets(secrets_manager_client):
     if not does_secret_already_exist(secrets_manager_client, S3_SECRET_NAME):

--- a/website/content/en/docs/about/security.md
+++ b/website/content/en/docs/about/security.md
@@ -6,6 +6,17 @@ weight = 40
 
 We highly recommend that you follow AWS security best practices while provisioning any AWS resources. 
 
+## Default security configuration
+
+### Amazon Simple Storage Service (S3)
+
+When you use Amazon S3 for kubeflow artifact storage, Kubeflow on AWS configures the Amazon S3 bucket to use [server-side encryption with Amazon S3-managed encryption keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html) (SSE-S3). If you prefer to use [server-side encryption with AWS Key Management Service](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html) (SSE-KMS), you can modify these files to specify an AWS KMS key.
+
+* [main.tf](https://github.com/awslabs/kubeflow-manifests/blob/main/iaac/terraform/aws-infra/s3/main.tf) for Terraform deployments
+* [auto-rds-s3-setup.py](https://github.com/awslabs/kubeflow-manifests/blob/main/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py) for manifest deployments
+
+Both SSE-S3 and SSE-KMS provide encryption of objects in the Amazon S3 bucket. You may prefer SSE-KMS if you want to separate the management of encryption keys (via AWS KMS) from management of the Amazon S3 bucket. That separation may provide a stronger security posture. In order to access and use an object in an Amazon S3 bucket, a user needs permission to read the object in the Amazon S3 bucket as well as permission to use the AWS KMS encryption key.
+
 ## Security resources
 
 Refer to the following documents for more information: 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

For both terraform and manifest deployments, turn on SSE-S3 bucket encryption by default. 

I also added a small security section to the documentation describing the default encryption setting and discussing when using SSE-KMS might be preferable.

**Testing:**
- [x ] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

Manually deployed using both terraform and manifests and confirmed that S3 bucket encryption is on.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.