### PR TITLE
[Cherry pick] Change Dex Service from Nodeport to ClusterIP

### DIFF
--- a/awsconfigs/common/dex/kustomization.yaml
+++ b/awsconfigs/common/dex/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: auth
+bases:
+- ../../../upstream/common/dex/overlays/istio
+
+patchesStrategicMerge:
+- patches/service.yaml
+- patches/disable-nodeport.yaml

--- a/awsconfigs/common/dex/patches/disable-nodeport.yaml
+++ b/awsconfigs/common/dex/patches/disable-nodeport.yaml
@@ -2,13 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dex
-  namespace: auth
 spec:
   ports:
   - name: dex
     port: 5556
     protocol: TCP
     targetPort: 5556
-  selector:
-    app: dex
-  type: ClusterIP
+    nodePort: null

--- a/awsconfigs/common/dex/patches/service.yaml
+++ b/awsconfigs/common/dex/patches/service.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+spec:
+  type: ClusterIP

--- a/charts/common/dex/Chart.yaml
+++ b/charts/common/dex/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployments/rds-s3/base/kustomization.yaml
+++ b/deployments/rds-s3/base/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
   # OIDC Authservice
   - ../../../upstream/common/oidc-authservice/base
   # Dex
-  - ../../../upstream/common/dex/overlays/istio
+  - ../../../awsconfigs/common/dex
   # KNative
   - ../../../upstream/common/knative/knative-serving/overlays/gateways
   - ../../../upstream/common/knative/knative-eventing/base

--- a/deployments/vanilla/kustomization.yaml
+++ b/deployments/vanilla/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
   # OIDC Authservice
   - ../../upstream/common/oidc-authservice/base
   # Dex
-  - ../../upstream/common/dex/overlays/istio
+  - ../../awsconfigs/common/dex
   # KNative
   - ../../upstream/common/knative/knative-serving/overlays/gateways
   - ../../upstream/common/knative/knative-eventing/base

--- a/tests/e2e/resources/installation_config/rds-only.yaml
+++ b/tests/e2e/resources/installation_config/rds-only.yaml
@@ -55,7 +55,7 @@ dex:
   installation_options:
     kustomize:
       paths: 
-        - ../../upstream/common/dex/overlays/istio
+        - ../../awsconfigs/common/dex
     helm: 
       paths: ../../charts/common/dex
   validations:

--- a/tests/e2e/resources/installation_config/rds-s3.yaml
+++ b/tests/e2e/resources/installation_config/rds-s3.yaml
@@ -55,7 +55,7 @@ dex:
   installation_options:
     kustomize:
       paths: 
-        - ../../upstream/common/dex/overlays/istio
+        - ../../awsconfigs/common/dex
     helm: 
       paths: ../../charts/common/dex
   validations:

--- a/tests/e2e/resources/installation_config/s3-only.yaml
+++ b/tests/e2e/resources/installation_config/s3-only.yaml
@@ -55,7 +55,7 @@ dex:
   installation_options:
     kustomize:
       paths: 
-        - ../../upstream/common/dex/overlays/istio
+        - ../../awsconfigs/common/dex
     helm: 
       paths: ../../charts/common/dex
   validations:

--- a/tests/e2e/resources/installation_config/vanilla.yaml
+++ b/tests/e2e/resources/installation_config/vanilla.yaml
@@ -58,7 +58,7 @@ dex:
   installation_options:
     kustomize:
       paths: 
-        - ../../upstream/common/dex/overlays/istio
+        - ../../awsconfigs/common/dex
     helm: 
       paths: ../../charts/common/dex
   validations:


### PR DESCRIPTION
**Description of your changes:**
There are occasional times when installing dex we see the following error message:
```
The Service "dex" is invalid: spec.ports[0].nodePort: Invalid value: 32000: provided port is already allocated
```

It indicates that there is already a service using port 32000 on the same node trying to create the "dex" service.
Dex service was modified to be exposed as ClusterIP instead of NodePort in the new release KF v1.7.0 along with Istio for security upgrade (https://github.com/kubeflow/manifests/pull/2357)

This is a mirror patch from the above PR to change Dex service from NodePort to ClusterIP to solve the error message seen.



**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.