### PR TITLE
Update e2e tests to have credentials_option

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -58,6 +58,12 @@ def pytest_addoption(parser):
         action="store",
         help="vanilla/cognito/rds-and-s3/rds-only/s3-only, default is set to vanilla"
     )
+    parser.addoption(
+        "--credentials_option",
+        action="store",
+        help="irsa or static, default is set to static"
+    )
+
 
 
 
@@ -143,6 +149,21 @@ def deployment_option(metadata, request):
     metadata.insert("deployment_option", deployment_option)
     
     return deployment_option
+
+@pytest.fixture(scope="class")
+def credentials_option(metadata, request):
+    """
+    Test credentials option.
+    """
+    if metadata.get("credentials_option"):
+        return metadata.get("credentials_option")
+
+    credentials_option = request.config.getoption("--credentials_option")
+    if not credentials_option:
+        credentials_option = 'static'
+    metadata.insert("credentials_option", credentials_option)
+    
+    return credentials_option
 
 
 @pytest.fixture(scope="class")

--- a/tests/e2e/fixtures/installation.py
+++ b/tests/e2e/fixtures/installation.py
@@ -118,7 +118,7 @@ def installation(
         install_kubeflow(installation_option, deployment_option, cluster, credentials_option)
 
     def on_delete():
-        uninstall_kubeflow(installation_option, deployment_option)
+        uninstall_kubeflow(installation_option, deployment_option, credentials_option)
 
     configure_resource_fixture(
         metadata, request, installation_path, "installation_path", on_create, on_delete

--- a/tests/e2e/fixtures/installation.py
+++ b/tests/e2e/fixtures/installation.py
@@ -101,6 +101,7 @@ def installation(
     ebs_addon,
     installation_path,
     installation_option,
+    credentials_option,
     request,
 ):
     """
@@ -114,7 +115,7 @@ def installation(
     """
 
     def on_create():
-        install_kubeflow(installation_option, deployment_option, cluster)
+        install_kubeflow(installation_option, deployment_option, cluster, credentials_option)
 
     def on_delete():
         uninstall_kubeflow(installation_option, deployment_option)

--- a/tests/e2e/resources/installation_config/s3-only-static.yaml
+++ b/tests/e2e/resources/installation_config/s3-only-static.yaml
@@ -356,6 +356,21 @@ user-namespace:
     helm: 
       paths: ../../charts/common/user-namespace
 
+#AWS Secrets Manager
+aws-secrets-manager:
+  installation_options:
+    kustomize: 
+      paths:
+        - ../../awsconfigs/common/aws-secrets-manager/s3
+    helm:
+      paths: ../../charts/common/aws-secrets-manager/s3-only
+  validations:
+    pods:
+      namespace: kubeflow
+      labels:
+        - key: app
+          value: aws-secrets-sync
+
 ack-sagemaker-controller:
   installation_options:
     kustomize: 

--- a/tests/e2e/utils/kubeflow_installation.py
+++ b/tests/e2e/utils/kubeflow_installation.py
@@ -77,7 +77,7 @@ def install_kubeflow(
         installation_config = load_yaml_file(INSTALLATION_CONFIG_COGNITO)
     elif deployment_option == "rds-s3" and credentials_option == "static":
         installation_config = load_yaml_file(INSTALLATION_CONFIG_RDS_S3_STATIC)
-    elif deployment_option == "s3" and credentials_option == "static":
+    elif deployment_option == "s3-only" and credentials_option == "static":
         installation_config = load_yaml_file(INSTALLATION_CONFIG_S3_ONLY_STATIC)
     elif deployment_option == "cognito-rds-s3" and credentials_option == "static":
         installation_config = load_yaml_file(INSTALLATION_CONFIG_COGNITO_RDS_S3_STATIC)
@@ -283,27 +283,30 @@ def configure_kubeflow_pipelines(
 ):
     if credentials_option == "static":
         return
-    
+
     cfg = load_yaml_file(file_path="./utils/pipelines/config.yaml")
     IAM_ROLE_ARN_FOR_IRSA = cfg["pipeline_oidc_role"]
 
     if installation_option == "kustomize":
         CHART_EXPORT_PATH = "../../awsconfigs/apps/pipeline/s3/service-account.yaml"
-        USER_NAMESPACE_PATH = "../../awsconfigs/common/user-namespace/overlay/profile.yaml"
+        USER_NAMESPACE_PATH = (
+            "../../awsconfigs/common/user-namespace/overlay/profile.yaml"
+        )
 
     else:
         CHART_EXPORT_PATH = f"{installation_paths}/templates/ServiceAccount/ml-pipeline-kubeflow-ServiceAccount.yaml"
         USER_NAMESPACE_PATH = "../../charts/common/user-namespace/templates/Profile/kubeflow-user-example-com-Profile.yaml"
 
     exec_shell(
-            f'yq e \'.metadata.annotations."eks.amazonaws.com/role-arn"="{IAM_ROLE_ARN_FOR_IRSA}"\' '
-            + f"-i {CHART_EXPORT_PATH}"
-        )
+        f'yq e \'.metadata.annotations."eks.amazonaws.com/role-arn"="{IAM_ROLE_ARN_FOR_IRSA}"\' '
+        + f"-i {CHART_EXPORT_PATH}"
+    )
     exec_shell(
-            f'yq e \'.spec.plugins[0].spec."awsIamRole"="{IAM_ROLE_ARN_FOR_IRSA}"\' '
-            + f"-i {USER_NAMESPACE_PATH}"
-        )
-    
+        f'yq e \'.spec.plugins[0].spec."awsIamRole"="{IAM_ROLE_ARN_FOR_IRSA}"\' '
+        + f"-i {USER_NAMESPACE_PATH}"
+    )
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     INSTALLATION_OPTION_DEFAULT = "kustomize"

--- a/tests/e2e/utils/kubeflow_uninstallation.py
+++ b/tests/e2e/utils/kubeflow_uninstallation.py
@@ -7,7 +7,7 @@ from e2e.utils.utils import (
     delete_kustomize,
     load_yaml_file,
     exec_shell,
-    check_helm_chart_exists
+    check_helm_chart_exists,
 )
 import os
 import subprocess
@@ -18,8 +18,16 @@ INSTALLATION_CONFIG_COGNITO = "./resources/installation_config/cognito.yaml"
 INSTALLATION_CONFIG_RDS_S3 = "./resources/installation_config/rds-s3.yaml"
 INSTALLATION_CONFIG_RDS_ONLY = "./resources/installation_config/rds-only.yaml"
 INSTALLATION_CONFIG_S3_ONLY = "./resources/installation_config/s3-only.yaml"
-INSTALLATION_CONFIG_COGNITO_RDS_S3 = "./resources/installation_config/cognito-rds-s3.yaml"
-
+INSTALLATION_CONFIG_COGNITO_RDS_S3 = (
+    "./resources/installation_config/cognito-rds-s3.yaml"
+)
+INSTALLATION_CONFIG_S3_ONLY_STATIC = (
+    "./resources/installation_config/s3-only-static.yaml"
+)
+INSTALLATION_CONFIG_RDS_S3_STATIC = "./resources/installation_config/rds-s3-static.yaml"
+INSTALLATION_CONFIG_COGNITO_RDS_S3_STATIC = (
+    "./resources/installation_config/cognito-rds-s3-static.yaml"
+)
 
 Uninstall_Sequence = [
     "aws-authservice",
@@ -56,13 +64,18 @@ Uninstall_Sequence = [
 ]
 
 
-def uninstall_kubeflow(installation_option, deployment_option):
-    
+def uninstall_kubeflow(installation_option, deployment_option, credentials_option):
 
     if deployment_option == "vanilla":
         path_dic = load_yaml_file(INSTALLATION_CONFIG_VANILLA)
     elif deployment_option == "cognito":
         path_dic = load_yaml_file(INSTALLATION_CONFIG_COGNITO)
+    elif deployment_option == "rds-s3" and credentials_option == "static":
+        path_dic = load_yaml_file(INSTALLATION_CONFIG_RDS_S3_STATIC)
+    elif deployment_option == "s3-only" and credentials_option == "static":
+        path_dic = load_yaml_file(INSTALLATION_CONFIG_S3_ONLY_STATIC)
+    elif deployment_option == "cognito-rds-s3" and credentials_option == "static":
+        path_dic = load_yaml_file(INSTALLATION_CONFIG_COGNITO_RDS_S3_STATIC)
     elif deployment_option == "rds-s3":
         path_dic = load_yaml_file(INSTALLATION_CONFIG_RDS_S3)
     elif deployment_option == "rds-only":
@@ -73,7 +86,7 @@ def uninstall_kubeflow(installation_option, deployment_option):
         path_dic = load_yaml_file(INSTALLATION_CONFIG_COGNITO_RDS_S3)
 
     print_banner(
-        f"You are uninstalling kubeflow {deployment_option} deployment with {installation_option}"
+        f"You are uninstalling kubeflow {deployment_option} deployment with {installation_option} with {credentials_option}"
     )
 
     for component in Uninstall_Sequence:
@@ -85,10 +98,7 @@ def uninstall_kubeflow(installation_option, deployment_option):
             namespace = "ack-system"
         else:
             namespace = None
-        delete_component(
-            installation_option, path_dic, component, namespace
-        )
-
+        delete_component(installation_option, path_dic, component, namespace)
 
 
 def delete_component(
@@ -98,23 +108,34 @@ def delete_component(
         return
     else:
         print(f"==========uninstallating {component_name}...==========")
-        #remote
-        if "repo" in installation_config[component_name]["installation_options"][installation_option]:
+        # remote
+        if (
+            "repo"
+            in installation_config[component_name]["installation_options"][
+                installation_option
+            ]
+        ):
             uninstall_remote_component(component_name, namespace)
-        #local
+        # local
         else:
-            installation_path = installation_config[component_name]["installation_options"][installation_option]["paths"]
-            
+            installation_path = installation_config[component_name][
+                "installation_options"
+            ][installation_option]["paths"]
+
             if installation_option == "helm":
                 if component_name == "kubeflow-namespace":
-                    for kustomize_path in installation_config[component_name]["installation_options"]["kustomize"]["paths"]:
+                    for kustomize_path in installation_config[component_name][
+                        "installation_options"
+                    ]["kustomize"]["paths"]:
                         delete_kustomize(kustomize_path)
                 else:
                     if check_helm_chart_exists(component_name, namespace):
                         uninstall_helm(component_name, namespace)
-                        if component_name == "ingress": 
-                            #Helm doesn't seem to delete ingress during uninstall
-                            exec_shell(f"kubectl delete ingress -n istio-system istio-ingress")
+                        if component_name == "ingress":
+                            # Helm doesn't seem to delete ingress during uninstall
+                            exec_shell(
+                                f"kubectl delete ingress -n istio-system istio-ingress"
+                            )
                     if os.path.isdir(f"{installation_path}/crds"):
                         print(f"deleting {component_name} crds ...")
                         kubectl_delete(f"{installation_path}/crds")
@@ -138,16 +159,16 @@ def delete_component(
 
         print(f"All {component_name} resources are cleared!")
 
+
 def uninstall_remote_component(component_name, namespace):
     if check_helm_chart_exists(component_name, namespace):
         uninstall_helm(component_name, namespace)
         if component_name == "aws-load-balancer-controller":
             kubectl_delete(
-                            "https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/6d3e976e3f60dc4588c01bad036d77c127a68e71/helm/aws-load-balancer-controller/crds/crds.yaml"
-                          )
+                "https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/6d3e976e3f60dc4588c01bad036d77c127a68e71/helm/aws-load-balancer-controller/crds/crds.yaml"
+            )
         elif component_name == "ack-sagemaker-controller":
             kubectl_delete(f"../../charts/common/ack-controller/sagemaker-chart/crds")
-
 
 
 if __name__ == "__main__":
@@ -158,20 +179,39 @@ if __name__ == "__main__":
         type=str,
         default=INSTALLATION_OPTION_DEFAULT,
         help=f"Kubeflow Installation option default is set to {INSTALLATION_OPTION_DEFAULT}",
-        choices=['kustomize','helm'],
+        choices=["kustomize", "helm"],
         required=False,
     )
-    
+
     DEPLOYMENT_OPTION_DEFAULT = "vanilla"
     parser.add_argument(
         "--deployment_option",
         type=str,
         default=DEPLOYMENT_OPTION_DEFAULT,
-        choices=['vanilla','cognito','rds-s3','rds-only','s3-only','cognito-rds-s3'],
+        choices=[
+            "vanilla",
+            "cognito",
+            "rds-s3",
+            "rds-only",
+            "s3-only",
+            "cognito-rds-s3",
+        ],
         help=f"Kubeflow deployment options default is set to {DEPLOYMENT_OPTION_DEFAULT}",
+        required=False,
+    )
+
+    CREDENTIALS_OPTION_DEFAULT = "irsa"
+    parser.add_argument(
+        "--credentials_option",
+        type=str,
+        default=CREDENTIALS_OPTION_DEFAULT,
+        choices=["irsa", "static"],
+        help=f"Kubeflow default credential option default is set to irsa",
         required=False,
     )
 
     args, _ = parser.parse_known_args()
 
-    uninstall_kubeflow(args.installation_option,  args.deployment_option)
+    uninstall_kubeflow(
+        args.installation_option, args.deployment_option, args.credentials_option
+    )


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Setting default to static, while spending time to refactor the kubeflow pipelines irsa setup. Most e2e tests will be using static anyway.

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.