### PR TITLE
Task/s3nopublic

### DIFF
--- a/iaac/terraform/aws-infra/s3/main.tf
+++ b/iaac/terraform/aws-infra/s3/main.tf
@@ -19,7 +19,7 @@ resource "aws_secretsmanager_secret_version" "s3_secret_version" {
   })
 }
 
-resource "aws_s3_bucket_public_access_block" "example" {
+resource "aws_s3_bucket_public_access_block" "artifact_store_block_access" {
   bucket = aws_s3_bucket.artifact_store.id
 
   block_public_acls       = true

--- a/iaac/terraform/aws-infra/s3/main.tf
+++ b/iaac/terraform/aws-infra/s3/main.tf
@@ -18,3 +18,12 @@ resource "aws_secretsmanager_secret_version" "s3_secret_version" {
     secretkey = var.minio_aws_secret_access_key
   })
 }
+
+resource "aws_s3_bucket_public_access_block" "example" {
+  bucket = aws_s3_bucket.artifact_store.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
+++ b/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
@@ -124,6 +124,15 @@ def create_s3_bucket(s3_client):
         args["CreateBucketConfiguration"] = {"LocationConstraint": CLUSTER_REGION}
 
     s3_client.create_bucket(**args)
+    s3_client.put_public_access_block(
+        Bucket=S3_BUCKET_NAME,
+        PublicAccessBlockConfiguration={
+            'BlockPublicAcls': True,
+            'IgnorePublicAcls': True,
+            'BlockPublicPolicy': True,
+            'RestrictPublicBuckets': True
+        }
+    )
     print("S3 bucket created!")
 
 

--- a/website/content/en/docs/about/security.md
+++ b/website/content/en/docs/about/security.md
@@ -6,6 +6,12 @@ weight = 40
 
 We highly recommend that you follow AWS security best practices while provisioning any AWS resources. 
 
+## Default security configuration
+
+### Amazon Simple Storage Service (S3)
+
+The Amazon S3 bucket created for Kubeflow artifacts has a default ["block public access" configuration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html). 
+
 ## Security resources
 
 Refer to the following documents for more information: 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

Configure "block public access" by default for the S3 artifact bucket, when deployed both via terraform and manifests.

**Testing:**
- [x ] Unit tests pass
- [x ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

Deployed using both methods and verified things worked as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.