### PR TITLE
Remove Empty Credential Strings in Kserve IRSA configuration

### DIFF
--- a/tests/e2e/fixtures/kserve_dependencies.py
+++ b/tests/e2e/fixtures/kserve_dependencies.py
@@ -81,8 +81,8 @@ def kserve_iam_service_account(metadata, cluster, region, request):
 
 @pytest.fixture(scope="class")
 def s3_bucket_with_data_kserve(metadata, kserve_secret, request):
-    metadata_key = "s3-bucket"
-    bucket_name = "s3-kserve-" + RANDOM_PREFIX
+    metadata_key = "s3-bucket-kserve"
+    bucket_name = "s3-" + RANDOM_PREFIX
     bucket = S3BucketWithTrainingData(
         name=bucket_name,
         time_to_sleep=60,
@@ -156,7 +156,7 @@ def kserve_inference_service(
         print("creating allow-predictor-transformer AuthorizationPolicy...")
         kubectl_apply(AUTHORIZATION_POLICY_CONFIG_FILE)
         print("creating inference service...")
-        bucket_name = metadata.get("s3-bucket")
+        bucket_name = metadata.get("s3-bucket-kserve")
 
         inference_config = load_yaml_file(INFERENCE_CONFIG_FILE)
         inference_config["spec"]["predictor"]["model"][

--- a/tests/e2e/fixtures/kserve_dependencies.py
+++ b/tests/e2e/fixtures/kserve_dependencies.py
@@ -80,9 +80,9 @@ def kserve_iam_service_account(metadata, cluster, region, request):
 
 
 @pytest.fixture(scope="class")
-def s3_bucket_with_data(metadata, kserve_secret, request):
+def s3_bucket_with_data_kserve(metadata, kserve_secret, request):
     metadata_key = "s3-bucket"
-    bucket_name = "s3-" + RANDOM_PREFIX
+    bucket_name = "s3-kserve-" + RANDOM_PREFIX
     bucket = S3BucketWithTrainingData(
         name=bucket_name,
         time_to_sleep=60,
@@ -138,7 +138,7 @@ def kserve_secret(metadata, region, kserve_iam_service_account, request):
 def kserve_inference_service(
     metadata,
     kserve_iam_service_account,
-    s3_bucket_with_data,
+    s3_bucket_with_data_kserve,
     kserve_secret,
     cluster,
     region,

--- a/tests/e2e/resources/kserve/kserve-secret.yaml
+++ b/tests/e2e/resources/kserve/kserve-secret.yaml
@@ -1,7 +1,4 @@
 apiVersion: v1
-data:
-  AWS_ACCESS_KEY_ID: ''
-  AWS_SECRET_ACCESS_KEY: ''
 kind: Secret
 metadata:
   annotations:

--- a/tests/e2e/tests/test_sanity.py
+++ b/tests/e2e/tests/test_sanity.py
@@ -65,7 +65,7 @@ from e2e.fixtures.kserve_dependencies import (
     kserve_iam_service_account,
     kserve_secret,
     clone_tensorflow_serving,
-    s3_bucket_with_data,
+    s3_bucket_with_data_kserve,
     kserve_inference_service,
 )
 
@@ -235,8 +235,8 @@ def port_forward(installation):
     pass
 
 @pytest.fixture(scope="class")
-def s3_bucket_with_data(region):
-    bucket_name = "s3-" + RANDOM_PREFIX
+def s3_bucket_with_data_sagemaker(region):
+    bucket_name = "s3-sagemaker-" + RANDOM_PREFIX
     bucket = S3BucketWithTrainingData(name=bucket_name, cmd=f"python utils/s3_for_training/sync.py {bucket_name} {region}",
                                        time_to_sleep=120)
     bucket.create()
@@ -355,7 +355,7 @@ class TestSanity:
         clone_tensorflow_serving,
         kserve_iam_service_account,
         kserve_secret,
-        s3_bucket_with_data,
+        s3_bucket_with_data_kserve,
         kserve_inference_service,
     ):
         # Edit the ConfigMap to change the default domain as per your deployment
@@ -401,7 +401,7 @@ class TestSanity:
         assert retcode == 0
 
     def test_run_kfp_sagemaker_pipeline(
-        self, region, metadata, s3_bucket_with_data, sagemaker_execution_role, kfp_client, clean_up_training_jobs_in_user_ns
+        self, region, metadata, s3_bucket_with_data_sagemaker, sagemaker_execution_role, kfp_client, clean_up_training_jobs_in_user_ns
     ):
 
         experiment_name = "experiment-" + RANDOM_PREFIX

--- a/tests/e2e/tests/test_sanity.py
+++ b/tests/e2e/tests/test_sanity.py
@@ -236,9 +236,9 @@ def port_forward(installation):
 
 @pytest.fixture(scope="class")
 def s3_bucket_with_data_sagemaker(region):
-    bucket_name = "s3-sagemaker-" + RANDOM_PREFIX
+    bucket_name = "s3-" + RANDOM_PREFIX
     bucket = S3BucketWithTrainingData(name=bucket_name, cmd=f"python utils/s3_for_training/sync.py {bucket_name} {region}",
-                                       time_to_sleep=120)
+                                       time_to_sleep=180)
     bucket.create()
 
     yield

--- a/website/content/en/docs/component-guides/kserve/access-aws-services-from-kserve.md
+++ b/website/content/en/docs/component-guides/kserve/access-aws-services-from-kserve.md
@@ -25,7 +25,7 @@ weight = 10
      > NOTE: You can use ECR (`AmazonEC2ContainerRegistryReadOnly`) and S3 (`AmazonS3ReadOnlyAccess`) ReadOnly managed policies. We recommend creating fine grained policy for production usecase. 
 
 ### Deploy models from S3 Bucket 
-1. Create Secret with empty AWS Credential:
+1. Create Secret:
   ```sh
   cat <<EOF > secret.yaml
   apiVersion: v1
@@ -38,14 +38,10 @@ weight = 10
           serving.kserve.io/s3-usehttps: "1"
           serving.kserve.io/s3-region: ${CLUSTER_REGION}
       type: Opaque
-      data:
-        AWS_ACCESS_KEY_ID: ""
-        AWS_SECRET_ACCESS_KEY: ""
   EOF
 
   kubectl apply -f secret.yaml
   ```
-  > NOTE: The **empty** keys for `AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY` force it to add the env vars to the init containers but don't override the actual credentials from the IAM role (which happens if you add dummy values). These **empty** keys are needed for IRSA to work in current version and will not be needed in future release.
 
 1. Attach secret to IRSA in your profile namespace:
     ```


### PR DESCRIPTION
- remove empty credential string in Secret for Kserve IRSA configuration as it's no longer needed
- separate s3 bucket for kserve and s3 bucket for sagemaker 

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.