### PR TITLE
Add Kserve with IRSA testing in sanity integration test

### DIFF
--- a/tests/e2e/fixtures/kserve_dependencies.py
+++ b/tests/e2e/fixtures/kserve_dependencies.py
@@ -1,0 +1,204 @@
+import os
+import logging
+import re
+import subprocess
+import time
+import pytest
+from e2e.utils.constants import TENSORFLOW_SERVING_VERSION
+from e2e.utils.s3_for_training.data_bucket import S3BucketWithTrainingData
+from e2e.fixtures.cluster import (
+    cluster,
+    create_iam_service_account,
+    associate_iam_oidc_provider,
+    delete_iam_service_account,
+)
+from e2e.utils.utils import (
+    rand_name,
+    write_yaml_file,
+    exec_shell,
+    wait_for,
+    load_yaml_file,
+    kubectl_apply,
+)
+from e2e.utils.config import configure_resource_fixture, metadata
+from e2e.conftest import region
+from e2e.utils.load_balancer.setup_load_balancer import create_certificates
+from e2e.utils.custom_resources import get_inference_service
+
+
+RANDOM_PREFIX = rand_name("kserve-")
+SECRET_CONFIG_FILE = "./resources/kserve/kserve-secret.yaml"
+INFERENCE_CONFIG_FILE = "./resources/kserve/inference-service.yaml"
+AUTHORIZATION_POLICY_CONFIG_FILE = "./utils/kserve/allow-predictor-transformer.yaml"
+PROFILE_NAMESPACE = "kubeflow-user-example-com"
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="class")
+def clone_tensorflow_serving():
+    tensorflow_serving_path = "../../serving"
+    if not os.path.isdir(tensorflow_serving_path):
+        retcode = subprocess.call(
+            f"git clone --branch {TENSORFLOW_SERVING_VERSION} https://github.com/tensorflow/serving/ ../../serving".split()
+        )
+        assert retcode == 0
+    else:
+        print("serving directory already exists, skipping clone ...")
+
+
+@pytest.fixture(scope="class")
+def kserve_iam_service_account(metadata, cluster, region, request):
+    metadata_key = "aws-sa"
+
+    service_account_name = "aws-sa"
+
+    def on_create():
+        create_iam_service_account(
+            service_account_name=service_account_name,
+            namespace=PROFILE_NAMESPACE,
+            cluster_name=cluster,
+            region=region,
+            iam_policy_arns=["arn:aws:iam::aws:policy/AmazonS3FullAccess"],
+        )
+
+    def on_delete():
+        delete_iam_service_account(
+            service_account_name=service_account_name,
+            namespace=PROFILE_NAMESPACE,
+            cluster_name=cluster,
+            region=region,
+        )
+
+    return configure_resource_fixture(
+        metadata=metadata,
+        request=request,
+        resource_details="created",
+        metadata_key=metadata_key,
+        on_create=on_create,
+        on_delete=on_delete,
+    )
+
+
+@pytest.fixture(scope="class")
+def s3_bucket_with_data(metadata, kserve_secret, request):
+    metadata_key = "s3-bucket"
+    bucket_name = "s3-" + RANDOM_PREFIX
+    bucket = S3BucketWithTrainingData(
+        name=bucket_name,
+        time_to_sleep=60,
+        cmd=f"aws s3 sync ../../serving/tensorflow_serving/servables/tensorflow/testdata/saved_model_half_plus_two_cpu s3://{bucket_name}/saved_model_half_plus_two",
+    )
+
+    def on_create():
+        bucket.create()
+
+    def on_delete():
+        bucket.delete()
+
+    return configure_resource_fixture(
+        metadata=metadata,
+        request=request,
+        resource_details=bucket_name,
+        metadata_key=metadata_key,
+        on_create=on_create,
+        on_delete=on_delete,
+    )
+
+
+@pytest.fixture(scope="class")
+def kserve_secret(metadata, region, kserve_iam_service_account, request):
+    metadata_key = "kserve-aws-secret"
+
+    def on_create():
+        secret_config = load_yaml_file(SECRET_CONFIG_FILE)
+        secret_config["metadata"]["annotations"]["serving.kserve.io/s3-region"] = region
+        secret_config["metadata"]["namespace"] = PROFILE_NAMESPACE
+        write_yaml_file(secret_config, SECRET_CONFIG_FILE)
+        kubectl_apply(SECRET_CONFIG_FILE)
+        # patch secret to IRSA in profile namespace
+        cmd = f'kubectl patch serviceaccount aws-sa -n {PROFILE_NAMESPACE} -p \'{{"secrets": [{{"name": "kserve-aws-secret"}}]}}\''
+        print(cmd)
+        exec_shell(cmd)
+
+    def on_delete():
+        cmd = f"kubectl delete secret kserve-aws-secret -n {PROFILE_NAMESPACE}".split()
+        subprocess.call(cmd)
+
+    return configure_resource_fixture(
+        metadata=metadata,
+        request=request,
+        resource_details="created",
+        metadata_key=metadata_key,
+        on_create=on_create,
+        on_delete=on_delete,
+    )
+
+
+@pytest.fixture(scope="class")
+def kserve_inference_service(
+    metadata,
+    kserve_iam_service_account,
+    s3_bucket_with_data,
+    kserve_secret,
+    cluster,
+    region,
+    request,
+):
+    metadata_key = "kserve-inference-service"
+
+    def on_create():
+        # Namespaces created by the Kubeflow profile controller have a missing authorization policy that
+        # prevents the KServe predictor and transformer from working.
+        # https://github.com/kserve/kserve/issues/1558
+        # https://github.com/kubeflow/kubeflow/issues/5965
+        # https://github.com/awslabs/kubeflow-manifests/issues/82#issuecomment-1068641378
+
+        print("creating allow-predictor-transformer AuthorizationPolicy...")
+        kubectl_apply(AUTHORIZATION_POLICY_CONFIG_FILE)
+        print("creating inference service...")
+        bucket_name = metadata.get("s3-bucket")
+
+        inference_config = load_yaml_file(INFERENCE_CONFIG_FILE)
+        inference_config["spec"]["predictor"]["model"][
+            "storageUri"
+        ] = f"s3://{bucket_name}/saved_model_half_plus_two/"
+        inference_config["metadata"]["namespace"] = PROFILE_NAMESPACE
+        write_yaml_file(inference_config, INFERENCE_CONFIG_FILE)
+        kubectl_apply(INFERENCE_CONFIG_FILE)
+        wait_for_inference(cluster, region)
+
+    def on_delete():
+        cmd = f"kubectl delete -f {INFERENCE_CONFIG_FILE}".split()
+        subprocess.call(cmd)
+
+    return configure_resource_fixture(
+        metadata=metadata,
+        request=request,
+        resource_details="created",
+        metadata_key=metadata_key,
+        on_create=on_create,
+        on_delete=on_delete,
+    )
+
+
+def wait_for_inference(cluster_name: str, region: str):
+    logger.info("waiting for inference service creation ...")
+
+    def callback():
+        inference_service = get_inference_service(
+            cluster_name, region, namespace=PROFILE_NAMESPACE
+        )
+
+        assert inference_service.get("status") is not None
+        conditions = inference_service["status"]["conditions"]
+        for condition in conditions:
+            if condition["type"] == "IngressReady":
+                assert condition["status"] == "True"
+            if condition["type"] == "PredictorConfigurationReady":
+                assert condition["status"] == "True"
+            if condition["type"] == "PredictorRouteReady":
+                assert condition["status"] == "True"
+            if condition["type"] == "PredictorReady":
+                assert condition["status"] == "True"
+
+    wait_for(callback)

