### PR TITLE
Point terraform to updated istio directory

### DIFF
--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
@@ -152,7 +152,7 @@ module "kubeflow_issuer" {
 module "kubeflow_istio" {
   source            = "../../../../iaac/terraform/common/istio"
   helm_config = {
-    chart = "${var.kf_helm_repo_path}/charts/common/istio-1-14"
+    chart = "${var.kf_helm_repo_path}/charts/common/istio"
   }
   addon_context = var.addon_context
   depends_on = [module.kubeflow_issuer]

--- a/deployments/cognito/terraform/cognito-components/main.tf
+++ b/deployments/cognito/terraform/cognito-components/main.tf
@@ -50,7 +50,7 @@ module "kubeflow_issuer" {
 module "kubeflow_istio" {
   source            = "../../../../iaac/terraform/common/istio"
   helm_config = {
-    chart = "${var.kf_helm_repo_path}/charts/common/istio-1-14"
+    chart = "${var.kf_helm_repo_path}/charts/common/istio"
   }
   addon_context = var.addon_context
   depends_on = [module.kubeflow_issuer]

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -123,7 +123,7 @@ module "kubeflow_issuer" {
 module "kubeflow_istio" {
   source            = "../../../../iaac/terraform/common/istio"
   helm_config = {
-    chart = "${var.kf_helm_repo_path}/charts/common/istio-1-14"
+    chart = "${var.kf_helm_repo_path}/charts/common/istio"
   }
   addon_context = var.addon_context
   depends_on = [module.kubeflow_issuer]

--- a/deployments/vanilla/terraform/vanilla-components/main.tf
+++ b/deployments/vanilla/terraform/vanilla-components/main.tf
@@ -22,7 +22,7 @@ module "kubeflow_issuer" {
 module "kubeflow_istio" {
   source            = "../../../../iaac/terraform/common/istio"
   helm_config = {
-    chart = "${var.kf_helm_repo_path}/charts/common/istio-1-14"
+    chart = "${var.kf_helm_repo_path}/charts/common/istio"
   }
   addon_context = var.addon_context
   depends_on = [module.kubeflow_issuer]


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Directory was pointing to old istio-1-14 when it has been renamed to just istio. Updating this so that the charts can be found during helm installation

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.