### PR TITLE
Remove Trainium from blog

### DIFF
--- a/website/content/en/blog/_index.md
+++ b/website/content/en/blog/_index.md
@@ -31,8 +31,6 @@ Find case studies, use cases, best practices, benchmarks, and more.
 
 1. [Use Amazon SageMaker Operators for Kubernetes (ACK) to train and deploy machine learning models](https://aws.amazon.com/blogs/machine-learning/use-amazon-sagemaker-ack-operators-to-train-and-deploy-machine-learning-models/).
 
-1. [Scaling distributed training with AWS Trainium and Amazon EKS](https://aws.amazon.com/blogs/machine-learning/scaling-distributed-training-with-aws-trainium-and-amazon-eks/). Details about official support for distributed training jobs using Amazon EKS and EC2 Trn1 instances. You can now easily run large-scale containerized training jobs within Amazon EKS while taking full advantage of the price-performance, scalability, and ease of use offered by Trn1 instances.
-
 ## Watch 
 
 This section curates a list of recorded virtual workshops, demos, and general presentations illustrating how to leverage Kubeflow on AWS and SageMaker to build, run, and monitor scalable ML workflows on Kubernetes.

--- a/website/content/en/blog/_index.md
+++ b/website/content/en/blog/_index.md
@@ -8,7 +8,7 @@ layout: "list"
 
 In this section, we share posts, articles, and videos illustrating how some of our customers have leveraged AWS distribution of Kubeflow to optimize large-scale and compute-intensive machine learning workloads, we provide ML infrastructure recommendations and best practices, and we inform you on Kubelow on AWS coming training sessions and available recordings.
 
-Want to try the latest version of Kubeflow on AWS? Follow the steps in [Kubeflow on AWS documentation](http://localhost:1313/kubeflow-manifests/main/docs/deployment/prerequisites/).
+Want to try the latest version of Kubeflow on AWS? Follow the steps in [Kubeflow on AWS documentation](/kubeflow-manifests/main/docs/deployment/prerequisites/).
 
 [Read](#read) from our curated list of posts or [Watch](#watch) a recorded session.
 


### PR DESCRIPTION
Needs testing before being posted. Was removed from 1.6 branch. Now pulling from main.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.