### PR TITLE
update eks blueprints and csi-secrets-driver versions

### DIFF
--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
@@ -66,7 +66,7 @@ data "aws_iam_role" "user_namespace_irsa_iam_role" {
 }
 
 module "kubeflow_secrets_manager_irsa" {
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = true
@@ -81,7 +81,7 @@ module "kubeflow_secrets_manager_irsa" {
 
 module "kubeflow_pipeline_irsa" {
   count                             = var.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false
@@ -96,7 +96,7 @@ module "kubeflow_pipeline_irsa" {
 
 module "user_namespace_irsa" {
   count                             = var.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = "kubeflow-user-example-com"
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -114,7 +114,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -129,7 +129,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
@@ -152,6 +152,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   secrets_store_csi_driver_helm_config = {
     namespace = "kube-system"
+    version = "1.3.2"
     set = [
       {
         name  = "syncSecret.enabled",

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -115,7 +115,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -130,7 +130,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -107,7 +107,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -122,7 +122,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
@@ -145,6 +145,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   secrets_store_csi_driver_helm_config = {
     namespace = "kube-system"
+    version = "1.3.2"
     set = [
       {
         name  = "syncSecret.enabled",

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -59,7 +59,7 @@ data "aws_iam_role" "user_namespace_irsa_iam_role" {
 
 module "kubeflow_secrets_manager_irsa" {
   count                             = var.use_static || var.use_rds ? 1 : 0
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = true
@@ -74,7 +74,7 @@ module "kubeflow_secrets_manager_irsa" {
 
 module "kubeflow_pipeline_irsa" {
   count                             = var.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false
@@ -89,7 +89,7 @@ module "kubeflow_pipeline_irsa" {
 
 module "user_namespace_irsa" {
   count                             = var.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = "kubeflow-user-example-com"
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -107,7 +107,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -121,7 +121,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/iaac/terraform/apps/admission-webhook/main.tf
+++ b/iaac/terraform/apps/admission-webhook/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/central-dashboard/main.tf
+++ b/iaac/terraform/apps/central-dashboard/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/jupyter-web-app/main.tf
+++ b/iaac/terraform/apps/jupyter-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/katib/main.tf
+++ b/iaac/terraform/apps/katib/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/kubeflow-pipelines/main.tf
+++ b/iaac/terraform/apps/kubeflow-pipelines/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/models-web-app/main.tf
+++ b/iaac/terraform/apps/models-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/notebook-controller/main.tf
+++ b/iaac/terraform/apps/notebook-controller/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -5,7 +5,7 @@ resource "aws_iam_policy" "profile_controller_policy" {
 }
 
 module "irsa" {
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = "kubeflow"
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false
@@ -19,7 +19,7 @@ module "irsa" {
 }
 
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/tensorboard-controller/main.tf
+++ b/iaac/terraform/apps/tensorboard-controller/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/tensorboards-web-app/main.tf
+++ b/iaac/terraform/apps/tensorboards-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/training-operator/main.tf
+++ b/iaac/terraform/apps/training-operator/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/volumes-web-app/main.tf
+++ b/iaac/terraform/apps/volumes-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -5,7 +5,7 @@ resource "aws_iam_policy" "sagemaker_ack_controller_studio_access" {
 }
 
 module "irsa" {
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = local.namespace
   create_kubernetes_namespace       = true
   create_kubernetes_service_account = false
@@ -19,7 +19,7 @@ module "irsa" {
 }
 
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   manage_via_gitops = false
   helm_config       = local.helm_config
   set_values = [

--- a/iaac/terraform/common/aws-authservice/main.tf
+++ b/iaac/terraform/common/aws-authservice/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-secrets-manager/main.tf
+++ b/iaac/terraform/common/aws-secrets-manager/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-telemetry/main.tf
+++ b/iaac/terraform/common/aws-telemetry/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/cluster-local-gateway/main.tf
+++ b/iaac/terraform/common/cluster-local-gateway/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/dex/main.tf
+++ b/iaac/terraform/common/dex/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/istio/main.tf
+++ b/iaac/terraform/common/istio/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/knative-eventing/main.tf
+++ b/iaac/terraform/common/knative-eventing/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/knative-serving/main.tf
+++ b/iaac/terraform/common/knative-serving/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kserve/main.tf
+++ b/iaac/terraform/common/kserve/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-issuer/main.tf
+++ b/iaac/terraform/common/kubeflow-issuer/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-istio-resources/main.tf
+++ b/iaac/terraform/common/kubeflow-istio-resources/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-roles/main.tf
+++ b/iaac/terraform/common/kubeflow-roles/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/oidc-authservice/main.tf
+++ b/iaac/terraform/common/oidc-authservice/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/user-namespace/main.tf
+++ b/iaac/terraform/common/user-namespace/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #653 
One of the dependcies used by EKS blueprints moved their repository location which caused terraform init to fail. Secondly updating csi-secrets-driver to pull from registry.k8s.io as k8s.gcr.io is now legacy.

**Description of your changes:**
Updated to latest eks blueprints and csi-secrets-driver versions.

Manually verified that builds and pipelines can be run.

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.