--- a/tests/e2e/resources/kserve/inference-service.yaml
+++ b/tests/e2e/resources/kserve/inference-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    sidecar.istio.io/inject: 'false'
+  name: half-plus-two
+  namespace: ${PROFILE_NAMESPACE}
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: tensorflow
+      storageUri: ${S3_BUCKET_URI}
+    serviceAccountName: aws-sa

--- a/tests/e2e/resources/kserve/kserve-secret.yaml
+++ b/tests/e2e/resources/kserve/kserve-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  AWS_ACCESS_KEY_ID: ''
+  AWS_SECRET_ACCESS_KEY: ''
+kind: Secret
+metadata:
+  annotations:
+    serving.kserve.io/s3-endpoint: s3.amazonaws.com
+    serving.kserve.io/s3-region: ${REGION}
+    serving.kserve.io/s3-usehttps: '1'
+  name: kserve-aws-secret
+  namespace: ${PROFILE_NAMESPACE}
+type: Opaque

--- a/tests/e2e/tests/test_sanity.py
+++ b/tests/e2e/tests/test_sanity.py
@@ -11,13 +11,33 @@ import time
 import pytest
 
 from e2e.utils.constants import DEFAULT_USER_NAMESPACE
-from e2e.utils.utils import load_yaml_file, wait_for, rand_name, write_yaml_file
+from e2e.utils.utils import (
+    load_yaml_file,
+    wait_for,
+    rand_name,
+    write_yaml_file,
+    exec_shell,
+    load_json_file,
+    kubectl_apply,
+)
+
 from e2e.utils.config import configure_resource_fixture, metadata
