### PR TITLE
Update Terraform tagging and helm versions

### DIFF
--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
@@ -134,6 +134,7 @@ module "rds" {
   publicly_accessible            = var.publicly_accessible
   multi_az                       = var.multi_az
   secret_recovery_window_in_days = var.secret_recovery_window_in_days
+  tags                           = var.tags
 }
 
 module "s3" {
@@ -143,6 +144,7 @@ module "s3" {
   minio_aws_access_key_id        = var.minio_aws_access_key_id
   minio_aws_secret_access_key    = var.minio_aws_secret_access_key
   secret_recovery_window_in_days = var.secret_recovery_window_in_days
+  tags                           = var.tags
 }
 
 module "subdomain" {
@@ -150,6 +152,7 @@ module "subdomain" {
   source                          = "../../../../iaac/terraform/aws-infra/subdomain"
   aws_route53_root_zone_name      = var.aws_route53_root_zone_name
   aws_route53_subdomain_zone_name = var.aws_route53_subdomain_zone_name
+  tags                            = var.tags
 }
 
 module "cognito" {
@@ -157,6 +160,7 @@ module "cognito" {
   source                          = "../../../../iaac/terraform/aws-infra/cognito"
   cognito_user_pool_name          = var.cognito_user_pool_name
   aws_route53_subdomain_zone_name = var.aws_route53_subdomain_zone_name
+  tags                            = var.tags
 
   providers = {
     aws          = aws
@@ -234,6 +238,7 @@ module "ingress_cognito" {
   cognito_app_client_id           = module.cognito[0].app_client_id
   cognito_user_pool_domain        = module.cognito[0].user_pool_domain
   load_balancer_scheme            = var.load_balancer_scheme
+  tags                            = var.tags
 
   depends_on = [module.kubeflow_istio, module.cognito]
 }

--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/variables.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/variables.tf
@@ -228,3 +228,9 @@ variable "notebook_idleness_check_period" {
   type        = string
   default     = 5
 }
+
+variable "tags" {
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  type        = map(string)
+  default     = {}
+}

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -20,7 +20,7 @@ locals {
     Blueprint       = local.cluster_name
     GithubRepo      = "github.com/awslabs/kubeflow-manifests"
     Platform        = "kubeflow-on-aws"
-    KubeflowVersion = "1.6"
+    KubeflowVersion = "1.7"
   }
 
   kf_helm_repo_path = var.kf_helm_repo_path
@@ -248,6 +248,8 @@ module "kubeflow_components" {
   create_subdomain                = var.create_subdomain
   cognito_user_pool_name          = var.cognito_user_pool_name
   load_balancer_scheme            = var.load_balancer_scheme
+
+  tags                = local.tags
 
   providers = {
     aws          = aws

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -17,8 +17,6 @@ locals {
   azs      = slice(local.available_azs, 0, local.az_count)
 
   tags = {
-    Blueprint       = local.cluster_name
-    GithubRepo      = "github.com/awslabs/kubeflow-manifests"
     Platform        = "kubeflow-on-aws"
     KubeflowVersion = "1.7"
   }

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -148,23 +148,23 @@ module "eks_blueprints_kubernetes_addons" {
 
   aws_efs_csi_driver_helm_config = {
     namespace = "kube-system"
-    version = "2.4.1"
+    version   = "2.4.1"
   }
 
-  enable_aws_efs_csi_driver           = true
+  enable_aws_efs_csi_driver = true
 
   aws_fsx_csi_driver_helm_config = {
     namespace = "kube-system"
-    version = "1.5.1"
+    version   = "1.5.1"
   }
 
-  enable_aws_fsx_csi_driver           = true
+  enable_aws_fsx_csi_driver = true
 
   enable_nvidia_device_plugin = local.using_gpu
 
   secrets_store_csi_driver_helm_config = {
     namespace = "kube-system"
-    version = "1.3.2"
+    version   = "1.3.2"
     set = [
       {
         name  = "syncSecret.enabled",
@@ -249,7 +249,7 @@ module "kubeflow_components" {
   cognito_user_pool_name          = var.cognito_user_pool_name
   load_balancer_scheme            = var.load_balancer_scheme
 
-  tags                = local.tags
+  tags = local.tags
 
   providers = {
     aws          = aws

--- a/deployments/cognito/terraform/cognito-components/main.tf
+++ b/deployments/cognito/terraform/cognito-components/main.tf
@@ -22,12 +22,14 @@ module "subdomain" {
   source                          = "../../../../iaac/terraform/aws-infra/subdomain"
   aws_route53_root_zone_name      = var.aws_route53_root_zone_name
   aws_route53_subdomain_zone_name = var.aws_route53_subdomain_zone_name
+  tags                            = var.tags
 }
 
 module "cognito" {
   source                          = "../../../../iaac/terraform/aws-infra/cognito"
   cognito_user_pool_name          = var.cognito_user_pool_name
   aws_route53_subdomain_zone_name = var.aws_route53_subdomain_zone_name
+  tags                            = var.tags
 
   providers = {
     aws          = aws

--- a/deployments/cognito/terraform/cognito-components/variables.tf
+++ b/deployments/cognito/terraform/cognito-components/variables.tf
@@ -70,3 +70,9 @@ variable "notebook_idleness_check_period" {
   type        = string
   default     = 5
 }
+
+variable "tags" {
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  type        = map(string)
+  default     = {}
+}

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -149,17 +149,17 @@ module "eks_blueprints_kubernetes_addons" {
 
   aws_efs_csi_driver_helm_config = {
     namespace = "kube-system"
-    version = "2.4.1"
+    version   = "2.4.1"
   }
 
-  enable_aws_efs_csi_driver           = true
+  enable_aws_efs_csi_driver = true
 
   aws_fsx_csi_driver_helm_config = {
     namespace = "kube-system"
-    version = "1.5.1"
+    version   = "1.5.1"
   }
 
-  enable_aws_fsx_csi_driver           = true
+  enable_aws_fsx_csi_driver = true
 
   enable_nvidia_device_plugin = local.using_gpu
 
@@ -196,7 +196,7 @@ module "kubeflow_components" {
   cognito_user_pool_name          = var.cognito_user_pool_name
   load_balancer_scheme            = var.load_balancer_scheme
 
-  tags                = local.tags
+  tags = local.tags
 
   providers = {
     aws          = aws

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -20,7 +20,7 @@ locals {
     Blueprint       = local.cluster_name
     GithubRepo      = "github.com/awslabs/kubeflow-manifests"
     Platform        = "kubeflow-on-aws"
-    KubeflowVersion = "1.6"
+    KubeflowVersion = "1.7"
   }
 
   kf_helm_repo_path = var.kf_helm_repo_path
@@ -195,6 +195,8 @@ module "kubeflow_components" {
   create_subdomain                = var.create_subdomain
   cognito_user_pool_name          = var.cognito_user_pool_name
   load_balancer_scheme            = var.load_balancer_scheme
+
+  tags                = local.tags
 
   providers = {
     aws          = aws

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -17,8 +17,6 @@ locals {
   azs      = slice(local.available_azs, 0, local.az_count)
 
   tags = {
-    Blueprint       = local.cluster_name
-    GithubRepo      = "github.com/awslabs/kubeflow-manifests"
     Platform        = "kubeflow-on-aws"
     KubeflowVersion = "1.7"
   }

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -20,7 +20,7 @@ locals {
     Blueprint       = local.cluster_name
     GithubRepo      = "github.com/awslabs/kubeflow-manifests"
     Platform        = "kubeflow-on-aws"
-    KubeflowVersion = "1.6"
+    KubeflowVersion = "1.7"
   }
 
   kf_helm_repo_path = var.kf_helm_repo_path
@@ -234,6 +234,7 @@ module "kubeflow_components" {
   minio_aws_access_key_id     = var.minio_aws_access_key_id
   minio_aws_secret_access_key = var.minio_aws_secret_access_key
 
+  tags                = local.tags
 }
 
 #---------------------------------------------------------------

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -141,23 +141,23 @@ module "eks_blueprints_kubernetes_addons" {
 
   aws_efs_csi_driver_helm_config = {
     namespace = "kube-system"
-    version = "2.4.1"
+    version   = "2.4.1"
   }
-  
-  enable_aws_efs_csi_driver           = true
+
+  enable_aws_efs_csi_driver = true
 
   aws_fsx_csi_driver_helm_config = {
     namespace = "kube-system"
-    version = "1.5.1"
+    version   = "1.5.1"
   }
-  
-  enable_aws_fsx_csi_driver           = true
+
+  enable_aws_fsx_csi_driver = true
 
   enable_nvidia_device_plugin = local.using_gpu
 
   secrets_store_csi_driver_helm_config = {
     namespace = "kube-system"
-    version = "1.3.2"
+    version   = "1.3.2"
     set = [
       {
         name  = "syncSecret.enabled",
@@ -234,7 +234,7 @@ module "kubeflow_components" {
   minio_aws_access_key_id     = var.minio_aws_access_key_id
   minio_aws_secret_access_key = var.minio_aws_secret_access_key
 
-  tags                = local.tags
+  tags = local.tags
 }
 
 #---------------------------------------------------------------

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -17,8 +17,6 @@ locals {
   azs      = slice(local.available_azs, 0, local.az_count)
 
   tags = {
-    Blueprint       = local.cluster_name
-    GithubRepo      = "github.com/awslabs/kubeflow-manifests"
     Platform        = "kubeflow-on-aws"
     KubeflowVersion = "1.7"
   }

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -127,6 +127,7 @@ module "rds" {
   publicly_accessible            = var.publicly_accessible
   multi_az                       = var.multi_az
   secret_recovery_window_in_days = var.secret_recovery_window_in_days
+  tags                           = var.tags
 }
 
 module "s3" {
@@ -136,6 +137,7 @@ module "s3" {
   minio_aws_access_key_id        = var.minio_aws_access_key_id
   minio_aws_secret_access_key    = var.minio_aws_secret_access_key
   secret_recovery_window_in_days = var.secret_recovery_window_in_days
+  tags                           = var.tags
 }
 
 module "filter_secrets_manager_set_values" {

--- a/deployments/rds-s3/terraform/rds-s3-components/variables.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/variables.tf
@@ -190,3 +190,9 @@ variable "notebook_idleness_check_period" {
   type        = string
   default     = 5
 }
+
+variable "tags" {
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  type        = map(string)
+  default     = {}
+}

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -140,17 +140,17 @@ module "eks_blueprints_kubernetes_addons" {
 
   aws_efs_csi_driver_helm_config = {
     namespace = "kube-system"
-    version = "2.4.1"
+    version   = "2.4.1"
   }
 
-  enable_aws_efs_csi_driver           = true
+  enable_aws_efs_csi_driver = true
 
   aws_fsx_csi_driver_helm_config = {
     namespace = "kube-system"
-    version = "1.5.1"
+    version   = "1.5.1"
   }
 
-  enable_aws_fsx_csi_driver           = true
+  enable_aws_fsx_csi_driver = true
 
   enable_nvidia_device_plugin = local.using_gpu
 
@@ -181,7 +181,7 @@ module "kubeflow_components" {
   notebook_cull_idle_time        = var.notebook_cull_idle_time
   notebook_idleness_check_period = var.notebook_idleness_check_period
 
-  tags                = local.tags
+  tags = local.tags
 }
 
 #---------------------------------------------------------------

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -20,7 +20,7 @@ locals {
     Blueprint       = local.cluster_name
     GithubRepo      = "github.com/awslabs/kubeflow-manifests"
     Platform        = "kubeflow-on-aws"
-    KubeflowVersion = "1.6"
+    KubeflowVersion = "1.7"
   }
 
   kf_helm_repo_path = var.kf_helm_repo_path
@@ -180,6 +180,8 @@ module "kubeflow_components" {
   notebook_enable_culling        = var.notebook_enable_culling
   notebook_cull_idle_time        = var.notebook_cull_idle_time
   notebook_idleness_check_period = var.notebook_idleness_check_period
+
+  tags                = local.tags
 }
 
 #---------------------------------------------------------------

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -17,8 +17,6 @@ locals {
   azs      = slice(local.available_azs, 0, local.az_count)
 
   tags = {
-    Blueprint       = local.cluster_name
-    GithubRepo      = "github.com/awslabs/kubeflow-manifests"
     Platform        = "kubeflow-on-aws"
     KubeflowVersion = "1.7"
   }

--- a/deployments/vanilla/terraform/vanilla-components/variables.tf
+++ b/deployments/vanilla/terraform/vanilla-components/variables.tf
@@ -43,3 +43,9 @@ variable "notebook_idleness_check_period" {
   type        = string
   default     = 5
 }
+
+variable "tags" {
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  type        = map(string)
+  default     = {}
+}

--- a/iaac/terraform/apps/admission-webhook/locals.tf
+++ b/iaac/terraform/apps/admission-webhook/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.1"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/apps/central-dashboard/locals.tf
+++ b/iaac/terraform/apps/central-dashboard/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.1"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/apps/jupyter-web-app/locals.tf
+++ b/iaac/terraform/apps/jupyter-web-app/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.1"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/apps/katib/locals.tf
+++ b/iaac/terraform/apps/katib/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/apps/kubeflow-pipelines/locals.tf
+++ b/iaac/terraform/apps/kubeflow-pipelines/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.1"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/apps/models-web-app/locals.tf
+++ b/iaac/terraform/apps/models-web-app/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/apps/notebook-controller/locals.tf
+++ b/iaac/terraform/apps/notebook-controller/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.1"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/apps/profiles-and-kfam/locals.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.1"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/apps/tensorboard-controller/locals.tf
+++ b/iaac/terraform/apps/tensorboard-controller/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.1"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/apps/tensorboards-web-app/locals.tf
+++ b/iaac/terraform/apps/tensorboards-web-app/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.1"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/apps/training-operator/locals.tf
+++ b/iaac/terraform/apps/training-operator/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/apps/volumes-web-app/locals.tf
+++ b/iaac/terraform/apps/volumes-web-app/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.1"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/aws-infra/cognito/custom_domain.tf
+++ b/iaac/terraform/aws-infra/cognito/custom_domain.tf
@@ -29,6 +29,7 @@ resource "aws_route53_record" "pre_cognito_domain_a_record" {
 resource "aws_acm_certificate" "cognito_domain_cert" {
   domain_name       = "*.${data.aws_route53_zone.platform.name}"
   validation_method = "DNS"
+  tags              = var.tags
 
   lifecycle {
     create_before_destroy = true

--- a/iaac/terraform/aws-infra/cognito/userpool.tf
+++ b/iaac/terraform/aws-infra/cognito/userpool.tf
@@ -17,4 +17,5 @@ resource "aws_cognito_user_pool" "platform" {
 
   auto_verified_attributes = ["email"]
 
+  tags = var.tags
 }

--- a/iaac/terraform/aws-infra/cognito/variables.tf
+++ b/iaac/terraform/aws-infra/cognito/variables.tf
@@ -7,3 +7,9 @@ variable "aws_route53_subdomain_zone_name" {
   description = "SUBDOMAIN Route 53 hosted zone name(e.g. platform.example.com) which will be used for Kubeflow Platform. Must match exactly one zone"
   type        = string
 }
+
+variable "tags" {
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  type        = map(string)
+  default     = {}
+}

--- a/iaac/terraform/aws-infra/rds/main.tf
+++ b/iaac/terraform/aws-infra/rds/main.tf
@@ -26,7 +26,7 @@ resource "aws_security_group" "public_access" {
 
 resource "aws_db_subnet_group" "rds_db_subnet_group" {
   subnet_ids = var.subnet_ids
-  tags = var.tags
+  tags       = var.tags
 }
 
 resource "random_uuid" "db_snapshot_suffix" {

--- a/iaac/terraform/aws-infra/rds/main.tf
+++ b/iaac/terraform/aws-infra/rds/main.tf
@@ -20,10 +20,13 @@ resource "aws_security_group" "public_access" {
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
+
+  tags = var.tags
 }
 
 resource "aws_db_subnet_group" "rds_db_subnet_group" {
   subnet_ids = var.subnet_ids
+  tags = var.tags
 }
 
 resource "random_uuid" "db_snapshot_suffix" {
@@ -55,11 +58,13 @@ resource "aws_db_instance" "kubeflow_db" {
   max_allocated_storage     = var.max_allocated_storage
   publicly_accessible       = var.publicly_accessible
   final_snapshot_identifier = "snp-${random_uuid.db_snapshot_suffix.result}"
+  tags                      = var.tags
 }
 
 resource "aws_secretsmanager_secret" "rds_secret" {
   name_prefix             = "rds-secret-"
   recovery_window_in_days = var.secret_recovery_window_in_days
+  tags                    = var.tags
 }
 
 resource "aws_secretsmanager_secret_version" "rds_secret_version" {

--- a/iaac/terraform/aws-infra/rds/variables.tf
+++ b/iaac/terraform/aws-infra/rds/variables.tf
@@ -88,3 +88,9 @@ variable "secret_recovery_window_in_days" {
   type    = number
   default = 7
 }
+
+variable "tags" {
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  type        = map(string)
+  default     = {}
+}

--- a/iaac/terraform/aws-infra/s3/main.tf
+++ b/iaac/terraform/aws-infra/s3/main.tf
@@ -4,6 +4,7 @@
 resource "aws_s3_bucket" "artifact_store" {
   bucket_prefix = "kf-artifact-store-"
   force_destroy = var.force_destroy_bucket
+  tags          = var.tags
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "artifact_store_encryption" {
@@ -19,6 +20,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "artifact_store_en
 resource "aws_secretsmanager_secret" "s3_secret" {
   name_prefix             = "s3-secret-"
   recovery_window_in_days = var.secret_recovery_window_in_days
+  tags                    = var.tags
 }
 
 resource "aws_secretsmanager_secret_version" "s3_secret_version" {

--- a/iaac/terraform/aws-infra/s3/variables.tf
+++ b/iaac/terraform/aws-infra/s3/variables.tf
@@ -18,3 +18,9 @@ variable "force_destroy_bucket" {
   description = "Destroys s3 bucket even when the bucket is not empty"
   default     = false
 }
+
+variable "tags" {
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  type        = map(string)
+  default     = {}
+}

--- a/iaac/terraform/aws-infra/subdomain/certificate.tf
+++ b/iaac/terraform/aws-infra/subdomain/certificate.tf
@@ -1,6 +1,7 @@
 resource "aws_acm_certificate" "root_domain_deployment_region" {
   domain_name       = "*.${data.aws_route53_zone.root.name}"
   validation_method = "DNS"
+  tags              = var.tags
 
   lifecycle {
     create_before_destroy = true

--- a/iaac/terraform/aws-infra/subdomain/variables.tf
+++ b/iaac/terraform/aws-infra/subdomain/variables.tf
@@ -7,3 +7,9 @@ variable "aws_route53_subdomain_zone_name" {
   description = "SUBDOMAIN Route 53 hosted zone name(e.g. platform.example.com) which will be created for Kubeflow Platform"
   type        = string
 }
+
+variable "tags" {
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  type        = map(string)
+  default     = {}
+}

--- a/iaac/terraform/common/aws-authservice/locals.tf
+++ b/iaac/terraform/common/aws-authservice/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/aws-secrets-manager/locals.tf
+++ b/iaac/terraform/common/aws-secrets-manager/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created in
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/aws-telemetry/locals.tf
+++ b/iaac/terraform/common/aws-telemetry/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/cluster-local-gateway/locals.tf
+++ b/iaac/terraform/common/cluster-local-gateway/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/dex/locals.tf
+++ b/iaac/terraform/common/dex/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/ingress/cognito/main.tf
+++ b/iaac/terraform/common/ingress/cognito/main.tf
@@ -5,6 +5,7 @@ data "aws_route53_zone" "platform" {
 resource "aws_acm_certificate" "deployment_region" {
   domain_name       = "*.${data.aws_route53_zone.platform.name}"
   validation_method = "DNS"
+  tags              = var.tags
 
   lifecycle {
     create_before_destroy = true
@@ -46,6 +47,7 @@ resource "kubernetes_ingress_v1" "istio_ingress" {
       "alb.ingress.kubernetes.io/target-type" : "ip",
       "alb.ingress.kubernetes.io/load-balancer-attributes" : "routing.http.drop_invalid_header_fields.enabled=true",
       "alb.ingress.kubernetes.io/scheme" : "${var.load_balancer_scheme}"
+      "alb.ingress.kubernetes.io/tags" : trim(trimspace(replace(replace(jsonencode(var.tags), "\"", ""), ":", "=")), "{}")
     }
     name      = "istio-ingress"
     namespace = "istio-system"

--- a/iaac/terraform/common/ingress/cognito/variables.tf
+++ b/iaac/terraform/common/ingress/cognito/variables.tf
@@ -28,3 +28,9 @@ variable "load_balancer_scheme" {
   type        = string
   default     = "internet-facing"
 }
+
+variable "tags" {
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  type        = map(string)
+  default     = {}
+}

--- a/iaac/terraform/common/istio/locals.tf
+++ b/iaac/terraform/common/istio/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.1"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/knative-eventing/locals.tf
+++ b/iaac/terraform/common/knative-eventing/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/knative-serving/locals.tf
+++ b/iaac/terraform/common/knative-serving/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/kserve/locals.tf
+++ b/iaac/terraform/common/kserve/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/kubeflow-issuer/locals.tf
+++ b/iaac/terraform/common/kubeflow-issuer/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/kubeflow-istio-resources/locals.tf
+++ b/iaac/terraform/common/kubeflow-istio-resources/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/kubeflow-roles/locals.tf
+++ b/iaac/terraform/common/kubeflow-roles/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/oidc-authservice/locals.tf
+++ b/iaac/terraform/common/oidc-authservice/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"

--- a/iaac/terraform/common/user-namespace/locals.tf
+++ b/iaac/terraform/common/user-namespace/locals.tf
@@ -3,7 +3,6 @@ locals {
 
   default_helm_config = {
     name      = local.name
-    version   = "0.1.0"
     namespace = "default" # change to namespace resources are being created it
     values    = []
     timeout   = "600"


### PR DESCRIPTION
**Description of your changes:**
- Updated tag KubeflowVersion = "1.6" --> 1.7
- Added Platform = "kubeflow-on-aws" tag on all resources
- Removed helm version in iaac/terraform since we are using a local helm chart path

**Testing:**

Deployed vanilla, cognito, cognito-rds-s3, rds-s3 Terraform stacks

<img width="1021" alt="Screen Shot 2023-04-18 at 2 52 57 PM" src="https://user-images.githubusercontent.com/91350438/232913515-3ae7493b-485c-4ba9-87ad-8cd422bccce2.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.