### PR TITLE
Release v1.6.1 aws b1.0.2

### DIFF
--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
@@ -49,9 +49,9 @@ resource "kubernetes_namespace" "kubeflow" {
 }
 
 module "kubeflow_secrets_manager_irsa" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
-  kubernetes_namespace = kubernetes_namespace.kubeflow.metadata[0].name
-  create_kubernetes_namespace = false
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
+  kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
+  create_kubernetes_namespace       = false
   create_kubernetes_service_account = true
   kubernetes_service_account        = "kubeflow-secrets-manager-sa"
   irsa_iam_role_name = format("%s-%s-%s-%s", "kf-secrets-manager", "irsa", var.addon_context.eks_cluster_id, var.addon_context.aws_region_name)

--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/outputs.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/outputs.tf
@@ -1,5 +1,5 @@
 output "kubelow_platform_domain" {
-    value = module.ingress_cognito[0].kubelow_platform_domain
+  value = module.ingress_cognito[0].kubelow_platform_domain
 }
 
 output "rds_endpoint" {

--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/variables.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/variables.tf
@@ -22,22 +22,22 @@ variable "addon_context" {
 
 variable "enable_aws_telemetry" {
   description = "Enable AWS telemetry component"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "use_rds" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "use_s3" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "use_cognito" {
-  type = bool
+  type    = bool
   default = true
 }
 
@@ -61,67 +61,67 @@ variable "security_group_id" {
 variable "db_name" {
   type        = string
   description = "Database name"
-  default = "kubeflow"
+  default     = "kubeflow"
 }
 
 variable "db_username" {
   type        = string
   description = "Database admin account username"
-  default = "admin"
+  default     = "admin"
 }
 
 variable "db_password" {
   type        = string
   description = "Database admin account password"
-  default = null
+  default     = null
 }
 
 variable "db_class" {
   type        = string
   description = "Database instance type"
-  default = "db.m5.large"
+  default     = "db.m5.large"
 }
 
 variable "db_allocated_storage" {
   type        = string
   description = "The size of the database (Gb)"
-  default = "20"
+  default     = "20"
 }
 
 variable "mysql_engine_version" {
   type        = string
   description = "The engine version of MySQL"
-  default = "8.0.32"
+  default     = "8.0.32"
 }
 
 variable "backup_retention_period" {
   type        = number
   description = "Number of days to retain backups for"
-  default = 7
+  default     = 7
 }
 
 variable "storage_type" {
   type        = string
   description = "Instance storage type: standard, gp2, or io1"
-  default = "gp2"
+  default     = "gp2"
 }
 
 variable "deletion_protection" {
   type        = bool
   description = "Prevents the deletion of the instance when set to true"
-  default = true
+  default     = true
 }
 
 variable "max_allocated_storage" {
   type        = number
   description = "The upper limit of scalable storage (Gb)"
-  default = 1000
+  default     = 1000
 }
 
 variable "publicly_accessible" {
   type        = bool
   description = "Makes the instance publicly accessible when true"
-  default = false
+  default     = false
 }
 
 variable "multi_az" {
@@ -132,39 +132,39 @@ variable "multi_az" {
 
 variable "mlmdb_name" {
   type        = string
-  default = "metadb"
+  default     = "metadb"
   description = "Name of the mlm DB to create"
 }
 
 variable "generate_db_password" {
   description = "Generates a random admin password for the RDS database. Is overriden by db_password"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 # S3
 
 variable "minio_service_region" {
   type        = string
-  default = null
+  default     = null
   description = "S3 service region. Change this field if the S3 bucket will be in a different region than the EKS cluster"
 }
 
 variable "minio_service_host" {
   type        = string
-  default = "s3.amazonaws.com"
+  default     = "s3.amazonaws.com"
   description = "S3 service host DNS. This field will need to be changed when making requests from other partitions e.g. China Regions"
 }
 
 variable "secret_recovery_window_in_days" {
-  type = number
+  type    = number
   default = 7
 }
 
 variable "force_destroy_s3_bucket" {
-  type = bool
+  type        = bool
   description = "Destroys s3 bucket even when the bucket is not empty"
-  default = false
+  default     = false
 }
 
 variable "minio_aws_access_key_id" {
@@ -196,30 +196,30 @@ variable "aws_route53_subdomain_zone_name" {
 
 variable "create_subdomain" {
   description = "Creates a subdomain with the name provided in var.aws_route53_subdomain_zone_name"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "load_balancer_scheme" {
   description = "Load Balancer Scheme"
   type        = string
-  default = "internet-facing"
+  default     = "internet-facing"
 }
 
 variable "notebook_enable_culling" {
   description = "Enable Notebook culling feature. If set to true then the Notebook Controller will scale all Notebooks with Last activity older than the notebook_cull_idle_time to zero"
-  type = string
-  default = false
+  type        = string
+  default     = false
 }
 
 variable "notebook_cull_idle_time" {
   description = "If a Notebook's LAST_ACTIVITY_ANNOTATION from the current timestamp exceeds this value then the Notebook will be scaled to zero (culled). ENABLE_CULLING must be set to 'true' for this setting to take effect.(minutes)"
-  type = string
-  default = 30
+  type        = string
+  default     = 30
 }
 
 variable "notebook_idleness_check_period" {
   description = "How frequently the controller should poll each Notebook to update its LAST_ACTIVITY_ANNOTATION (minutes)"
-  type = string
-  default = 5
+  type        = string
+  default     = 5
 }

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -114,7 +114,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -129,7 +129,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
@@ -152,6 +152,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   secrets_store_csi_driver_helm_config = {
     namespace = "kube-system"
+    version = "1.3.2"
     set = [
       {
         name  = "syncSecret.enabled",

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name = var.cluster_name
   region       = var.cluster_region
-  eks_version = var.eks_version
+  eks_version  = var.eks_version
 
   vpc_cidr = "10.0.0.0/16"
 
@@ -17,9 +17,9 @@ locals {
   azs      = slice(local.available_azs, 0, local.az_count)
 
   tags = {
-    Blueprint  = local.cluster_name
-    GithubRepo = "github.com/awslabs/kubeflow-manifests"
-    Platform = "kubeflow-on-aws"
+    Blueprint       = local.cluster_name
+    GithubRepo      = "github.com/awslabs/kubeflow-manifests"
+    Platform        = "kubeflow-on-aws"
     KubeflowVersion = "1.6"
   }
 
@@ -50,7 +50,7 @@ locals {
     mg_gpu = local.managed_node_group_gpu
   }
 
-  managed_node_groups = { for k, v in local.potential_managed_node_groups : k => v if v != null}
+  managed_node_groups = { for k, v in local.potential_managed_node_groups : k => v if v != null }
 }
 
 provider "aws" {
@@ -61,7 +61,7 @@ provider "aws" {
 # https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html
 provider "aws" {
   region = "us-east-1"
-  alias = "virginia"
+  alias  = "virginia"
 }
 
 provider "kubernetes" {
@@ -137,24 +137,24 @@ module "eks_blueprints_kubernetes_addons" {
   eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni    = true
-  enable_amazon_eks_coredns    = true
-  enable_amazon_eks_kube_proxy = true
+  enable_amazon_eks_vpc_cni            = true
+  enable_amazon_eks_coredns            = true
+  enable_amazon_eks_kube_proxy         = true
   enable_amazon_eks_aws_ebs_csi_driver = true
 
   # EKS Blueprints Add-ons
-  enable_cert_manager = true
+  enable_cert_manager                 = true
   enable_aws_load_balancer_controller = true
-  enable_aws_efs_csi_driver = true
-  enable_aws_fsx_csi_driver = true
+  enable_aws_efs_csi_driver           = true
+  enable_aws_fsx_csi_driver           = true
 
   enable_nvidia_device_plugin = local.using_gpu
 
   secrets_store_csi_driver_helm_config = {
-    namespace   = "kube-system"
+    namespace = "kube-system"
     set = [
       {
-        name = "syncSecret.enabled",
+        name  = "syncSecret.enabled",
         value = "true"
       }
     ]
@@ -166,7 +166,7 @@ module "eks_blueprints_kubernetes_addons" {
     namespace = "kube-system"
     set = [
       {
-        name = "secrets-store-csi-driver.install",
+        name  = "secrets-store-csi-driver.install",
         value = "false"
       }
     ]
@@ -192,33 +192,33 @@ module "eks_blueprints_outputs" {
 module "kubeflow_components" {
   source = "./cognito-rds-s3-components"
 
-  kf_helm_repo_path = local.kf_helm_repo_path
-  addon_context = module.eks_blueprints_outputs.addon_context
-  enable_aws_telemetry = var.enable_aws_telemetry
-  notebook_enable_culling = var.notebook_enable_culling
-  notebook_cull_idle_time = var.notebook_cull_idle_time
+  kf_helm_repo_path              = local.kf_helm_repo_path
+  addon_context                  = module.eks_blueprints_outputs.addon_context
+  enable_aws_telemetry           = var.enable_aws_telemetry
+  notebook_enable_culling        = var.notebook_enable_culling
+  notebook_cull_idle_time        = var.notebook_cull_idle_time
   notebook_idleness_check_period = var.notebook_idleness_check_period
 
   # rds
-  use_rds = var.use_rds
-  vpc_id     = module.vpc.vpc_id
-  subnet_ids = var.publicly_accessible ? module.vpc.public_subnets : module.vpc.private_subnets
-  security_group_id = module.eks_blueprints.cluster_primary_security_group_id
-  db_name = var.db_name
-  db_username = var.db_username
-  db_password = var.db_password
-  db_class = var.db_class
-  mlmdb_name = var.mlmdb_name
-  db_allocated_storage = var.db_allocated_storage
-  mysql_engine_version = var.mysql_engine_version
-  backup_retention_period = var.backup_retention_period
-  storage_type = var.storage_type
-  deletion_protection = var.deletion_protection
-  max_allocated_storage = var.max_allocated_storage
-  publicly_accessible = var.publicly_accessible
-  multi_az = var.multi_az
+  use_rds                        = var.use_rds
+  vpc_id                         = module.vpc.vpc_id
+  subnet_ids                     = var.publicly_accessible ? module.vpc.public_subnets : module.vpc.private_subnets
+  security_group_id              = module.eks_blueprints.cluster_primary_security_group_id
+  db_name                        = var.db_name
+  db_username                    = var.db_username
+  db_password                    = var.db_password
+  db_class                       = var.db_class
+  mlmdb_name                     = var.mlmdb_name
+  db_allocated_storage           = var.db_allocated_storage
+  mysql_engine_version           = var.mysql_engine_version
+  backup_retention_period        = var.backup_retention_period
+  storage_type                   = var.storage_type
+  deletion_protection            = var.deletion_protection
+  max_allocated_storage          = var.max_allocated_storage
+  publicly_accessible            = var.publicly_accessible
+  multi_az                       = var.multi_az
   secret_recovery_window_in_days = var.secret_recovery_window_in_days
-  generate_db_password = var.generate_db_password
+  generate_db_password           = var.generate_db_password
 
   # s3
   use_s3 = var.use_s3
@@ -228,15 +228,15 @@ module "kubeflow_components" {
   minio_aws_secret_access_key = var.minio_aws_secret_access_key
 
   # cognito
-  use_cognito = var.use_cognito
-  aws_route53_root_zone_name = var.aws_route53_root_zone_name
+  use_cognito                     = var.use_cognito
+  aws_route53_root_zone_name      = var.aws_route53_root_zone_name
   aws_route53_subdomain_zone_name = var.aws_route53_subdomain_zone_name
-  create_subdomain = var.create_subdomain
-  cognito_user_pool_name = var.cognito_user_pool_name
-  load_balancer_scheme = var.load_balancer_scheme
+  create_subdomain                = var.create_subdomain
+  cognito_user_pool_name          = var.cognito_user_pool_name
+  load_balancer_scheme            = var.load_balancer_scheme
 
   providers = {
-    aws = aws
+    aws          = aws
     aws.virginia = aws.virginia
   }
 

--- a/deployments/cognito-rds-s3/terraform/outputs.tf
+++ b/deployments/cognito-rds-s3/terraform/outputs.tf
@@ -54,7 +54,7 @@ output "region" {
 }
 
 output "kubelow_platform_domain" {
-    value = module.kubeflow_components.kubelow_platform_domain
+  value = module.kubeflow_components.kubelow_platform_domain
 }
 
 output "rds_endpoint" {

--- a/deployments/cognito-rds-s3/terraform/variables.tf
+++ b/deployments/cognito-rds-s3/terraform/variables.tf
@@ -30,28 +30,28 @@ variable "node_instance_type_gpu" {
 variable "kf_helm_repo_path" {
   description = "Full path to the location of the helm repo for KF"
   type        = string
-  default = "../../.."
+  default     = "../../.."
 }
 
 variable "use_rds" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "use_s3" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "use_cognito" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "enable_aws_telemetry" {
   description = "Enable AWS telemetry component"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 # RDS
@@ -59,67 +59,67 @@ variable "enable_aws_telemetry" {
 variable "db_name" {
   type        = string
   description = "Database name"
-  default = "kubeflow"
+  default     = "kubeflow"
 }
 
 variable "db_username" {
   type        = string
   description = "Database admin account username"
-  default = "admin"
+  default     = "admin"
 }
 
 variable "db_password" {
   type        = string
   description = "Database admin account password"
-  default = null
+  default     = null
 }
 
 variable "db_class" {
   type        = string
   description = "Database instance type"
-  default = "db.m5.large"
+  default     = "db.m5.large"
 }
 
 variable "db_allocated_storage" {
   type        = string
   description = "The size of the database (Gb)"
-  default = "20"
+  default     = "20"
 }
 
 variable "mysql_engine_version" {
   type        = string
   description = "The engine version of MySQL"
-  default = "8.0.32"
+  default     = "8.0.32"
 }
 
 variable "backup_retention_period" {
   type        = number
   description = "Number of days to retain backups for"
-  default = 7
+  default     = 7
 }
 
 variable "storage_type" {
   type        = string
   description = "Instance storage type: standard, gp2, or io1"
-  default = "gp2"
+  default     = "gp2"
 }
 
 variable "deletion_protection" {
   type        = bool
   description = "Prevents the deletion of the instance when set to true"
-  default = true
+  default     = true
 }
 
 variable "max_allocated_storage" {
   type        = number
   description = "The upper limit of scalable storage (Gb)"
-  default = 1000
+  default     = 1000
 }
 
 variable "publicly_accessible" {
   type        = bool
   description = "Makes the instance publicly accessible when true"
-  default = false
+  default     = false
 }
 
 variable "multi_az" {
@@ -130,51 +130,51 @@ variable "multi_az" {
 
 variable "mlmdb_name" {
   type        = string
-  default = "metadb"
+  default     = "metadb"
   description = "Name of the mlm DB to create"
 }
 
 variable "generate_db_password" {
   description = "Generates a random admin password for the RDS database. Is overriden by db_password"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 # S3
 
 variable "minio_service_region" {
   type        = string
-  default = null
+  default     = null
   description = "S3 service region. Change this field if the S3 bucket will be in a different region than the EKS cluster"
 }
 
 variable "minio_service_host" {
   type        = string
-  default = "s3.amazonaws.com"
+  default     = "s3.amazonaws.com"
   description = "S3 service host DNS. This field will need to be changed when making requests from other partitions e.g. China Regions"
 }
 
 variable "secret_recovery_window_in_days" {
-  type = number
+  type    = number
   default = 7
 }
 
 variable "force_destroy_s3_bucket" {
-  type = bool
+  type        = bool
   description = "Destroys s3 bucket even when the bucket is not empty"
-  default = false
+  default     = false
 }
 
 variable "minio_aws_access_key_id" {
   type        = string
   description = "AWS access key ID to authenticate minio client"
-  default = null
+  default     = null
 }
 
 variable "minio_aws_secret_access_key" {
   type        = string
   description = "AWS secret access key to authenticate minio client"
-  default = null
+  default     = null
 }
 
 # Cognito
@@ -196,30 +196,30 @@ variable "aws_route53_subdomain_zone_name" {
 
 variable "create_subdomain" {
   description = "Creates a subdomain with the name provided in var.aws_route53_subdomain_zone_name"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "load_balancer_scheme" {
   description = "Load Balancer Scheme"
   type        = string
-  default = "internet-facing"
+  default     = "internet-facing"
 }
 
 variable "notebook_enable_culling" {
   description = "Enable Notebook culling feature. If set to true then the Notebook Controller will scale all Notebooks with Last activity older than the notebook_cull_idle_time to zero"
-  type = string
-  default = false
+  type        = string
+  default     = false
 }
 
 variable "notebook_cull_idle_time" {
   description = "If a Notebook's LAST_ACTIVITY_ANNOTATION from the current timestamp exceeds this value then the Notebook will be scaled to zero (culled). ENABLE_CULLING must be set to 'true' for this setting to take effect.(minutes)"
-  type = string
-  default = 30
+  type        = string
+  default     = 30
 }
 
 variable "notebook_idleness_check_period" {
   description = "How frequently the controller should poll each Notebook to update its LAST_ACTIVITY_ANNOTATION (minutes)"
-  type = string
-  default = 5
+  type        = string
+  default     = 5
 }

--- a/deployments/cognito/terraform/cognito-components/main.tf
+++ b/deployments/cognito/terraform/cognito-components/main.tf
@@ -9,7 +9,7 @@ provider "aws" {
 resource "kubernetes_namespace" "kubeflow" {
   metadata {
     labels = {
-      control-plane = "kubeflow"
+      control-plane   = "kubeflow"
       istio-injection = "enabled"
     }
 
@@ -18,19 +18,19 @@ resource "kubernetes_namespace" "kubeflow" {
 }
 
 module "subdomain" {
-  count = var.create_subdomain ? 1 : 0
-  source            = "../../../../iaac/terraform/aws-infra/subdomain"
-  aws_route53_root_zone_name = var.aws_route53_root_zone_name
+  count                           = var.create_subdomain ? 1 : 0
+  source                          = "../../../../iaac/terraform/aws-infra/subdomain"
+  aws_route53_root_zone_name      = var.aws_route53_root_zone_name
   aws_route53_subdomain_zone_name = var.aws_route53_subdomain_zone_name
 }
 
 module "cognito" {
-  source            = "../../../../iaac/terraform/aws-infra/cognito"
-  cognito_user_pool_name = var.cognito_user_pool_name
+  source                          = "../../../../iaac/terraform/aws-infra/cognito"
+  cognito_user_pool_name          = var.cognito_user_pool_name
   aws_route53_subdomain_zone_name = var.aws_route53_subdomain_zone_name
 
   providers = {
-    aws = aws
+    aws          = aws
     aws.virginia = aws.virginia
   }
 
@@ -38,247 +38,247 @@ module "cognito" {
 }
 
 module "kubeflow_issuer" {
-  source            = "../../../../iaac/terraform/common/kubeflow-issuer"
+  source = "../../../../iaac/terraform/common/kubeflow-issuer"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/kubeflow-issuer"
   }
 
   addon_context = var.addon_context
-  depends_on = [kubernetes_namespace.kubeflow]
+  depends_on    = [kubernetes_namespace.kubeflow]
 }
 
 module "kubeflow_istio" {
-  source            = "../../../../iaac/terraform/common/istio"
+  source = "../../../../iaac/terraform/common/istio"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/istio-1-14"
   }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_issuer]
+  depends_on    = [module.kubeflow_issuer]
 }
 
 module "ingress_cognito" {
-  source            = "../../../../iaac/terraform/common/ingress/cognito"
+  source                          = "../../../../iaac/terraform/common/ingress/cognito"
   aws_route53_subdomain_zone_name = var.aws_route53_subdomain_zone_name
-  cluster_name = var.addon_context.eks_cluster_id
-  cognito_user_pool_arn = module.cognito.user_pool_arn
-  cognito_app_client_id = module.cognito.app_client_id
-  cognito_user_pool_domain = module.cognito.user_pool_domain
-  load_balancer_scheme = var.load_balancer_scheme
+  cluster_name                    = var.addon_context.eks_cluster_id
+  cognito_user_pool_arn           = module.cognito.user_pool_arn
+  cognito_app_client_id           = module.cognito.app_client_id
+  cognito_user_pool_domain        = module.cognito.user_pool_domain
+  load_balancer_scheme            = var.load_balancer_scheme
 
   depends_on = [module.kubeflow_istio, module.cognito]
 }
 
 module "kubeflow_aws_authservice" {
-  source            = "../../../../iaac/terraform/common/aws-authservice"
+  source = "../../../../iaac/terraform/common/aws-authservice"
   helm_config = {
-    chart = "${var.kf_helm_repo_path}/charts/common/aws-authservice" 
+    chart = "${var.kf_helm_repo_path}/charts/common/aws-authservice"
     set = [
       {
-        name = "LOGOUT_URL"
+        name  = "LOGOUT_URL"
         value = module.cognito.logout_url
       }
     ]
   }
   addon_context = var.addon_context
-  depends_on = [module.ingress_cognito]
+  depends_on    = [module.ingress_cognito]
 }
 
 module "kubeflow_knative_serving" {
-  source            = "../../../../iaac/terraform/common/knative-serving"
+  source = "../../../../iaac/terraform/common/knative-serving"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/knative-serving"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_aws_authservice]
+  depends_on    = [module.kubeflow_aws_authservice]
 }
 
 module "kubeflow_cluster_local_gateway" {
-  source            = "../../../../iaac/terraform/common/cluster-local-gateway"
+  source = "../../../../iaac/terraform/common/cluster-local-gateway"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/cluster-local-gateway"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_knative_serving]
+  depends_on    = [module.kubeflow_knative_serving]
 }
 
 module "kubeflow_knative_eventing" {
-  source            = "../../../../iaac/terraform/common/knative-eventing"
+  source = "../../../../iaac/terraform/common/knative-eventing"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/knative-eventing"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_cluster_local_gateway]
+  depends_on    = [module.kubeflow_cluster_local_gateway]
 }
 
 module "kubeflow_roles" {
-  source            = "../../../../iaac/terraform/common/kubeflow-roles"
+  source = "../../../../iaac/terraform/common/kubeflow-roles"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/kubeflow-roles"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_knative_eventing]
+  depends_on    = [module.kubeflow_knative_eventing]
 }
 
 module "kubeflow_istio_resources" {
-  source            = "../../../../iaac/terraform/common/kubeflow-istio-resources"
+  source = "../../../../iaac/terraform/common/kubeflow-istio-resources"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/kubeflow-istio-resources"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_roles]
+  depends_on    = [module.kubeflow_roles]
 }
 
 module "kubeflow_pipelines" {
-  source            = "../../../../iaac/terraform/apps/kubeflow-pipelines"
+  source = "../../../../iaac/terraform/apps/kubeflow-pipelines"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/kubeflow-pipelines/vanilla"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_istio_resources]
+  depends_on    = [module.kubeflow_istio_resources]
 }
 
 module "kubeflow_kserve" {
-  source            = "../../../../iaac/terraform/common/kserve"
+  source = "../../../../iaac/terraform/common/kserve"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/kserve"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_pipelines]
+  depends_on    = [module.kubeflow_pipelines]
 }
 
 module "kubeflow_models_web_app" {
-  source            = "../../../../iaac/terraform/apps/models-web-app"
+  source = "../../../../iaac/terraform/apps/models-web-app"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/models-web-app"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_kserve]
+  depends_on    = [module.kubeflow_kserve]
 }
 
 module "kubeflow_katib" {
-  source            = "../../../../iaac/terraform/apps/katib"
+  source = "../../../../iaac/terraform/apps/katib"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/katib/vanilla"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_models_web_app]
+  depends_on    = [module.kubeflow_models_web_app]
 }
 
 module "kubeflow_central_dashboard" {
-  source            = "../../../../iaac/terraform/apps/central-dashboard"
+  source = "../../../../iaac/terraform/apps/central-dashboard"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/central-dashboard"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_katib]
+  depends_on    = [module.kubeflow_katib]
 }
 
 module "kubeflow_admission_webhook" {
-  source            = "../../../../iaac/terraform/apps/admission-webhook"
+  source = "../../../../iaac/terraform/apps/admission-webhook"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/admission-webhook"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_central_dashboard]
+  depends_on    = [module.kubeflow_central_dashboard]
 }
 
 module "kubeflow_notebook_controller" {
-  source            = "../../../../iaac/terraform/apps/notebook-controller"
+  source = "../../../../iaac/terraform/apps/notebook-controller"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/notebook-controller"
     set = [
       {
-        name = "cullingPolicy.cullIdleTime",
+        name  = "cullingPolicy.cullIdleTime",
         value = var.notebook_cull_idle_time
       },
       {
-        name = "cullingPolicy.enableCulling",
+        name  = "cullingPolicy.enableCulling",
         value = var.notebook_enable_culling
       },
       {
-        name = "cullingPolicy.idlenessCheckPeriod",
-        value= var.notebook_idleness_check_period
+        name  = "cullingPolicy.idlenessCheckPeriod",
+        value = var.notebook_idleness_check_period
       }
     ]
   }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_admission_webhook]
+  depends_on    = [module.kubeflow_admission_webhook]
 }
 
 module "kubeflow_jupyter_web_app" {
-  source            = "../../../../iaac/terraform/apps/jupyter-web-app"
+  source = "../../../../iaac/terraform/apps/jupyter-web-app"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/jupyter-web-app"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_notebook_controller]
+  depends_on    = [module.kubeflow_notebook_controller]
 }
 
 module "kubeflow_profiles_and_kfam" {
-  source            = "../../../../iaac/terraform/apps/profiles-and-kfam"
+  source = "../../../../iaac/terraform/apps/profiles-and-kfam"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/profiles-and-kfam"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_jupyter_web_app]
+  depends_on    = [module.kubeflow_jupyter_web_app]
 }
 
 module "kubeflow_volumes_web_app" {
-  source            = "../../../../iaac/terraform/apps/volumes-web-app"
+  source = "../../../../iaac/terraform/apps/volumes-web-app"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/volumes-web-app"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_profiles_and_kfam]
+  depends_on    = [module.kubeflow_profiles_and_kfam]
 }
 
 module "kubeflow_tensorboards_web_app" {
-  source            = "../../../../iaac/terraform/apps/tensorboards-web-app"
+  source = "../../../../iaac/terraform/apps/tensorboards-web-app"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/tensorboards-web-app"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_volumes_web_app]
+  depends_on    = [module.kubeflow_volumes_web_app]
 }
 
 module "kubeflow_tensorboard_controller" {
-  source            = "../../../../iaac/terraform/apps/tensorboard-controller"
+  source = "../../../../iaac/terraform/apps/tensorboard-controller"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/tensorboard-controller"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_tensorboards_web_app]
+  depends_on    = [module.kubeflow_tensorboards_web_app]
 }
 
 module "kubeflow_training_operator" {
-  source            = "../../../../iaac/terraform/apps/training-operator"
+  source = "../../../../iaac/terraform/apps/training-operator"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/training-operator"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_tensorboard_controller]
+  depends_on    = [module.kubeflow_tensorboard_controller]
 }
 
 module "kubeflow_aws_telemetry" {
-  count = var.enable_aws_telemetry ? 1 : 0
-  source            = "../../../../iaac/terraform/common/aws-telemetry"
+  count  = var.enable_aws_telemetry ? 1 : 0
+  source = "../../../../iaac/terraform/common/aws-telemetry"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/aws-telemetry"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_training_operator]
+  depends_on    = [module.kubeflow_training_operator]
 }
 
 module "kubeflow_user_namespace" {
-  source            = "../../../../iaac/terraform/common/user-namespace"
+  source = "../../../../iaac/terraform/common/user-namespace"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/user-namespace"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_aws_telemetry]
+  depends_on    = [module.kubeflow_aws_telemetry]
 }
 
 module "ack_sagemaker" {
-  source            = "../../../../iaac/terraform/common/ack-sagemaker-controller"
+  source        = "../../../../iaac/terraform/common/ack-sagemaker-controller"
   addon_context = var.addon_context
 }

--- a/deployments/cognito/terraform/cognito-components/outputs.tf
+++ b/deployments/cognito/terraform/cognito-components/outputs.tf
@@ -1,3 +1,3 @@
 output "kubelow_platform_domain" {
-    value = module.ingress_cognito.kubelow_platform_domain
+  value = module.ingress_cognito.kubelow_platform_domain
 }

--- a/deployments/cognito/terraform/cognito-components/variables.tf
+++ b/deployments/cognito/terraform/cognito-components/variables.tf
@@ -37,36 +37,36 @@ variable "aws_route53_subdomain_zone_name" {
 
 variable "create_subdomain" {
   description = "Creates a subdomain with the name provided in var.aws_route53_subdomain_zone_name"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "load_balancer_scheme" {
   description = "Load Balancer Scheme"
   type        = string
-  default = "internet-facing"
+  default     = "internet-facing"
 }
 
 variable "enable_aws_telemetry" {
   description = "Enable AWS telemetry component"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "notebook_enable_culling" {
   description = "Enable Notebook culling feature. If set to true then the Notebook Controller will scale all Notebooks with Last activity older than the notebook_cull_idle_time to zero"
-  type = string
-  default = false
+  type        = string
+  default     = false
 }
 
 variable "notebook_cull_idle_time" {
   description = "If a Notebook's LAST_ACTIVITY_ANNOTATION from the current timestamp exceeds this value then the Notebook will be scaled to zero (culled). ENABLE_CULLING must be set to 'true' for this setting to take effect.(minutes)"
-  type = string
-  default = 30
+  type        = string
+  default     = 30
 }
 
 variable "notebook_idleness_check_period" {
   description = "How frequently the controller should poll each Notebook to update its LAST_ACTIVITY_ANNOTATION (minutes)"
-  type = string
-  default = 5
+  type        = string
+  default     = 5
 }

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -115,7 +115,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -130,7 +130,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name = var.cluster_name
   region       = var.cluster_region
-  eks_version = var.eks_version
+  eks_version  = var.eks_version
 
   vpc_cidr = "10.0.0.0/16"
 
@@ -17,9 +17,9 @@ locals {
   azs      = slice(local.available_azs, 0, local.az_count)
 
   tags = {
-    Blueprint  = local.cluster_name
-    GithubRepo = "github.com/awslabs/kubeflow-manifests"
-    Platform = "kubeflow-on-aws"
+    Blueprint       = local.cluster_name
+    GithubRepo      = "github.com/awslabs/kubeflow-manifests"
+    Platform        = "kubeflow-on-aws"
     KubeflowVersion = "1.6"
   }
 
@@ -50,7 +50,7 @@ locals {
     mg_gpu = local.managed_node_group_gpu
   }
 
-  managed_node_groups = { for k, v in local.potential_managed_node_groups : k => v if v != null}
+  managed_node_groups = { for k, v in local.potential_managed_node_groups : k => v if v != null }
 }
 
 provider "aws" {
@@ -61,7 +61,7 @@ provider "aws" {
 # https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html
 provider "aws" {
   region = "us-east-1"
-  alias = "virginia"
+  alias  = "virginia"
 }
 
 
@@ -138,16 +138,16 @@ module "eks_blueprints_kubernetes_addons" {
   eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni    = true
-  enable_amazon_eks_coredns    = true
-  enable_amazon_eks_kube_proxy = true
+  enable_amazon_eks_vpc_cni            = true
+  enable_amazon_eks_coredns            = true
+  enable_amazon_eks_kube_proxy         = true
   enable_amazon_eks_aws_ebs_csi_driver = true
 
   # EKS Blueprints Add-ons
-  enable_cert_manager = true
+  enable_cert_manager                 = true
   enable_aws_load_balancer_controller = true
-  enable_aws_efs_csi_driver = true
-  enable_aws_fsx_csi_driver = true
+  enable_aws_efs_csi_driver           = true
+  enable_aws_fsx_csi_driver           = true
 
   enable_nvidia_device_plugin = local.using_gpu
 
@@ -170,22 +170,22 @@ module "eks_blueprints_outputs" {
 module "kubeflow_components" {
   source = "./cognito-components"
 
-  kf_helm_repo_path = local.kf_helm_repo_path
-  addon_context = module.eks_blueprints_outputs.addon_context
+  kf_helm_repo_path    = local.kf_helm_repo_path
+  addon_context        = module.eks_blueprints_outputs.addon_context
   enable_aws_telemetry = var.enable_aws_telemetry
 
-  notebook_enable_culling = var.notebook_enable_culling
-  notebook_cull_idle_time = var.notebook_cull_idle_time
+  notebook_enable_culling        = var.notebook_enable_culling
+  notebook_cull_idle_time        = var.notebook_cull_idle_time
   notebook_idleness_check_period = var.notebook_idleness_check_period
 
-  aws_route53_root_zone_name = var.aws_route53_root_zone_name
+  aws_route53_root_zone_name      = var.aws_route53_root_zone_name
   aws_route53_subdomain_zone_name = var.aws_route53_subdomain_zone_name
-  create_subdomain = var.create_subdomain
-  cognito_user_pool_name = var.cognito_user_pool_name
-  load_balancer_scheme = var.load_balancer_scheme
+  create_subdomain                = var.create_subdomain
+  cognito_user_pool_name          = var.cognito_user_pool_name
+  load_balancer_scheme            = var.load_balancer_scheme
 
   providers = {
-    aws = aws
+    aws          = aws
     aws.virginia = aws.virginia
   }
 

--- a/deployments/cognito/terraform/outputs.tf
+++ b/deployments/cognito/terraform/outputs.tf
@@ -54,5 +54,5 @@ output "region" {
 }
 
 output "kubelow_platform_domain" {
-    value = module.kubeflow_components.kubelow_platform_domain
+  value = module.kubeflow_components.kubelow_platform_domain
 }

--- a/deployments/cognito/terraform/variables.tf
+++ b/deployments/cognito/terraform/variables.tf
@@ -44,42 +44,42 @@ variable "aws_route53_subdomain_zone_name" {
 
 variable "create_subdomain" {
   description = "Creates a subdomain with the name provided in var.aws_route53_subdomain_zone_name"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "load_balancer_scheme" {
   description = "Load Balancer Scheme"
   type        = string
-  default = "internet-facing"
+  default     = "internet-facing"
 }
 
 variable "enable_aws_telemetry" {
   description = "Enable AWS telemetry component"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "kf_helm_repo_path" {
   description = "Full path to the location of the helm repo for KF"
   type        = string
-  default = "../../.."
+  default     = "../../.."
 }
 
 variable "notebook_enable_culling" {
   description = "Enable Notebook culling feature. If set to true then the Notebook Controller will scale all Notebooks with Last activity older than the notebook_cull_idle_time to zero"
-  type = string
-  default = false
+  type        = string
+  default     = false
 }
 
 variable "notebook_cull_idle_time" {
   description = "If a Notebook's LAST_ACTIVITY_ANNOTATION from the current timestamp exceeds this value then the Notebook will be scaled to zero (culled). ENABLE_CULLING must be set to 'true' for this setting to take effect.(minutes)"
-  type = string
-  default = 30
+  type        = string
+  default     = 30
 }
 
 variable "notebook_idleness_check_period" {
   description = "How frequently the controller should poll each Notebook to update its LAST_ACTIVITY_ANNOTATION (minutes)"
-  type = string
-  default = 5
+  type        = string
+  default     = 5
 }

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -107,7 +107,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -122,7 +122,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
@@ -145,6 +145,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   secrets_store_csi_driver_helm_config = {
     namespace = "kube-system"
+    version = "1.3.2"
     set = [
       {
         name  = "syncSecret.enabled",

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name = var.cluster_name
   region       = var.cluster_region
-  eks_version = var.eks_version
+  eks_version  = var.eks_version
 
   vpc_cidr = "10.0.0.0/16"
 
@@ -17,9 +17,9 @@ locals {
   azs      = slice(local.available_azs, 0, local.az_count)
 
   tags = {
-    Blueprint  = local.cluster_name
-    GithubRepo = "github.com/awslabs/kubeflow-manifests"
-    Platform = "kubeflow-on-aws"
+    Blueprint       = local.cluster_name
+    GithubRepo      = "github.com/awslabs/kubeflow-manifests"
+    Platform        = "kubeflow-on-aws"
     KubeflowVersion = "1.6"
   }
 
@@ -50,7 +50,7 @@ locals {
     mg_gpu = local.managed_node_group_gpu
   }
 
-  managed_node_groups = { for k, v in local.potential_managed_node_groups : k => v if v != null}
+  managed_node_groups = { for k, v in local.potential_managed_node_groups : k => v if v != null }
 }
 
 provider "aws" {
@@ -130,24 +130,24 @@ module "eks_blueprints_kubernetes_addons" {
   eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni    = true
-  enable_amazon_eks_coredns    = true
-  enable_amazon_eks_kube_proxy = true
+  enable_amazon_eks_vpc_cni            = true
+  enable_amazon_eks_coredns            = true
+  enable_amazon_eks_kube_proxy         = true
   enable_amazon_eks_aws_ebs_csi_driver = true
 
   # EKS Blueprints Add-ons
-  enable_cert_manager = true
+  enable_cert_manager                 = true
   enable_aws_load_balancer_controller = true
-  enable_aws_efs_csi_driver = true
-  enable_aws_fsx_csi_driver = true
+  enable_aws_efs_csi_driver           = true
+  enable_aws_fsx_csi_driver           = true
 
   enable_nvidia_device_plugin = local.using_gpu
 
   secrets_store_csi_driver_helm_config = {
-    namespace   = "kube-system"
+    namespace = "kube-system"
     set = [
       {
-        name = "syncSecret.enabled",
+        name  = "syncSecret.enabled",
         value = "true"
       }
     ]
@@ -159,7 +159,7 @@ module "eks_blueprints_kubernetes_addons" {
     namespace = "kube-system"
     set = [
       {
-        name = "secrets-store-csi-driver.install",
+        name  = "secrets-store-csi-driver.install",
         value = "false"
       }
     ]
@@ -185,39 +185,39 @@ module "eks_blueprints_outputs" {
 module "kubeflow_components" {
   source = "./rds-s3-components"
 
-  kf_helm_repo_path = local.kf_helm_repo_path
-  addon_context = module.eks_blueprints_outputs.addon_context
+  kf_helm_repo_path    = local.kf_helm_repo_path
+  addon_context        = module.eks_blueprints_outputs.addon_context
   enable_aws_telemetry = var.enable_aws_telemetry
 
-  notebook_enable_culling = var.notebook_enable_culling
-  notebook_cull_idle_time = var.notebook_cull_idle_time
+  notebook_enable_culling        = var.notebook_enable_culling
+  notebook_cull_idle_time        = var.notebook_cull_idle_time
   notebook_idleness_check_period = var.notebook_idleness_check_period
   
   use_rds = var.use_rds
   use_s3 = var.use_s3
 
-  vpc_id     = module.vpc.vpc_id
-  subnet_ids = var.publicly_accessible ? module.vpc.public_subnets : module.vpc.private_subnets
-  security_group_id = module.eks_blueprints.cluster_primary_security_group_id
-  db_name = var.db_name
-  db_username = var.db_username
-  db_password = var.db_password
-  db_class = var.db_class
-  mlmdb_name = var.mlmdb_name
-  db_allocated_storage = var.db_allocated_storage
-  mysql_engine_version = var.mysql_engine_version
-  backup_retention_period = var.backup_retention_period
-  storage_type = var.storage_type
-  deletion_protection = var.deletion_protection
-  max_allocated_storage = var.max_allocated_storage
-  publicly_accessible = var.publicly_accessible
-  multi_az = var.multi_az
+  vpc_id                         = module.vpc.vpc_id
+  subnet_ids                     = var.publicly_accessible ? module.vpc.public_subnets : module.vpc.private_subnets
+  security_group_id              = module.eks_blueprints.cluster_primary_security_group_id
+  db_name                        = var.db_name
+  db_username                    = var.db_username
+  db_password                    = var.db_password
+  db_class                       = var.db_class
+  mlmdb_name                     = var.mlmdb_name
+  db_allocated_storage           = var.db_allocated_storage
+  mysql_engine_version           = var.mysql_engine_version
+  backup_retention_period        = var.backup_retention_period
+  storage_type                   = var.storage_type
+  deletion_protection            = var.deletion_protection
+  max_allocated_storage          = var.max_allocated_storage
+  publicly_accessible            = var.publicly_accessible
+  multi_az                       = var.multi_az
   secret_recovery_window_in_days = var.secret_recovery_window_in_days
-  generate_db_password = var.generate_db_password
+  generate_db_password           = var.generate_db_password
 
-  minio_service_region = var.minio_service_region
-  force_destroy_s3_bucket = var.force_destroy_s3_bucket
-  minio_aws_access_key_id = var.minio_aws_access_key_id
+  minio_service_region        = var.minio_service_region
+  force_destroy_s3_bucket     = var.force_destroy_s3_bucket
+  minio_aws_access_key_id     = var.minio_aws_access_key_id
   minio_aws_secret_access_key = var.minio_aws_secret_access_key
 
 }

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -41,7 +41,7 @@ resource "kubernetes_namespace" "kubeflow" {
 }
 
 module "kubeflow_secrets_manager_irsa" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace = false
   create_kubernetes_service_account = true

--- a/deployments/rds-s3/terraform/rds-s3-components/variables.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/variables.tf
@@ -22,17 +22,17 @@ variable "addon_context" {
 
 variable "enable_aws_telemetry" {
   description = "Enable AWS telemetry component"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "use_rds" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "use_s3" {
-  type = bool
+  type    = bool
   default = true
 }
 
@@ -54,67 +54,67 @@ variable "security_group_id" {
 variable "db_name" {
   type        = string
   description = "Database name"
-  default = "kubeflow"
+  default     = "kubeflow"
 }
 
 variable "db_username" {
   type        = string
   description = "Database admin account username"
-  default = "admin"
+  default     = "admin"
 }
 
 variable "db_password" {
   type        = string
   description = "Database admin account password"
-  default = null
+  default     = null
 }
 
 variable "db_class" {
   type        = string
   description = "Database instance type"
-  default = "db.m5.large"
+  default     = "db.m5.large"
 }
 
 variable "db_allocated_storage" {
   type        = string
   description = "The size of the database (Gb)"
-  default = "20"
+  default     = "20"
 }
 
 variable "mysql_engine_version" {
   type        = string
   description = "The engine version of MySQL"
-  default = "8.0.32"
+  default     = "8.0.32"
 }
 
 variable "backup_retention_period" {
   type        = number
   description = "Number of days to retain backups for"
-  default = 7
+  default     = 7
 }
 
 variable "storage_type" {
   type        = string
   description = "Instance storage type: standard, gp2, or io1"
-  default = "gp2"
+  default     = "gp2"
 }
 
 variable "deletion_protection" {
   type        = bool
   description = "Prevents the deletion of the instance when set to true"
-  default = true
+  default     = true
 }
 
 variable "max_allocated_storage" {
   type        = number
   description = "The upper limit of scalable storage (Gb)"
-  default = 1000
+  default     = 1000
 }
 
 variable "publicly_accessible" {
   type        = bool
   description = "Makes the instance publicly accessible when true"
-  default = false
+  default     = false
 }
 
 variable "multi_az" {
@@ -125,37 +125,37 @@ variable "multi_az" {
 
 variable "mlmdb_name" {
   type        = string
-  default = "metadb"
+  default     = "metadb"
   description = "Name of the mlm DB to create"
 }
 
 variable "minio_service_region" {
   type        = string
-  default = null
+  default     = null
   description = "S3 service region. Change this field if the S3 bucket will be in a different region than the EKS cluster"
 }
 
 variable "minio_service_host" {
   type        = string
-  default = "s3.amazonaws.com"
+  default     = "s3.amazonaws.com"
   description = "S3 service host DNS. This field will need to be changed when making requests from other partitions e.g. China Regions"
 }
 
 variable "secret_recovery_window_in_days" {
-  type = number
+  type    = number
   default = 7
 }
 
 variable "generate_db_password" {
   description = "Generates a random admin password for the RDS database. Is overriden by db_password"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "force_destroy_s3_bucket" {
-  type = bool
+  type        = bool
   description = "Destroys s3 bucket even when the bucket is not empty"
-  default = false
+  default     = false
 }
 
 variable "minio_aws_access_key_id" {
@@ -170,18 +170,18 @@ variable "minio_aws_secret_access_key" {
 
 variable "notebook_enable_culling" {
   description = "Enable Notebook culling feature. If set to true then the Notebook Controller will scale all Notebooks with Last activity older than the notebook_cull_idle_time to zero"
-  type = string
-  default = false
+  type        = string
+  default     = false
 }
 
 variable "notebook_cull_idle_time" {
   description = "If a Notebook's LAST_ACTIVITY_ANNOTATION from the current timestamp exceeds this value then the Notebook will be scaled to zero (culled). ENABLE_CULLING must be set to 'true' for this setting to take effect.(minutes)"
-  type = string
-  default = 30
+  type        = string
+  default     = 30
 }
 
 variable "notebook_idleness_check_period" {
   description = "How frequently the controller should poll each Notebook to update its LAST_ACTIVITY_ANNOTATION (minutes)"
-  type = string
-  default = 5
+  type        = string
+  default     = 5
 }

--- a/deployments/rds-s3/terraform/variables.tf
+++ b/deployments/rds-s3/terraform/variables.tf
@@ -28,85 +28,85 @@ variable "node_instance_type_gpu" {
 }
 
 variable "use_rds" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "use_s3" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "enable_aws_telemetry" {
   description = "Enable AWS telemetry component"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "db_name" {
   type        = string
   description = "Database name"
-  default = "kubeflow"
+  default     = "kubeflow"
 }
 
 variable "db_username" {
   type        = string
   description = "Database admin account username"
-  default = "admin"
+  default     = "admin"
 }
 
 variable "db_password" {
   type        = string
   description = "Database admin account password"
-  default = null
+  default     = null
 }
 
 variable "db_class" {
   type        = string
   description = "Database instance type"
-  default = "db.m5.large"
+  default     = "db.m5.large"
 }
 
 variable "db_allocated_storage" {
   type        = string
   description = "The size of the database (Gb)"
-  default = "20"
+  default     = "20"
 }
 
 variable "mysql_engine_version" {
   type        = string
   description = "The engine version of MySQL"
-  default = "8.0.32"
+  default     = "8.0.32"
 }
 
 variable "backup_retention_period" {
   type        = number
   description = "Number of days to retain backups for"
-  default = 7
+  default     = 7
 }
 
 variable "storage_type" {
   type        = string
   description = "Instance storage type: standard, gp2, or io1"
-  default = "gp2"
+  default     = "gp2"
 }
 
 variable "deletion_protection" {
   type        = bool
   description = "Prevents the deletion of the instance when set to true"
-  default = true
+  default     = true
 }
 
 variable "max_allocated_storage" {
   type        = number
   description = "The upper limit of scalable storage (Gb)"
-  default = 1000
+  default     = 1000
 }
 
 variable "publicly_accessible" {
   type        = bool
   description = "Makes the instance publicly accessible when true"
-  default = false
+  default     = false
 }
 
 variable "multi_az" {
@@ -117,71 +117,71 @@ variable "multi_az" {
 
 variable "mlmdb_name" {
   type        = string
-  default = "metadb"
+  default     = "metadb"
   description = "Name of the mlm DB to create"
 }
 
 variable "minio_service_region" {
   type        = string
-  default = null
+  default     = null
   description = "S3 service region. Change this field if the S3 bucket will be in a different region than the EKS cluster"
 }
 
 variable "minio_service_host" {
   type        = string
-  default = "s3.amazonaws.com"
+  default     = "s3.amazonaws.com"
   description = "S3 service host DNS. This field will need to be changed when making requests from other partitions e.g. China Regions"
 }
 
 variable "secret_recovery_window_in_days" {
-  type = number
+  type    = number
   default = 7
 }
 
 variable "generate_db_password" {
   description = "Generates a random admin password for the RDS database. Is overriden by db_password"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "force_destroy_s3_bucket" {
-  type = bool
+  type        = bool
   description = "Destroys s3 bucket even when the bucket is not empty"
-  default = false
+  default     = false
 }
 
 variable "minio_aws_access_key_id" {
   type        = string
   description = "AWS access key ID to authenticate minio client"
-  default = null
+  default     = null
 }
 
 variable "minio_aws_secret_access_key" {
   type        = string
   description = "AWS secret access key to authenticate minio client"
-  default = null
+  default     = null
 }
 
 variable "kf_helm_repo_path" {
   description = "Full path to the location of the helm repo for KF"
   type        = string
-  default = "../../.."
+  default     = "../../.."
 }
 
 variable "notebook_enable_culling" {
   description = "Enable Notebook culling feature. If set to true then the Notebook Controller will scale all Notebooks with Last activity older than the notebook_cull_idle_time to zero"
-  type = string
-  default = false
+  type        = string
+  default     = false
 }
 
 variable "notebook_cull_idle_time" {
   description = "If a Notebook's LAST_ACTIVITY_ANNOTATION from the current timestamp exceeds this value then the Notebook will be scaled to zero (culled). ENABLE_CULLING must be set to 'true' for this setting to take effect.(minutes)"
-  type = string
-  default = 30
+  type        = string
+  default     = 30
 }
 
 variable "notebook_idleness_check_period" {
   description = "How frequently the controller should poll each Notebook to update its LAST_ACTIVITY_ANNOTATION (minutes)"
-  type = string
-  default = 5
+  type        = string
+  default     = 5
 }

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name = var.cluster_name
   region       = var.cluster_region
-  eks_version = var.eks_version
+  eks_version  = var.eks_version
 
   vpc_cidr = "10.0.0.0/16"
 
@@ -17,9 +17,9 @@ locals {
   azs      = slice(local.available_azs, 0, local.az_count)
 
   tags = {
-    Blueprint  = local.cluster_name
-    GithubRepo = "github.com/awslabs/kubeflow-manifests"
-    Platform = "kubeflow-on-aws"
+    Blueprint       = local.cluster_name
+    GithubRepo      = "github.com/awslabs/kubeflow-manifests"
+    Platform        = "kubeflow-on-aws"
     KubeflowVersion = "1.6"
   }
 
@@ -50,7 +50,7 @@ locals {
     mg_gpu = local.managed_node_group_gpu
   }
 
-  managed_node_groups = { for k, v in local.potential_managed_node_groups : k => v if v != null}
+  managed_node_groups = { for k, v in local.potential_managed_node_groups : k => v if v != null }
 }
 
 provider "aws" {
@@ -117,7 +117,7 @@ module "eks_blueprints" {
 
   # configuration settings: https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/modules/aws-eks-managed-node-groups/locals.tf
   managed_node_groups = local.managed_node_groups
-  tags = local.tags
+  tags                = local.tags
 }
 
 module "eks_blueprints_kubernetes_addons" {
@@ -129,16 +129,16 @@ module "eks_blueprints_kubernetes_addons" {
   eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni    = true
-  enable_amazon_eks_coredns    = true
-  enable_amazon_eks_kube_proxy = true
+  enable_amazon_eks_vpc_cni            = true
+  enable_amazon_eks_coredns            = true
+  enable_amazon_eks_kube_proxy         = true
   enable_amazon_eks_aws_ebs_csi_driver = true
 
   # EKS Blueprints Add-ons
-  enable_cert_manager = true
+  enable_cert_manager                 = true
   enable_aws_load_balancer_controller = true
-  enable_aws_efs_csi_driver = true
-  enable_aws_fsx_csi_driver = true
+  enable_aws_efs_csi_driver           = true
+  enable_aws_fsx_csi_driver           = true
 
   enable_nvidia_device_plugin = local.using_gpu
 
@@ -161,11 +161,11 @@ module "eks_blueprints_outputs" {
 module "kubeflow_components" {
   source = "./vanilla-components"
 
-  kf_helm_repo_path = local.kf_helm_repo_path
-  addon_context = module.eks_blueprints_outputs.addon_context
-  enable_aws_telemetry = var.enable_aws_telemetry
-  notebook_enable_culling = var.notebook_enable_culling
-  notebook_cull_idle_time = var.notebook_cull_idle_time
+  kf_helm_repo_path              = local.kf_helm_repo_path
+  addon_context                  = module.eks_blueprints_outputs.addon_context
+  enable_aws_telemetry           = var.enable_aws_telemetry
+  notebook_enable_culling        = var.notebook_enable_culling
+  notebook_cull_idle_time        = var.notebook_cull_idle_time
   notebook_idleness_check_period = var.notebook_idleness_check_period
 }
 

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -107,7 +107,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -121,7 +121,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.12.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/deployments/vanilla/terraform/vanilla-components/main.tf
+++ b/deployments/vanilla/terraform/vanilla-components/main.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_namespace" "kubeflow" {
   metadata {
     labels = {
-      control-plane = "kubeflow"
+      control-plane   = "kubeflow"
       istio-injection = "enabled"
     }
 
@@ -10,238 +10,238 @@ resource "kubernetes_namespace" "kubeflow" {
 }
 
 module "kubeflow_issuer" {
-  source            = "../../../../iaac/terraform/common/kubeflow-issuer"
+  source = "../../../../iaac/terraform/common/kubeflow-issuer"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/kubeflow-issuer"
   }
 
   addon_context = var.addon_context
-  depends_on = [kubernetes_namespace.kubeflow]
+  depends_on    = [kubernetes_namespace.kubeflow]
 }
 
 module "kubeflow_istio" {
-  source            = "../../../../iaac/terraform/common/istio"
+  source = "../../../../iaac/terraform/common/istio"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/istio-1-14"
   }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_issuer]
+  depends_on    = [module.kubeflow_issuer]
 }
 
 module "kubeflow_dex" {
-  source            = "../../../../iaac/terraform/common/dex"
+  source = "../../../../iaac/terraform/common/dex"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/dex"
   }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_istio]
+  depends_on    = [module.kubeflow_istio]
 }
 
 module "kubeflow_oidc_authservice" {
-  source            = "../../../../iaac/terraform/common/oidc-authservice"
+  source = "../../../../iaac/terraform/common/oidc-authservice"
   helm_config = {
-    chart = "${var.kf_helm_repo_path}/charts/common/oidc-authservice" 
+    chart = "${var.kf_helm_repo_path}/charts/common/oidc-authservice"
   }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_dex]
+  depends_on    = [module.kubeflow_dex]
 }
 
 module "kubeflow_knative_serving" {
-  source            = "../../../../iaac/terraform/common/knative-serving"
+  source = "../../../../iaac/terraform/common/knative-serving"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/knative-serving"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_oidc_authservice]
+  depends_on    = [module.kubeflow_oidc_authservice]
 }
 
 module "kubeflow_cluster_local_gateway" {
-  source            = "../../../../iaac/terraform/common/cluster-local-gateway"
+  source = "../../../../iaac/terraform/common/cluster-local-gateway"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/cluster-local-gateway"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_knative_serving]
+  depends_on    = [module.kubeflow_knative_serving]
 }
 
 module "kubeflow_knative_eventing" {
-  source            = "../../../../iaac/terraform/common/knative-eventing"
+  source = "../../../../iaac/terraform/common/knative-eventing"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/knative-eventing"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_cluster_local_gateway]
+  depends_on    = [module.kubeflow_cluster_local_gateway]
 }
 
 module "kubeflow_roles" {
-  source            = "../../../../iaac/terraform/common/kubeflow-roles"
+  source = "../../../../iaac/terraform/common/kubeflow-roles"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/kubeflow-roles"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_knative_eventing]
+  depends_on    = [module.kubeflow_knative_eventing]
 }
 
 module "kubeflow_istio_resources" {
-  source            = "../../../../iaac/terraform/common/kubeflow-istio-resources"
+  source = "../../../../iaac/terraform/common/kubeflow-istio-resources"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/kubeflow-istio-resources"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_roles]
+  depends_on    = [module.kubeflow_roles]
 }
 
 module "kubeflow_pipelines" {
-  source            = "../../../../iaac/terraform/apps/kubeflow-pipelines"
+  source = "../../../../iaac/terraform/apps/kubeflow-pipelines"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/kubeflow-pipelines/vanilla"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_istio_resources]
+  depends_on    = [module.kubeflow_istio_resources]
 }
 
 module "kubeflow_kserve" {
-  source            = "../../../../iaac/terraform/common/kserve"
+  source = "../../../../iaac/terraform/common/kserve"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/kserve"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_pipelines]
+  depends_on    = [module.kubeflow_pipelines]
 }
 
 module "kubeflow_models_web_app" {
-  source            = "../../../../iaac/terraform/apps/models-web-app"
+  source = "../../../../iaac/terraform/apps/models-web-app"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/models-web-app"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_kserve]
+  depends_on    = [module.kubeflow_kserve]
 }
 
 module "kubeflow_katib" {
-  source            = "../../../../iaac/terraform/apps/katib"
+  source = "../../../../iaac/terraform/apps/katib"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/katib/vanilla"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_models_web_app]
+  depends_on    = [module.kubeflow_models_web_app]
 }
 
 module "kubeflow_central_dashboard" {
-  source            = "../../../../iaac/terraform/apps/central-dashboard"
+  source = "../../../../iaac/terraform/apps/central-dashboard"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/central-dashboard"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_katib]
+  depends_on    = [module.kubeflow_katib]
 }
 
 module "kubeflow_admission_webhook" {
-  source            = "../../../../iaac/terraform/apps/admission-webhook"
+  source = "../../../../iaac/terraform/apps/admission-webhook"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/admission-webhook"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_central_dashboard]
+  depends_on    = [module.kubeflow_central_dashboard]
 }
 
 module "kubeflow_notebook_controller" {
-  source            = "../../../../iaac/terraform/apps/notebook-controller"
+  source = "../../../../iaac/terraform/apps/notebook-controller"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/notebook-controller"
     set = [
       {
-        name = "cullingPolicy.cullIdleTime",
+        name  = "cullingPolicy.cullIdleTime",
         value = var.notebook_cull_idle_time
       },
       {
-        name = "cullingPolicy.enableCulling",
+        name  = "cullingPolicy.enableCulling",
         value = var.notebook_enable_culling
       },
       {
-        name = "cullingPolicy.idlenessCheckPeriod",
-        value= var.notebook_idleness_check_period
+        name  = "cullingPolicy.idlenessCheckPeriod",
+        value = var.notebook_idleness_check_period
       }
     ]
   }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_admission_webhook]
+  depends_on    = [module.kubeflow_admission_webhook]
 }
 
 module "kubeflow_jupyter_web_app" {
-  source            = "../../../../iaac/terraform/apps/jupyter-web-app"
+  source = "../../../../iaac/terraform/apps/jupyter-web-app"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/jupyter-web-app"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_notebook_controller]
+  depends_on    = [module.kubeflow_notebook_controller]
 }
 
 module "kubeflow_profiles_and_kfam" {
-  source            = "../../../../iaac/terraform/apps/profiles-and-kfam"
+  source = "../../../../iaac/terraform/apps/profiles-and-kfam"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/profiles-and-kfam"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_jupyter_web_app]
+  depends_on    = [module.kubeflow_jupyter_web_app]
 }
 
 module "kubeflow_volumes_web_app" {
-  source            = "../../../../iaac/terraform/apps/volumes-web-app"
+  source = "../../../../iaac/terraform/apps/volumes-web-app"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/volumes-web-app"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_profiles_and_kfam]
+  depends_on    = [module.kubeflow_profiles_and_kfam]
 }
 
 module "kubeflow_tensorboards_web_app" {
-  source            = "../../../../iaac/terraform/apps/tensorboards-web-app"
+  source = "../../../../iaac/terraform/apps/tensorboards-web-app"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/tensorboards-web-app"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_volumes_web_app]
+  depends_on    = [module.kubeflow_volumes_web_app]
 }
 
 module "kubeflow_tensorboard_controller" {
-  source            = "../../../../iaac/terraform/apps/tensorboard-controller"
+  source = "../../../../iaac/terraform/apps/tensorboard-controller"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/tensorboard-controller"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_tensorboards_web_app]
+  depends_on    = [module.kubeflow_tensorboards_web_app]
 }
 
 module "kubeflow_training_operator" {
-  source            = "../../../../iaac/terraform/apps/training-operator"
+  source = "../../../../iaac/terraform/apps/training-operator"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/apps/training-operator"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_tensorboard_controller]
+  depends_on    = [module.kubeflow_tensorboard_controller]
 }
 
 module "kubeflow_aws_telemetry" {
-  count = var.enable_aws_telemetry ? 1 : 0
-  source            = "../../../../iaac/terraform/common/aws-telemetry"
+  count  = var.enable_aws_telemetry ? 1 : 0
+  source = "../../../../iaac/terraform/common/aws-telemetry"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/aws-telemetry"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_training_operator]
+  depends_on    = [module.kubeflow_training_operator]
 }
 
 module "kubeflow_user_namespace" {
-  source            = "../../../../iaac/terraform/common/user-namespace"
+  source = "../../../../iaac/terraform/common/user-namespace"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/user-namespace"
-  }  
+  }
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_aws_telemetry]
+  depends_on    = [module.kubeflow_aws_telemetry]
 }
 
 module "ack_sagemaker" {
-  source            = "../../../../iaac/terraform/common/ack-sagemaker-controller"
+  source        = "../../../../iaac/terraform/common/ack-sagemaker-controller"
   addon_context = var.addon_context
 }

--- a/deployments/vanilla/terraform/vanilla-components/variables.tf
+++ b/deployments/vanilla/terraform/vanilla-components/variables.tf
@@ -22,24 +22,24 @@ variable "addon_context" {
 
 variable "enable_aws_telemetry" {
   description = "Enable AWS telemetry component"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "notebook_enable_culling" {
   description = "Enable Notebook culling feature. If set to true then the Notebook Controller will scale all Notebooks with Last activity older than the notebook_cull_idle_time to zero"
-  type = string
-  default = false
+  type        = string
+  default     = false
 }
 
 variable "notebook_cull_idle_time" {
   description = "If a Notebook's LAST_ACTIVITY_ANNOTATION from the current timestamp exceeds this value then the Notebook will be scaled to zero (culled). ENABLE_CULLING must be set to 'true' for this setting to take effect.(minutes)"
-  type = string
-  default = 30
+  type        = string
+  default     = 30
 }
 
 variable "notebook_idleness_check_period" {
   description = "How frequently the controller should poll each Notebook to update its LAST_ACTIVITY_ANNOTATION (minutes)"
-  type = string
-  default = 5
+  type        = string
+  default     = 5
 }

--- a/deployments/vanilla/terraform/variables.tf
+++ b/deployments/vanilla/terraform/variables.tf
@@ -29,30 +29,30 @@ variable "node_instance_type_gpu" {
 
 variable "enable_aws_telemetry" {
   description = "Enable AWS telemetry component"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "kf_helm_repo_path" {
   description = "Full path to the location of the helm repo for KF"
   type        = string
-  default = "../../.."
+  default     = "../../.."
 }
 
 variable "notebook_enable_culling" {
   description = "Enable Notebook culling feature. If set to true then the Notebook Controller will scale all Notebooks with Last activity older than the notebook_cull_idle_time to zero"
-  type = string
-  default = false
+  type        = string
+  default     = false
 }
 
 variable "notebook_cull_idle_time" {
   description = "If a Notebook's LAST_ACTIVITY_ANNOTATION from the current timestamp exceeds this value then the Notebook will be scaled to zero (culled). ENABLE_CULLING must be set to 'true' for this setting to take effect.(minutes)"
-  type = string
-  default = 30
+  type        = string
+  default     = 30
 }
 
 variable "notebook_idleness_check_period" {
   description = "How frequently the controller should poll each Notebook to update its LAST_ACTIVITY_ANNOTATION (minutes)"
-  type = string
-  default = 5
+  type        = string
+  default     = 5
 }

--- a/iaac/terraform/apps/admission-webhook/locals.tf
+++ b/iaac/terraform/apps/admission-webhook/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "admission-webhook"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.1"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.1"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/apps/admission-webhook/main.tf
+++ b/iaac/terraform/apps/admission-webhook/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/admission-webhook/main.tf
+++ b/iaac/terraform/apps/admission-webhook/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/admission-webhook/variables.tf
+++ b/iaac/terraform/apps/admission-webhook/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/apps/central-dashboard/locals.tf
+++ b/iaac/terraform/apps/central-dashboard/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "central-dashboard"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.1"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.1"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/apps/central-dashboard/main.tf
+++ b/iaac/terraform/apps/central-dashboard/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/central-dashboard/main.tf
+++ b/iaac/terraform/apps/central-dashboard/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/central-dashboard/variables.tf
+++ b/iaac/terraform/apps/central-dashboard/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/apps/jupyter-web-app/locals.tf
+++ b/iaac/terraform/apps/jupyter-web-app/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "jupyter-web-app"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.1"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.1"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/apps/jupyter-web-app/main.tf
+++ b/iaac/terraform/apps/jupyter-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/jupyter-web-app/main.tf
+++ b/iaac/terraform/apps/jupyter-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/jupyter-web-app/variables.tf
+++ b/iaac/terraform/apps/jupyter-web-app/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/apps/katib/locals.tf
+++ b/iaac/terraform/apps/katib/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "katib"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/apps/katib/main.tf
+++ b/iaac/terraform/apps/katib/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/katib/main.tf
+++ b/iaac/terraform/apps/katib/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/katib/variables.tf
+++ b/iaac/terraform/apps/katib/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/apps/kubeflow-pipelines/locals.tf
+++ b/iaac/terraform/apps/kubeflow-pipelines/locals.tf
@@ -2,13 +2,13 @@ locals {
   name = "kubeflow-pipelines"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.1"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.1"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
-  
+
   helm_config = merge(
     local.default_helm_config,
     var.helm_config

--- a/iaac/terraform/apps/kubeflow-pipelines/main.tf
+++ b/iaac/terraform/apps/kubeflow-pipelines/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/kubeflow-pipelines/main.tf
+++ b/iaac/terraform/apps/kubeflow-pipelines/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/kubeflow-pipelines/variables.tf
+++ b/iaac/terraform/apps/kubeflow-pipelines/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/apps/models-web-app/locals.tf
+++ b/iaac/terraform/apps/models-web-app/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "models-web-app"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/apps/models-web-app/main.tf
+++ b/iaac/terraform/apps/models-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/models-web-app/main.tf
+++ b/iaac/terraform/apps/models-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/models-web-app/variables.tf
+++ b/iaac/terraform/apps/models-web-app/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/apps/notebook-controller/locals.tf
+++ b/iaac/terraform/apps/notebook-controller/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "notebook-controller"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.1"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.1"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/apps/notebook-controller/main.tf
+++ b/iaac/terraform/apps/notebook-controller/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/notebook-controller/main.tf
+++ b/iaac/terraform/apps/notebook-controller/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/notebook-controller/variables.tf
+++ b/iaac/terraform/apps/notebook-controller/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/apps/profiles-and-kfam/locals.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "profiles-and-kfam"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.1"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.1"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -5,7 +5,7 @@ resource "aws_iam_policy" "profile_controller_policy" {
 }
 
 module "irsa" {
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = "kubeflow"
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false
@@ -19,7 +19,7 @@ module "irsa" {
 }
 
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -1,17 +1,17 @@
 resource "aws_iam_policy" "profile_controller_policy" {
-  name_prefix        = "profile-controller-policy"
+  name_prefix = "profile-controller-policy"
   description = "IAM policy for the kubeflow pipelines profile controller"
-  policy        = "${file("../../../awsconfigs/infra_configs/iam_profile_controller_policy.json")}"
+  policy      = file("../../../awsconfigs/infra_configs/iam_profile_controller_policy.json")
 }
 
 module "irsa" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
-  kubernetes_namespace = "kubeflow"
-  create_kubernetes_namespace = false
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  kubernetes_namespace              = "kubeflow"
+  create_kubernetes_namespace       = false
   create_kubernetes_service_account = false
-  kubernetes_service_account = "profiles-controller-service-account"
-  irsa_iam_role_name = format("%s-%s-%s-%s", "profiles-controller", "irsa", var.addon_context.eks_cluster_id, var.addon_context.aws_region_name)
-  irsa_iam_policies = [aws_iam_policy.profile_controller_policy.arn]
+  kubernetes_service_account        = "profiles-controller-service-account"
+  irsa_iam_role_name                = format("%s-%s-%s-%s", "profiles-controller", "irsa", var.addon_context.eks_cluster_id, var.addon_context.aws_region_name)
+  irsa_iam_policies                 = [aws_iam_policy.profile_controller_policy.arn]
   irsa_iam_role_path                = var.addon_context.irsa_iam_role_path
   irsa_iam_permissions_boundary     = var.addon_context.irsa_iam_permissions_boundary
   eks_cluster_id                    = var.addon_context.eks_cluster_id
@@ -19,19 +19,19 @@ module "irsa" {
 }
 
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }
 
 resource "kubernetes_annotations" "sa_role_arn" {
   api_version = "v1"
   kind        = "ServiceAccount"
   metadata {
-    name        = module.irsa.service_account
-    namespace   = module.irsa.namespace
+    name      = module.irsa.service_account
+    namespace = module.irsa.namespace
   }
-  annotations = { 
+  annotations = {
     "eks.amazonaws.com/role-arn" : module.irsa.irsa_iam_role_arn
   }
 

--- a/iaac/terraform/apps/profiles-and-kfam/variables.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/apps/tensorboard-controller/locals.tf
+++ b/iaac/terraform/apps/tensorboard-controller/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "tensorboard-controller"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.1"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.1"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/apps/tensorboard-controller/main.tf
+++ b/iaac/terraform/apps/tensorboard-controller/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/tensorboard-controller/main.tf
+++ b/iaac/terraform/apps/tensorboard-controller/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/tensorboard-controller/variables.tf
+++ b/iaac/terraform/apps/tensorboard-controller/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/apps/tensorboards-web-app/locals.tf
+++ b/iaac/terraform/apps/tensorboards-web-app/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "tensorboards-web-app"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.1"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.1"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/apps/tensorboards-web-app/main.tf
+++ b/iaac/terraform/apps/tensorboards-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/tensorboards-web-app/main.tf
+++ b/iaac/terraform/apps/tensorboards-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/tensorboards-web-app/variables.tf
+++ b/iaac/terraform/apps/tensorboards-web-app/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/apps/training-operator/locals.tf
+++ b/iaac/terraform/apps/training-operator/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "training-operator"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/apps/training-operator/main.tf
+++ b/iaac/terraform/apps/training-operator/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/training-operator/main.tf
+++ b/iaac/terraform/apps/training-operator/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/training-operator/variables.tf
+++ b/iaac/terraform/apps/training-operator/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/apps/volumes-web-app/locals.tf
+++ b/iaac/terraform/apps/volumes-web-app/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "volumes-web-app"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.1"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.1"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/apps/volumes-web-app/main.tf
+++ b/iaac/terraform/apps/volumes-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/volumes-web-app/main.tf
+++ b/iaac/terraform/apps/volumes-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/volumes-web-app/variables.tf
+++ b/iaac/terraform/apps/volumes-web-app/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/aws-infra/cognito/custom_domain.tf
+++ b/iaac/terraform/aws-infra/cognito/custom_domain.tf
@@ -14,10 +14,10 @@ data "aws_route53_zone" "platform" {
 # In order to use a custom domain, its root(i.e. platform.example.com) must have an valid A type record
 resource "aws_route53_record" "pre_cognito_domain_a_record" {
   allow_overwrite = true
-  zone_id = data.aws_route53_zone.platform.zone_id
-  name    = data.aws_route53_zone.platform.name
-  type    = "A"
-  ttl     = "300"
+  zone_id         = data.aws_route53_zone.platform.zone_id
+  name            = data.aws_route53_zone.platform.name
+  type            = "A"
+  ttl             = "300"
   # This record will be updated after ALB creation
   records = ["127.0.0.1"]
 
@@ -73,9 +73,9 @@ resource "aws_cognito_user_pool_domain" "platform" {
 
 resource "aws_route53_record" "auth_cognito_domain_record" {
   allow_overwrite = true
-  name    = aws_cognito_user_pool_domain.platform.domain
-  type    = "A"
-  zone_id = data.aws_route53_zone.platform.zone_id
+  name            = aws_cognito_user_pool_domain.platform.domain
+  type            = "A"
+  zone_id         = data.aws_route53_zone.platform.zone_id
   alias {
     evaluate_target_health = false
     name                   = aws_cognito_user_pool_domain.platform.cloudfront_distribution_arn

--- a/iaac/terraform/aws-infra/cognito/userpool.tf
+++ b/iaac/terraform/aws-infra/cognito/userpool.tf
@@ -1,11 +1,11 @@
 resource "aws_cognito_user_pool" "platform" {
-  name                = var.cognito_user_pool_name
+  name = var.cognito_user_pool_name
 
   schema {
-    name                     = "email"
-    attribute_data_type      = "String"
-    mutable                  = true
-    required                 = true
+    name                = "email"
+    attribute_data_type = "String"
+    mutable             = true
+    required            = true
     string_attribute_constraints {
       min_length = "1"
       max_length = "2048"

--- a/iaac/terraform/aws-infra/rds/main.tf
+++ b/iaac/terraform/aws-infra/rds/main.tf
@@ -30,45 +30,45 @@ resource "random_uuid" "db_snapshot_suffix" {
   keepers = {
     instance_class       = var.db_class
     db_name              = var.db_name
-    username = var.db_username
-    password = var.db_password
-    multi_az = var.multi_az
+    username             = var.db_username
+    password             = var.db_password
+    multi_az             = var.multi_az
     db_subnet_group_name = aws_db_subnet_group.rds_db_subnet_group.id
-    security_group_id = var.security_group_id
+    security_group_id    = var.security_group_id
   }
 }
 
 resource "aws_db_instance" "kubeflow_db" {
-  allocated_storage    = var.db_allocated_storage
-  engine               = "mysql"
-  engine_version       = var.mysql_engine_version
-  instance_class       = var.db_class
-  db_name                 = var.db_name
-  username = var.db_username
-  password = var.db_password
-  multi_az = var.multi_az
-  db_subnet_group_name = aws_db_subnet_group.rds_db_subnet_group.id
-  vpc_security_group_ids = var.publicly_accessible ? [aws_security_group.public_access[0].id, var.security_group_id] : [var.security_group_id]
-  backup_retention_period = var.backup_retention_period
-  storage_type = var.storage_type
-  deletion_protection = var.deletion_protection
-  max_allocated_storage = var.max_allocated_storage
-  publicly_accessible = var.publicly_accessible
+  allocated_storage         = var.db_allocated_storage
+  engine                    = "mysql"
+  engine_version            = var.mysql_engine_version
+  instance_class            = var.db_class
+  db_name                   = var.db_name
+  username                  = var.db_username
+  password                  = var.db_password
+  multi_az                  = var.multi_az
+  db_subnet_group_name      = aws_db_subnet_group.rds_db_subnet_group.id
+  vpc_security_group_ids    = var.publicly_accessible ? [aws_security_group.public_access[0].id, var.security_group_id] : [var.security_group_id]
+  backup_retention_period   = var.backup_retention_period
+  storage_type              = var.storage_type
+  deletion_protection       = var.deletion_protection
+  max_allocated_storage     = var.max_allocated_storage
+  publicly_accessible       = var.publicly_accessible
   final_snapshot_identifier = "snp-${random_uuid.db_snapshot_suffix.result}"
 }
 
 resource "aws_secretsmanager_secret" "rds_secret" {
-  name_prefix = "rds-secret-"
+  name_prefix             = "rds-secret-"
   recovery_window_in_days = var.secret_recovery_window_in_days
 }
 
 resource "aws_secretsmanager_secret_version" "rds_secret_version" {
-  secret_id     = aws_secretsmanager_secret.rds_secret.id
+  secret_id = aws_secretsmanager_secret.rds_secret.id
   secret_string = jsonencode({
     username = aws_db_instance.kubeflow_db.username
     password = aws_db_instance.kubeflow_db.password
     database = aws_db_instance.kubeflow_db.db_name
-    host = aws_db_instance.kubeflow_db.address
-    port = tostring(aws_db_instance.kubeflow_db.port)
+    host     = aws_db_instance.kubeflow_db.address
+    port     = tostring(aws_db_instance.kubeflow_db.port)
   })
 }

--- a/iaac/terraform/aws-infra/rds/outputs.tf
+++ b/iaac/terraform/aws-infra/rds/outputs.tf
@@ -1,7 +1,7 @@
 output "rds_secret_name" {
-    value = aws_secretsmanager_secret.rds_secret.name
+  value = aws_secretsmanager_secret.rds_secret.name
 }
 
 output "rds_endpoint" {
-    value = aws_db_instance.kubeflow_db.address
+  value = aws_db_instance.kubeflow_db.address
 }

--- a/iaac/terraform/aws-infra/rds/variables.tf
+++ b/iaac/terraform/aws-infra/rds/variables.tf
@@ -16,13 +16,13 @@ variable "security_group_id" {
 variable "db_name" {
   type        = string
   description = "Database name"
-  default = "kubeflow"
+  default     = "kubeflow"
 }
 
 variable "db_username" {
   type        = string
   description = "Database admin account username"
-  default = "admin"
+  default     = "admin"
 }
 
 variable "db_password" {
@@ -33,49 +33,49 @@ variable "db_password" {
 variable "db_class" {
   type        = string
   description = "Database instance type"
-  default = "db.m5.large"
+  default     = "db.m5.large"
 }
 
 variable "db_allocated_storage" {
   type        = string
   description = "The size of the database (Gb)"
-  default = "20"
+  default     = "20"
 }
 
 variable "mysql_engine_version" {
   type        = string
   description = "The engine version of MySQL"
-  default = "8.0.32"
+  default     = "8.0.32"
 }
 
 variable "backup_retention_period" {
   type        = number
   description = "Number of days to retain backups for"
-  default = 7
+  default     = 7
 }
 
 variable "storage_type" {
   type        = string
   description = "Instance storage type: standard, gp2, or io1"
-  default = "gp2"
+  default     = "gp2"
 }
 
 variable "deletion_protection" {
   type        = bool
   description = "Prevents the deletion of the instance when set to true"
-  default = true
+  default     = true
 }
 
 variable "max_allocated_storage" {
   type        = number
   description = "The upper limit of scalable storage (Gb)"
-  default = 1000
+  default     = 1000
 }
 
 variable "publicly_accessible" {
   type        = bool
   description = "Makes the instance publicly accessible when true"
-  default = false
+  default     = false
 }
 
 variable "multi_az" {
@@ -85,6 +85,6 @@ variable "multi_az" {
 }
 
 variable "secret_recovery_window_in_days" {
-  type = number
+  type    = number
   default = 7
 }

--- a/iaac/terraform/aws-infra/s3/main.tf
+++ b/iaac/terraform/aws-infra/s3/main.tf
@@ -7,12 +7,12 @@ resource "aws_s3_bucket" "artifact_store" {
 }
 
 resource "aws_secretsmanager_secret" "s3_secret" {
-  name_prefix = "s3-secret-"
+  name_prefix             = "s3-secret-"
   recovery_window_in_days = var.secret_recovery_window_in_days
 }
 
 resource "aws_secretsmanager_secret_version" "s3_secret_version" {
-  secret_id     = aws_secretsmanager_secret.s3_secret.id
+  secret_id = aws_secretsmanager_secret.s3_secret.id
   secret_string = jsonencode({
     accesskey = var.minio_aws_access_key_id
     secretkey = var.minio_aws_secret_access_key

--- a/iaac/terraform/aws-infra/s3/outputs.tf
+++ b/iaac/terraform/aws-infra/s3/outputs.tf
@@ -1,7 +1,7 @@
 output "s3_secret_name" {
-    value = aws_secretsmanager_secret.s3_secret.name
+  value = aws_secretsmanager_secret.s3_secret.name
 }
 
 output "s3_bucket_name" {
-    value = aws_s3_bucket.artifact_store.id
+  value = aws_s3_bucket.artifact_store.id
 }

--- a/iaac/terraform/aws-infra/s3/variables.tf
+++ b/iaac/terraform/aws-infra/s3/variables.tf
@@ -9,12 +9,12 @@ variable "minio_aws_secret_access_key" {
 }
 
 variable "secret_recovery_window_in_days" {
-  type = number
+  type    = number
   default = 7
 }
 
 variable "force_destroy_bucket" {
-  type = bool
+  type        = bool
   description = "Destroys s3 bucket even when the bucket is not empty"
-  default = false
+  default     = false
 }

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -5,7 +5,7 @@ resource "aws_iam_policy" "sagemaker_ack_controller_studio_access" {
 }
 
 module "irsa" {
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = local.namespace
   create_kubernetes_namespace       = true
   create_kubernetes_service_account = false
@@ -19,7 +19,7 @@ module "irsa" {
 }
 
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   manage_via_gitops = false
   helm_config       = local.helm_config
   set_values = [

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -1,17 +1,17 @@
 resource "aws_iam_policy" "sagemaker_ack_controller_studio_access" {
-  name_prefix        = "${local.service}-ack-controller-policy"
+  name_prefix = "${local.service}-ack-controller-policy"
   description = "IAM policy for the ${local.service} ack controller"
-  policy        = "${file("../../../awsconfigs/infra_configs/iam_ack_oidc_sm_studio_policy.json")}"
+  policy      = file("../../../awsconfigs/infra_configs/iam_ack_oidc_sm_studio_policy.json")
 }
 
 module "irsa" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
-  kubernetes_namespace = local.namespace
-  create_kubernetes_namespace = true
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.12.1"
+  kubernetes_namespace              = local.namespace
+  create_kubernetes_namespace       = true
   create_kubernetes_service_account = false
-  kubernetes_service_account = local.name
-  irsa_iam_role_name = format("%s-%s-%s-%s", "ack-sagemaker-controller", "irsa", var.addon_context.eks_cluster_id, var.addon_context.aws_region_name)
-  irsa_iam_policies = ["arn:aws:iam::aws:policy/AmazonSageMakerFullAccess", aws_iam_policy.sagemaker_ack_controller_studio_access.arn]
+  kubernetes_service_account        = local.name
+  irsa_iam_role_name                = format("%s-%s-%s-%s", "ack-sagemaker-controller", "irsa", var.addon_context.eks_cluster_id, var.addon_context.aws_region_name)
+  irsa_iam_policies                 = ["arn:aws:iam::aws:policy/AmazonSageMakerFullAccess", aws_iam_policy.sagemaker_ack_controller_studio_access.arn]
   irsa_iam_role_path                = var.addon_context.irsa_iam_role_path
   irsa_iam_permissions_boundary     = var.addon_context.irsa_iam_permissions_boundary
   eks_cluster_id                    = var.addon_context.eks_cluster_id
@@ -21,23 +21,23 @@ module "irsa" {
 module "helm_addon" {
   source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
   manage_via_gitops = false
-  helm_config = local.helm_config
+  helm_config       = local.helm_config
   set_values = [
     {
-      name = "aws.region" 
+      name  = "aws.region"
       value = var.addon_context.aws_region_name
     },
     {
-      name = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+      name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
       value = module.irsa.irsa_iam_role_arn
     },
     {
-      name = "role.labels.rbac\\.authorization\\.kubeflow\\.org/aggregate-to-kubeflow-edit"
+      name  = "role.labels.rbac\\.authorization\\.kubeflow\\.org/aggregate-to-kubeflow-edit"
       value = "true"
     },
   ]
 
-  addon_context     = var.addon_context
+  addon_context = var.addon_context
 
   depends_on = [module.irsa]
 }

--- a/iaac/terraform/common/ack-sagemaker-controller/variables.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/aws-authservice/locals.tf
+++ b/iaac/terraform/common/aws-authservice/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "aws-authservice"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/aws-authservice/main.tf
+++ b/iaac/terraform/common/aws-authservice/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-authservice/main.tf
+++ b/iaac/terraform/common/aws-authservice/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-authservice/variables.tf
+++ b/iaac/terraform/common/aws-authservice/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/aws-secrets-manager/locals.tf
+++ b/iaac/terraform/common/aws-secrets-manager/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "secrets-manager"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created in
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created in
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/aws-secrets-manager/main.tf
+++ b/iaac/terraform/common/aws-secrets-manager/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-secrets-manager/main.tf
+++ b/iaac/terraform/common/aws-secrets-manager/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-telemetry/locals.tf
+++ b/iaac/terraform/common/aws-telemetry/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "aws-telemetry"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/aws-telemetry/main.tf
+++ b/iaac/terraform/common/aws-telemetry/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-telemetry/main.tf
+++ b/iaac/terraform/common/aws-telemetry/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-telemetry/variables.tf
+++ b/iaac/terraform/common/aws-telemetry/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/cluster-local-gateway/locals.tf
+++ b/iaac/terraform/common/cluster-local-gateway/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "cluster-local-gateway"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/cluster-local-gateway/main.tf
+++ b/iaac/terraform/common/cluster-local-gateway/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/cluster-local-gateway/main.tf
+++ b/iaac/terraform/common/cluster-local-gateway/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/cluster-local-gateway/variables.tf
+++ b/iaac/terraform/common/cluster-local-gateway/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/dex/locals.tf
+++ b/iaac/terraform/common/dex/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "dex"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/dex/main.tf
+++ b/iaac/terraform/common/dex/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/dex/main.tf
+++ b/iaac/terraform/common/dex/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/dex/variables.tf
+++ b/iaac/terraform/common/dex/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/ingress/cognito/main.tf
+++ b/iaac/terraform/common/ingress/cognito/main.tf
@@ -39,14 +39,15 @@ resource "kubernetes_ingress_v1" "istio_ingress" {
 
   metadata {
     annotations = {
-        "alb.ingress.kubernetes.io/auth-type": "cognito",
-        "alb.ingress.kubernetes.io/auth-idp-cognito": "{\"UserPoolArn\":\"${var.cognito_user_pool_arn}\",\"UserPoolClientId\":\"${var.cognito_app_client_id}\", \"UserPoolDomain\":\"${var.cognito_user_pool_domain}\"}"
-        "alb.ingress.kubernetes.io/certificate-arn": "${aws_acm_certificate.deployment_region.arn}"
-        "alb.ingress.kubernetes.io/listen-ports": "[{\"HTTPS\":443}]",
-        "alb.ingress.kubernetes.io/load-balancer-attributes": "routing.http.drop_invalid_header_fields.enabled=true",
-        "alb.ingress.kubernetes.io/scheme": "${var.load_balancer_scheme}"
+      "alb.ingress.kubernetes.io/auth-type" : "cognito",
+      "alb.ingress.kubernetes.io/auth-idp-cognito" : "{\"UserPoolArn\":\"${var.cognito_user_pool_arn}\",\"UserPoolClientId\":\"${var.cognito_app_client_id}\", \"UserPoolDomain\":\"${var.cognito_user_pool_domain}\"}"
+      "alb.ingress.kubernetes.io/certificate-arn" : "${aws_acm_certificate.deployment_region.arn}"
+      "alb.ingress.kubernetes.io/listen-ports" : "[{\"HTTPS\":443}]",
+      "alb.ingress.kubernetes.io/target-type" : "ip",
+      "alb.ingress.kubernetes.io/load-balancer-attributes" : "routing.http.drop_invalid_header_fields.enabled=true",
+      "alb.ingress.kubernetes.io/scheme" : "${var.load_balancer_scheme}"
     }
-    name = "istio-ingress"
+    name      = "istio-ingress"
     namespace = "istio-system"
   }
 
@@ -94,11 +95,11 @@ resource "aws_route53_record" "cname_record" {
 resource "aws_route53_record" "a_record" {
   allow_overwrite = true
   zone_id         = data.aws_route53_zone.platform.zone_id
-  name            = "${data.aws_route53_zone.platform.name}"
+  name            = data.aws_route53_zone.platform.name
   type            = "A"
 
   alias {
-    name                   = "${data.aws_lb.istio_ingress.dns_name}"
+    name                   = data.aws_lb.istio_ingress.dns_name
     zone_id                = data.aws_lb.istio_ingress.zone_id
     evaluate_target_health = false
   }

--- a/iaac/terraform/common/ingress/cognito/variables.tf
+++ b/iaac/terraform/common/ingress/cognito/variables.tf
@@ -26,5 +26,5 @@ variable "cognito_user_pool_domain" {
 variable "load_balancer_scheme" {
   description = "Load Balancer Scheme"
   type        = string
-  default = "internet-facing"
+  default     = "internet-facing"
 }

--- a/iaac/terraform/common/istio/locals.tf
+++ b/iaac/terraform/common/istio/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "istio"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.1"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.1"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/istio/main.tf
+++ b/iaac/terraform/common/istio/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/istio/main.tf
+++ b/iaac/terraform/common/istio/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/istio/variables.tf
+++ b/iaac/terraform/common/istio/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/knative-eventing/locals.tf
+++ b/iaac/terraform/common/knative-eventing/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "knative-eventing"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/knative-eventing/main.tf
+++ b/iaac/terraform/common/knative-eventing/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/knative-eventing/main.tf
+++ b/iaac/terraform/common/knative-eventing/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/knative-eventing/variables.tf
+++ b/iaac/terraform/common/knative-eventing/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/knative-serving/locals.tf
+++ b/iaac/terraform/common/knative-serving/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "knative-serving"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/knative-serving/main.tf
+++ b/iaac/terraform/common/knative-serving/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/knative-serving/main.tf
+++ b/iaac/terraform/common/knative-serving/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/knative-serving/variables.tf
+++ b/iaac/terraform/common/knative-serving/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/kserve/locals.tf
+++ b/iaac/terraform/common/kserve/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "kserve"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/kserve/main.tf
+++ b/iaac/terraform/common/kserve/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kserve/main.tf
+++ b/iaac/terraform/common/kserve/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kserve/variables.tf
+++ b/iaac/terraform/common/kserve/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/kubeflow-issuer/locals.tf
+++ b/iaac/terraform/common/kubeflow-issuer/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "kubeflow-issuer"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/kubeflow-issuer/main.tf
+++ b/iaac/terraform/common/kubeflow-issuer/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-issuer/main.tf
+++ b/iaac/terraform/common/kubeflow-issuer/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-issuer/variables.tf
+++ b/iaac/terraform/common/kubeflow-issuer/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/kubeflow-istio-resources/locals.tf
+++ b/iaac/terraform/common/kubeflow-istio-resources/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "kubeflow-istio-resources"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/kubeflow-istio-resources/main.tf
+++ b/iaac/terraform/common/kubeflow-istio-resources/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-istio-resources/main.tf
+++ b/iaac/terraform/common/kubeflow-istio-resources/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-istio-resources/variables.tf
+++ b/iaac/terraform/common/kubeflow-istio-resources/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/kubeflow-roles/locals.tf
+++ b/iaac/terraform/common/kubeflow-roles/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "kubeflow-roles"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/kubeflow-roles/main.tf
+++ b/iaac/terraform/common/kubeflow-roles/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-roles/main.tf
+++ b/iaac/terraform/common/kubeflow-roles/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-roles/variables.tf
+++ b/iaac/terraform/common/kubeflow-roles/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/oidc-authservice/locals.tf
+++ b/iaac/terraform/common/oidc-authservice/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "oidc-authservice"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/oidc-authservice/main.tf
+++ b/iaac/terraform/common/oidc-authservice/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/oidc-authservice/main.tf
+++ b/iaac/terraform/common/oidc-authservice/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/oidc-authservice/variables.tf
+++ b/iaac/terraform/common/oidc-authservice/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/common/user-namespace/locals.tf
+++ b/iaac/terraform/common/user-namespace/locals.tf
@@ -2,11 +2,11 @@ locals {
   name = "user-namespace"
 
   default_helm_config = {
-    name        = local.name
-    version     = "0.1.0"
-    namespace   = "default"    # change to namespace resources are being created it
-    values      = []
-    timeout     = "600"
+    name      = local.name
+    version   = "0.1.0"
+    namespace = "default" # change to namespace resources are being created it
+    values    = []
+    timeout   = "600"
   }
 
   helm_config = merge(

--- a/iaac/terraform/common/user-namespace/main.tf
+++ b/iaac/terraform/common/user-namespace/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  helm_config   = local.helm_config
+  addon_context = var.addon_context
 }

--- a/iaac/terraform/common/user-namespace/main.tf
+++ b/iaac/terraform/common/user-namespace/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/user-namespace/variables.tf
+++ b/iaac/terraform/common/user-namespace/variables.tf
@@ -1,6 +1,6 @@
 variable "helm_config" {
-  type        = any
-  default     = {}
+  type    = any
+  default = {}
 }
 
 variable "addon_context" {

--- a/iaac/terraform/utils/blueprints-extended-outputs/outputs.tf
+++ b/iaac/terraform/utils/blueprints-extended-outputs/outputs.tf
@@ -1,3 +1,3 @@
 output "addon_context" {
-    value = local.addon_context
+  value = local.addon_context
 }

--- a/iaac/terraform/utils/set-values-filter/main.tf
+++ b/iaac/terraform/utils/set-values-filter/main.tf
@@ -1,3 +1,3 @@
 locals {
-  set_values = [for k,v in var.set_values : {name = k, value = v} if v != null]
+  set_values = [for k, v in var.set_values : { name = k, value = v } if v != null]
 }

--- a/iaac/terraform/utils/set-values-filter/outputs.tf
+++ b/iaac/terraform/utils/set-values-filter/outputs.tf
@@ -1,3 +1,3 @@
 output "set_values" {
-    value = local.set_values
+  value = local.set_values
 }

--- a/iaac/terraform/utils/set-values-filter/variables.tf
+++ b/iaac/terraform/utils/set-values-filter/variables.tf
@@ -1,4 +1,4 @@
 variable "set_values" {
   description = "Map of values to pass to set for helm charts. Null values must be an empty string (e.g. '')"
-  type        = map
+  type        = map(any)
 }

--- a/tests/e2e/resources/external/secrets_store_csi_driver.py
+++ b/tests/e2e/resources/external/secrets_store_csi_driver.py
@@ -1,16 +1,16 @@
 from e2e.utils.utils import kubectl_apply
 
-RBAC_SECRETS_PROVIDER_CLASS = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/rbac-secretproviderclass.yaml"
+RBAC_SECRETS_PROVIDER_CLASS = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/rbac-secretproviderclass.yaml"
 
-CSI_DRIVER_V_1_0_0 = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/csidriver.yaml"
+CSI_DRIVER_V_1_0_0 = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/csidriver.yaml"
 
-SECRETS_STORE_SECRETS_PROVIDER_CLASSES = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml"
+SECRETS_STORE_SECRETS_PROVIDER_CLASSES = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml"
 
-SECRETS_STORE_SECRETS_PROVIDER_CLASS_POD_STATUSES = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml"
+SECRETS_STORE_SECRETS_PROVIDER_CLASS_POD_STATUSES = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml"
 
-SECRETS_STORE_CSI_DRIVER = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store-csi-driver.yaml"
+SECRETS_STORE_CSI_DRIVER = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store-csi-driver.yaml"
 
-RBAC_SECRETS_PROVIDER_SYNCING = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/rbac-secretprovidersyncing.yaml"
+RBAC_SECRETS_PROVIDER_SYNCING = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/rbac-secretprovidersyncing.yaml"
 
 
 def install():

--- a/tests/e2e/utils/rds-s3/auto-rds-s3-cleanup.py
+++ b/tests/e2e/utils/rds-s3/auto-rds-s3-cleanup.py
@@ -39,7 +39,8 @@ def delete_s3_bucket(metadata, secrets_manager_client, region):
         SecretId=metadata["S3"]["secretName"], ForceDeleteWithoutRecovery=True
     )
 
-def check_bucket(bucket_name,s3_client):
+
+def check_bucket(bucket_name, s3_client):
     try:
         s3_client.head_bucket(Bucket=bucket_name)
         print("Bucket Exists!")
@@ -47,7 +48,7 @@ def check_bucket(bucket_name,s3_client):
     except botocore.exceptions.ClientError as e:
         # If a client error is thrown, then check that it was a 404 error.
         # If it was a 404 error, then the bucket does not exist.
-        error_code = int(e.response['Error']['Code'])
+        error_code = int(e.response["Error"]["Code"])
         if error_code == 403:
             print("Private Bucket. Forbidden Access!")
             return True
@@ -60,7 +61,7 @@ def delete_rds(metadata, secrets_manager_client, region):
     rds_client = get_rds_client(region)
     db_instance_name = metadata["RDS"]["instanceName"]
     db_subnet_group_name = metadata["RDS"]["subnetGroupName"]
-    
+
     print("Deleting RDS instance...")
 
     rds_client.modify_db_instance(
@@ -83,13 +84,11 @@ def delete_rds(metadata, secrets_manager_client, region):
         except:
             print("RDS instance has been successfully deleted")
             break
-  
 
     print("Deleting DB Subnet Group...")
- 
+
     rds_client.delete_db_subnet_group(DBSubnetGroupName=db_subnet_group_name)
     print("DB Subnet Group has been successfully deleted")
-
 
     secrets_manager_client.delete_secret(
         SecretId=metadata["RDS"]["secretName"], ForceDeleteWithoutRecovery=True
@@ -98,22 +97,22 @@ def delete_rds(metadata, secrets_manager_client, region):
 
 def uninstall_secrets_manager(region, cluster_name):
     kubectl_delete(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/rbac-secretproviderclass.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/rbac-secretproviderclass.yaml"
     )
     kubectl_delete(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/csidriver.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/csidriver.yaml"
     )
     kubectl_delete(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml"
     )
     kubectl_delete(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml"
     )
     kubectl_delete(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store-csi-driver.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store-csi-driver.yaml"
     )
     kubectl_delete(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/rbac-secretprovidersyncing.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/rbac-secretprovidersyncing.yaml"
     )
     kubectl_delete(
         "https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml"

--- a/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
+++ b/tests/e2e/utils/rds-s3/auto-rds-s3-setup.py
@@ -19,7 +19,7 @@ from e2e.utils.utils import (
     load_yaml_file,
     wait_for,
     WaitForCircuitBreakerError,
-    write_env_to_yaml
+    write_env_to_yaml,
 )
 
 from shutil import which
@@ -30,6 +30,7 @@ INSTALLATION_PATH_FILE_S3_ONLY = "./resources/installation_config/s3-only.yaml"
 path_dic_rds_s3 = load_yaml_file(INSTALLATION_PATH_FILE_RDS_S3)
 path_dic_rds_only = load_yaml_file(INSTALLATION_PATH_FILE_RDS_ONLY)
 path_dic_s3_only = load_yaml_file(INSTALLATION_PATH_FILE_S3_ONLY)
+
 
 def main():
     verify_prerequisites()
@@ -161,12 +162,16 @@ def create_s3_secret(secrets_manager_client, s3_secret_name):
 def setup_rds(rds_client, secrets_manager_client, eks_client, ec2_client):
     print_banner("RDS Setup")
 
-    rds_secret_exists = does_secret_already_exist(secrets_manager_client, RDS_SECRET_NAME)
+    rds_secret_exists = does_secret_already_exist(
+        secrets_manager_client, RDS_SECRET_NAME
+    )
 
     if not does_database_exist(rds_client):
         if rds_secret_exists:
             # Avoiding overwriting an existing secret with a new DB endpoint in case that secret is being used with an existing installation
-            raise Exception(f"A RDS DB instance was not created because a secret with the name {RDS_SECRET_NAME} already exists. To create the instance, delete the existing secret or provide a unique name for a new secret to be created.")
+            raise Exception(
+                f"A RDS DB instance was not created because a secret with the name {RDS_SECRET_NAME} already exists. To create the instance, delete the existing secret or provide a unique name for a new secret to be created."
+            )
 
         db_root_password = setup_db_instance(
             rds_client, secrets_manager_client, eks_client, ec2_client
@@ -179,7 +184,9 @@ def setup_rds(rds_client, secrets_manager_client, eks_client, ec2_client):
         # The username and password for the existing DB instance are unknown at this point (since they are only known during DB instance creation.)
         # So a new secret with the username and password values can't be created.
         if not rds_secret_exists:
-            raise Exception(f"Secret {RDS_SECRET_NAME} was not created because the username and password of the instance {DB_INSTANCE_NAME} are hidden (in another secret) after creation. To create the secret, specify a new DB instance to be created or delete the existing DB instance.")
+            raise Exception(
+                f"Secret {RDS_SECRET_NAME} was not created because the username and password of the instance {DB_INSTANCE_NAME} are hidden (in another secret) after creation. To create the secret, specify a new DB instance to be created or delete the existing DB instance."
+            )
 
 
 def does_database_exist(rds_client):
@@ -238,7 +245,7 @@ def get_cluster_private_subnet_ids(eks_client, ec2_client):
     private_subnets = []
     for subnet in subnets:
         for tags in subnet["Tags"]:
-            # eksctl generated clusters       
+            # eksctl generated clusters
             if "SubnetPrivate" in tags["Value"]:
                 private_subnets.append(subnet)
             # cdk generated clusters
@@ -395,56 +402,75 @@ def setup_secrets_provider():
 
 def install_secrets_store_csi_driver():
     kubectl_apply(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/rbac-secretproviderclass.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/rbac-secretproviderclass.yaml"
     )
     kubectl_apply(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/csidriver.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/csidriver.yaml"
     )
     kubectl_apply(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml"
     )
     kubectl_apply(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml"
     )
     kubectl_apply(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store-csi-driver.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store-csi-driver.yaml"
     )
     kubectl_apply(
-        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/rbac-secretprovidersyncing.yaml"
+        "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/rbac-secretprovidersyncing.yaml"
     )
     kubectl_apply(
         "https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml"
     )
 
-#TO DO: decouple kustomize params.env and helm values.yaml write up in future
+
+# TO DO: decouple kustomize params.env and helm values.yaml write up in future
 def setup_kubeflow_pipeline():
     print("Setting up Kubeflow Pipeline...")
 
     print("Retrieving DB instance info...")
     db_instance_info = get_db_instance_info()
-    
-    #helm
-    #pipelines helm path
-    pipeline_rds_s3_helm_path = path_dic_rds_s3["kubeflow-pipelines"]["installation_options"]["helm"]["paths"]
-    pipeline_rds_only_helm_path = path_dic_rds_only["kubeflow-pipelines"]["installation_options"]["helm"]["paths"]
-    pipeline_s3_only_helm_path = path_dic_s3_only["kubeflow-pipelines"]["installation_options"]["helm"]["paths"]
-    
-    #secrets-manager helm path
-    secrets_manager_rds_s3_helm_path = path_dic_rds_s3["aws-secrets-manager"]["installation_options"]["helm"]["paths"]
-    secrets_manager_rds_only_helm_path = path_dic_rds_only["aws-secrets-manager"]["installation_options"]["helm"]["paths"]
-    secrets_manager_s3_only_helm_path = path_dic_s3_only["aws-secrets-manager"]["installation_options"]["helm"]["paths"]
 
-    #pipelines values file
-    pipeline_rds_s3_values_file = f"{pipeline_rds_s3_helm_path}/values.yaml" 
-    pipeline_rds_only_values_file = f"{pipeline_rds_only_helm_path}/values.yaml" 
-    pipeline_s3_only_values_file = f"{pipeline_s3_only_helm_path}/values.yaml" 
-    
-    #secrets-manager values file
-    secrets_manager_rds_s3_values_file = f"{secrets_manager_rds_s3_helm_path}/values.yaml" 
-    secrets_manager_rds_only_values_file = f"{secrets_manager_rds_only_helm_path}/values.yaml" 
-    secrets_manager_s3_only_values_file = f"{secrets_manager_s3_only_helm_path}/values.yaml" 
-    
-    #kustomize params
+    # helm
+    # pipelines helm path
+    pipeline_rds_s3_helm_path = path_dic_rds_s3["kubeflow-pipelines"][
+        "installation_options"
+    ]["helm"]["paths"]
+    pipeline_rds_only_helm_path = path_dic_rds_only["kubeflow-pipelines"][
+        "installation_options"
+    ]["helm"]["paths"]
+    pipeline_s3_only_helm_path = path_dic_s3_only["kubeflow-pipelines"][
+        "installation_options"
+    ]["helm"]["paths"]
+
+    # secrets-manager helm path
+    secrets_manager_rds_s3_helm_path = path_dic_rds_s3["aws-secrets-manager"][
+        "installation_options"
+    ]["helm"]["paths"]
+    secrets_manager_rds_only_helm_path = path_dic_rds_only["aws-secrets-manager"][
+        "installation_options"
+    ]["helm"]["paths"]
+    secrets_manager_s3_only_helm_path = path_dic_s3_only["aws-secrets-manager"][
+        "installation_options"
+    ]["helm"]["paths"]
+
+    # pipelines values file
+    pipeline_rds_s3_values_file = f"{pipeline_rds_s3_helm_path}/values.yaml"
+    pipeline_rds_only_values_file = f"{pipeline_rds_only_helm_path}/values.yaml"
+    pipeline_s3_only_values_file = f"{pipeline_s3_only_helm_path}/values.yaml"
+
+    # secrets-manager values file
+    secrets_manager_rds_s3_values_file = (
+        f"{secrets_manager_rds_s3_helm_path}/values.yaml"
+    )
+    secrets_manager_rds_only_values_file = (
+        f"{secrets_manager_rds_only_helm_path}/values.yaml"
+    )
+    secrets_manager_s3_only_values_file = (
+        f"{secrets_manager_s3_only_helm_path}/values.yaml"
+    )
+
+    # kustomize params
     pipeline_rds_params_env_file = "../../awsconfigs/apps/pipeline/rds/params.env"
     pipeline_rds_secret_provider_class_file = (
         "../../awsconfigs/common/aws-secrets-manager/rds/secret-provider.yaml"
@@ -454,14 +480,16 @@ def setup_kubeflow_pipeline():
         "dbHost": db_instance_info["Endpoint"]["Address"],
         "mlmdDb": "metadb",
     }
-    rds_secret_params = {
-        "secretName": RDS_SECRET_NAME
-    }
+    rds_secret_params = {"secretName": RDS_SECRET_NAME}
     edit_pipeline_params_env_file(rds_params, pipeline_rds_params_env_file)
     write_env_to_yaml(rds_params, pipeline_rds_s3_values_file, module="rds")
     write_env_to_yaml(rds_params, pipeline_rds_only_values_file, module="rds")
-    write_env_to_yaml(rds_secret_params, secrets_manager_rds_s3_values_file, module="rds")
-    write_env_to_yaml(rds_secret_params, secrets_manager_rds_only_values_file, module="rds")
+    write_env_to_yaml(
+        rds_secret_params, secrets_manager_rds_s3_values_file, module="rds"
+    )
+    write_env_to_yaml(
+        rds_secret_params, secrets_manager_rds_only_values_file, module="rds"
+    )
     update_secret_provider_class(
         pipeline_rds_secret_provider_class_file, RDS_SECRET_NAME
     )
@@ -476,14 +504,14 @@ def setup_kubeflow_pipeline():
         "minioServiceRegion": CLUSTER_REGION,
         "minioServiceHost": "s3.amazonaws.com",
     }
-    s3_secret_params = {
-        "secretName": S3_SECRET_NAME
-    }
+    s3_secret_params = {"secretName": S3_SECRET_NAME}
     edit_pipeline_params_env_file(s3_params, pipeline_s3_params_env_file)
     write_env_to_yaml(s3_params, pipeline_rds_s3_values_file, module="s3")
     write_env_to_yaml(s3_params, pipeline_s3_only_values_file, module="s3")
     write_env_to_yaml(s3_secret_params, secrets_manager_rds_s3_values_file, module="s3")
-    write_env_to_yaml(s3_secret_params, secrets_manager_s3_only_values_file, module="s3")
+    write_env_to_yaml(
+        s3_secret_params, secrets_manager_s3_only_values_file, module="s3"
+    )
     update_secret_provider_class(pipeline_s3_secret_provider_class_file, S3_SECRET_NAME)
 
     print("Kubeflow pipeline setup done!")

--- a/website/content/en/docs/deployment/rds-s3/guide.md
+++ b/website/content/en/docs/deployment/rds-s3/guide.md
@@ -188,12 +188,12 @@ yq e '.s3.secretName = env(S3_SECRET)' -i charts/common/aws-secrets-manager/rds-
    2. Run the following commands to install AWS Secrets & Configuration Provider with Kubernetes Secrets Store CSI driver:
 
    ```bash
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/rbac-secretproviderclass.yaml
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/csidriver.yaml
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/secrets-store-csi-driver.yaml
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.0.0/deploy/rbac-secretprovidersyncing.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/rbac-secretproviderclass.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/csidriver.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/secrets-store-csi-driver.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/v1.3.2/deploy/rbac-secretprovidersyncing.yaml
     kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml
    ```
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

Note: As a result of the depreciation of k8s.gcr.io, images have moved to registry.k8s.io.  This only effects csi-secrets-driver for those who have installed either RDS-S3/Cognito-RDS-S3. To update your pulled image source run the following kubectl commands

```
kubectl set image daemonset/csi-secrets-store node-driver-registrar=registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0 -n kube-system
kubectl set image daemonset/csi-secrets-store secrets-store=registry.k8s.io/csi-secrets-store/driver:v1.0.0-rc.1 -n kube-system
kubectl set image daemonset/csi-secrets-store liveness-probe=registry.k8s.io/sig-storage/livenessprobe:v2.4.0 -n kube-system
```

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.