-
 from e2e.conftest import region
+from e2e.utils.load_balancer.setup_load_balancer import (
+    dns_update,
+    wait_for_alb_dns,
+    wait_for_alb_status,
+    get_ingress,
+)
 
+from e2e.utils.kserve.inference_sample import run_inference_sample
 from e2e.fixtures.cluster import cluster
-from e2e.fixtures.installation import installation, configure_manifests, clone_upstream, ebs_addon
+from e2e.fixtures.installation import (
+    installation,
+    configure_manifests,
+    clone_upstream,
+    ebs_addon,
+)
 from e2e.fixtures.clients import (
     kfp_client,
     port_forward,
@@ -26,8 +46,10 @@ from e2e.fixtures.clients import (
     login,
     password,
     client_namespace,
+    account_id,
 )
 
+from e2e.utils.aws.route53 import Route53HostedZone
 from e2e.utils.custom_resources import (
     create_katib_experiment_from_yaml,
     get_katib_experiment,
@@ -37,10 +59,18 @@ from e2e.utils.custom_resources import (
 from e2e.utils.load_balancer.common import CONFIG_FILE as LB_CONFIG_FILE
 from kfp_server_api.exceptions import ApiException as KFPApiException
 from kubernetes.client.exceptions import ApiException as K8sApiException
-
+from e2e.fixtures.kserve_dependencies import (
+    kserve_iam_service_account,
+    kserve_secret,
+    clone_tensorflow_serving,
+    s3_bucket_with_data,
+    kserve_inference_service,
+)
 
 INSTALLATION_PATH_FILE = "./resources/installation_config/vanilla.yaml"
 CUSTOM_RESOURCE_TEMPLATES_FOLDER = "./resources/custom-resource-templates"
+KNATIVE_CONFIG_FILE = "./resources/kserve/knative-config.yaml"
+PROFILE_NAMESPACE = "kubeflow-user-example-com"
 
 
 @pytest.fixture(scope="class")
@@ -62,12 +92,22 @@ def wait_for_run_succeeded(kfp_client, run, job_name, pipeline_id):
 
     wait_for(callback, timeout=600)
 
+
 @pytest.fixture(scope="class")
-def setup_load_balancer(metadata, region, request, cluster, installation, root_domain_name, root_domain_hosted_zone_id):
-    
+def setup_load_balancer(
+    metadata,
+    region,
+    request,
+    cluster,
+    installation,
+    root_domain_name,
+    root_domain_hosted_zone_id,
+):
+
     lb_deps = {}
     env_value = os.environ.copy()
     env_value["PYTHONPATH"] = f"{os.getcwd()}/..:" + os.environ.get("PYTHONPATH", "")
+
     def on_create():
         if not root_domain_name or not root_domain_hosted_zone_id:
             pytest.fail(
@@ -76,15 +116,8 @@ def setup_load_balancer(metadata, region, request, cluster, installation, root_d
 
         subdomain_name = rand_name("platform") + "." + root_domain_name
         lb_config = {
-            "cluster": {
-                "region": region,
-                "name": cluster
-            },
-            "kubeflow": {
-                "alb": {
-                    "scheme": "internet-facing"
-                }
-            },
+            "cluster": {"region": region, "name": cluster},
+            "kubeflow": {"alb": {"scheme": "internet-facing"}},
             "route53": {
                 "rootDomain": {
                     "name": root_domain_name,
@@ -92,24 +125,43 @@ def setup_load_balancer(metadata, region, request, cluster, installation, root_d
                 },
                 "subDomain": {
                     "name": subdomain_name,
+                    "subjectAlternativeNames": [
+                        f"{PROFILE_NAMESPACE}.{subdomain_name}"
+                    ],
                 },
-            }
+            },
         }
         write_yaml_file(lb_config, LB_CONFIG_FILE)
 
         cmd = "python utils/load_balancer/setup_load_balancer.py".split()
-        retcode = subprocess.call(
-            cmd, stderr=subprocess.STDOUT, env=env_value
-        )
+        retcode = subprocess.call(cmd, stderr=subprocess.STDOUT, env=env_value)
         assert retcode == 0
         lb_deps["config"] = load_yaml_file(LB_CONFIG_FILE)
+
+        # update dns record for kserve domain
+        subdomain_hosted_zone_id = lb_deps["config"]["route53"]["subDomain"][
+            "hostedZoneId"
+        ]
+        subdomain_hosted_zone = Route53HostedZone(
+            domain=subdomain_name, region=region, id=subdomain_hosted_zone_id
+        )
+        wait_for_alb_dns(cluster, region)
+        ingress = get_ingress(cluster, region)
+        alb_dns = ingress["status"]["loadBalancer"]["ingress"][0]["hostname"]
+        wait_for_alb_status(alb_dns, region)
+
+        _kserve_record = subdomain_hosted_zone.generate_change_record(
+            record_name=f"*.{PROFILE_NAMESPACE}.{subdomain_hosted_zone.domain}",
+            record_type="CNAME",
+            record_value=[alb_dns],
+        )
+
+        subdomain_hosted_zone.change_record_set([_kserve_record])
 
     def on_delete():
         if metadata.get("lb_deps"):
             cmd = "python utils/load_balancer/lb_resources_cleanup.py".split()
-            retcode = subprocess.call(
-                cmd, stderr=subprocess.STDOUT, env=env_value
-            )
+            retcode = subprocess.call(cmd, stderr=subprocess.STDOUT, env=env_value)
             assert retcode == 0
 
     return configure_resource_fixture(
@@ -121,14 +173,19 @@ def setup_load_balancer(metadata, region, request, cluster, installation, root_d
 def host(setup_load_balancer):
     print(setup_load_balancer["config"]["route53"]["subDomain"]["name"])
     print("wait for 60s for website to be available...")
-    time.sleep(60)
-    host = "https://kubeflow." + setup_load_balancer["config"]["route53"]["subDomain"]["name"]
+    # time.sleep(60)
+    host = (
+        "https://kubeflow."
+        + setup_load_balancer["config"]["route53"]["subDomain"]["name"]
+    )
     print(f"accessing {host}...")
     return host
+
 
 @pytest.fixture(scope="class")
 def port_forward(installation):
     pass
+
 
 class TestSanity:
     @pytest.fixture(scope="class")
@@ -224,3 +281,56 @@ class TestSanity:
             raise AssertionError("Expected K8sApiException Not Found")
         except K8sApiException as e:
             assert "Not Found" == e.reason
+
+    def test_kserve_with_irsa(
+        self,
+        region,
+        metadata,
+        kfp_client,
+        clone_tensorflow_serving,
+        kserve_iam_service_account,
+        kserve_secret,
+        s3_bucket_with_data,
+        kserve_inference_service,
+    ):
+        # Edit the ConfigMap to change the default domain as per your deployment
+        subdomain = (
+            metadata.get("lb_deps")
+            .get("config")
+            .get("route53")
+            .get("subDomain")
+            .get("name")
+        )
+        # Remove the _example key and replace example.com with your domain (e.g. platform.example.com).
+        exec_shell(
+            f'kubectl patch cm config-domain --patch \'{{"data":{{"{subdomain}":""}}}}\' -n knative-serving'
+        )
+        exec_shell(
+            'kubectl patch cm config-domain --patch \'{"data":{"_example":null}}\' -n knative-serving'
+        )
+        exec_shell(
+            'kubectl patch cm config-domain --patch \'{"data":{"example.com":null}}\' -n knative-serving'
+        )
+
+        # export env with subprocess
+        # run inference_sample.py
+        subdomain = (
+            metadata.get("lb_deps")
+            .get("config")
+            .get("route53")
+            .get("subDomain")
+            .get("name")
+        )
+        os.environ["KUBEFLOW_DOMAIN"] = subdomain
+        os.environ["PROFILE_NAMESPACE"] = PROFILE_NAMESPACE
+        os.environ["MODEL_NAME"] = "half-plus-two"
+        os.environ["AUTH_PROVIDER"] = "dex"
+
+        env_value = os.environ.copy()
+        env_value["PYTHONPATH"] = f"{os.getcwd()}/..:" + os.environ.get(
+            "PYTHONPATH", ""
+        )
+
+        cmd = "python utils/kserve/inference_sample.py".split()
+        retcode = subprocess.call(cmd, stderr=subprocess.STDOUT, env=env_value)
+        assert retcode == 0

--- a/tests/e2e/tests/test_sanity.py
+++ b/tests/e2e/tests/test_sanity.py
@@ -69,7 +69,6 @@ from e2e.fixtures.kserve_dependencies import (
 
 INSTALLATION_PATH_FILE = "./resources/installation_config/vanilla.yaml"
 CUSTOM_RESOURCE_TEMPLATES_FOLDER = "./resources/custom-resource-templates"
-KNATIVE_CONFIG_FILE = "./resources/kserve/knative-config.yaml"
 PROFILE_NAMESPACE = "kubeflow-user-example-com"
 
 

--- a/tests/e2e/tests/test_sanity.py
+++ b/tests/e2e/tests/test_sanity.py
@@ -172,7 +172,7 @@ def setup_load_balancer(
 def host(setup_load_balancer):
     print(setup_load_balancer["config"]["route53"]["subDomain"]["name"])
     print("wait for 60s for website to be available...")
-    # time.sleep(60)
+    time.sleep(60)
     host = (
         "https://kubeflow."
         + setup_load_balancer["config"]["route53"]["subDomain"]["name"]

--- a/tests/e2e/tests/test_sanity_portforward.py
+++ b/tests/e2e/tests/test_sanity_portforward.py
@@ -133,9 +133,10 @@ def sagemaker_execution_role(region, metadata, request):
     )
 
 @pytest.fixture(scope="class")
-def s3_bucket_with_data():
+def s3_bucket_with_data(region):
     bucket_name = "s3-" + RANDOM_PREFIX
-    bucket = S3BucketWithTrainingData(name=bucket_name)
+    bucket = S3BucketWithTrainingData(name=bucket_name, cmd=f"python utils/s3_for_training/sync.py {bucket_name} {region}",
+                                       time_to_sleep=120)
     bucket.create()
 
     yield

--- a/tests/e2e/utils/constants.py
+++ b/tests/e2e/utils/constants.py
@@ -10,6 +10,7 @@ DEFAULT_PASSWORD = "12341234"
 KUBEFLOW_GROUP = "kubeflow.org"
 KUBEFLOW_NAMESPACE = "kubeflow"
 KUBEFLOW_VERSION = "v1.7.0-rc.1"
+TENSORFLOW_SERVING_VERSION = "r2.11"
 ALTERNATE_MLMDB_NAME = "metadata_db"
 
 TO_ROOT = "../../"  # As of this commit, tests are run from the tests/e2e folder

--- a/tests/e2e/utils/custom_resources.py
+++ b/tests/e2e/utils/custom_resources.py
@@ -94,6 +94,18 @@ def get_ingress(cluster, region, name="istio-ingress", namespace="istio-system")
     )
 
 
+def get_inference_service(cluster, region, name="half-plus-two", namespace="kubeflow-user-example-com"):
+    return get_namespaced_resource(
+        cluster,
+        region,
+        group="serving.kserve.io",
+        version="v1beta1",
+        namespace=namespace,
+        plural="inferenceservices",
+        name=name,
+    )
+
+
 def get_pvc_status(cluster, region, namespace, name):
     client = create_k8s_core_api_client(cluster, region)
 

--- a/tests/e2e/utils/kserve/allow-predictor-transformer.yaml
+++ b/tests/e2e/utils/kserve/allow-predictor-transformer.yaml
@@ -1,0 +1,41 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-predictor
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      component: predictor
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        paths:
+        - /metrics
+        - /healthz
+        - /ready
+        - /wait-for-drain
+        - /v1/models/*
+        - /v2/models/*
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-transformer
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      component: transformer
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        paths:
+        - /metrics
+        - /healthz
+        - /ready
+        - /wait-for-drain
+        - /v1/models/*
+        - /v2/models/*

--- a/tests/e2e/utils/kserve/inference_sample.py
+++ b/tests/e2e/utils/kserve/inference_sample.py
@@ -4,44 +4,54 @@ import json
 
 from e2e.utils.utils import load_json_file
 
-# common vars
-KUBEFLOW_DOMAIN = os.environ.get("KUBEFLOW_DOMAIN", "kubeflow.example.com")
-PROFILE_NAMESPACE = os.environ.get("PROFILE_NAMESPACE", "staging")
-MODEL_NAME = os.environ.get("MODEL_NAME", "sklearn-iris")
-AUTH_PROVIDER = os.environ.get("AUTH_PROVIDER", "dex")
+def run_inference_sample():
+    # common vars
+    KUBEFLOW_DOMAIN = os.environ.get("KUBEFLOW_DOMAIN", "kubeflow.example.com")
+    PROFILE_NAMESPACE = os.environ.get("PROFILE_NAMESPACE", "kubeflow-user-example-com")
+    MODEL_NAME = os.environ.get("MODEL_NAME", "sklearn-iris")
+    AUTH_PROVIDER = os.environ.get("AUTH_PROVIDER", "dex")
 
-URL = f"https://{MODEL_NAME}.{PROFILE_NAMESPACE}.{KUBEFLOW_DOMAIN}/v1/models/{MODEL_NAME}:predict"
-HEADERS = {"Host": f"{MODEL_NAME}.{PROFILE_NAMESPACE}.{KUBEFLOW_DOMAIN}"}
-DASHBOARD_URL = f"https://kubeflow.{KUBEFLOW_DOMAIN}"
+    URL = f"https://{MODEL_NAME}.{PROFILE_NAMESPACE}.{KUBEFLOW_DOMAIN}/v1/models/{MODEL_NAME}:predict"
+    HEADERS = {"Host": f"{MODEL_NAME}.{PROFILE_NAMESPACE}.{KUBEFLOW_DOMAIN}"}
+    DASHBOARD_URL = f"https://kubeflow.{KUBEFLOW_DOMAIN}"
+    data = load_json_file("./utils/kserve/iris-input.json")
+    response = None
+    if AUTH_PROVIDER != "cognito":
+        PROFILE_USERNAME = os.environ.get("PROFILE_USERNAME", "user@example.com")
+        PASSWORD = os.environ.get("PASSWORD", "12341234")
 
-data = load_json_file("./utils/kserve/iris-input.json")
+        def session_cookie(host, login, password):
+            session = requests.Session()
+            response = session.get(host)
+            headers = {
+                "Content-Type": "application/x-www-form-urlencoded",
+            }
+            data = {"login": login, "password": password}
+            session.post(response.url, headers=headers, data=data)
+            session_cookie = session.cookies.get_dict()["authservice_session"]
+            return session_cookie
 
-response = None
-if AUTH_PROVIDER != "cognito":
-    USERNAME = os.environ.get("USERNAME", "user@example.com")
-    PASSWORD = os.environ.get("PASSWORD", "12341234")
-    
-    def session_cookie(host, login, password):
-        session = requests.Session()
-        response = session.get(host)
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
+        cookie = {
+            "authservice_session": session_cookie(
+                DASHBOARD_URL, PROFILE_USERNAME, PASSWORD
+            )
         }
-        data = {"login": login, "password": password}
-        session.post(response.url, headers=headers, data=data)
-        session_cookie = session.cookies.get_dict()["authservice_session"]
-        return session_cookie
+        response = requests.post(URL, headers=HEADERS, json=data, cookies=cookie)
+    else:
+        HTTP_HEADER_NAME = os.environ.get("HTTP_HEADER_NAME", "x-api-key")
+        HTTP_HEADER_VALUE = os.environ.get("HTTP_HEADER_VALUE", "token1")
+        HEADERS[HTTP_HEADER_NAME] = HTTP_HEADER_VALUE
 
-    cookie = {"authservice_session": session_cookie(DASHBOARD_URL, USERNAME, PASSWORD)}
-    response = requests.post(URL, headers=HEADERS, json=data, cookies=cookie)
-else:
-    HTTP_HEADER_NAME = os.environ.get("HTTP_HEADER_NAME", "x-api-key")
-    HTTP_HEADER_VALUE = os.environ.get("HTTP_HEADER_VALUE", "token1")
-    HEADERS[HTTP_HEADER_NAME] = HTTP_HEADER_VALUE
+        response = requests.post(URL, headers=HEADERS, json=data)
 
-    response = requests.post(URL, headers=HEADERS, json=data)
+    status_code = response.status_code
+    print("Status Code", status_code)
+    if status_code == 200:
+        print("JSON Response ", json.dumps(response.json(), indent=2))
 
-status_code = response.status_code
-print("Status Code", status_code)
-if status_code == 200:
-    print("JSON Response ", json.dumps(response.json(), indent=2))
+    else:
+        raise Exception("prediction failed, status code = ")
+
+
+if __name__ == "__main__":
+    run_inference_sample()


### PR DESCRIPTION
- This can be referred to previous PR https://github.com/awslabs/kubeflow-manifests/pull/527 to address some of the comments:
     - make s3 bucket class (`tests/e2e/utils/s3_for_training/data_bucket.py`) generic so it can reuse for kserve testing
     - code style for refactoring
     - add allow-transformer policy
     - default profile_namespace = kubeflow-user-example-com

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass
