### PR TITLE
Update TF S3 backend guide

### DIFF
--- a/website/content/en/docs/deployment/cognito-rds-s3/guide-terraform.md
+++ b/website/content/en/docs/deployment/cognito-rds-s3/guide-terraform.md
@@ -105,6 +105,9 @@ pwd
 ### (Optional) Configure Culling for Notebooks
 Enable culling for notebooks by following the [instructions]({{< ref "/docs/deployment/configure-notebook-culling.md#" >}}) in configure culling for notebooks guide.
 
+### (Optional) Configure AWS S3 to backup Terraform state
+Enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
+
 ### View all Configurations
 
 View [all possible configuration options of the terraform stack](https://github.com/awslabs/kubeflow-manifests/blob/main/deployments/cognito-rds-s3/terraform/variables.tf) in the `variables.tf` file.

--- a/website/content/en/docs/deployment/cognito-rds-s3/guide-terraform.md
+++ b/website/content/en/docs/deployment/cognito-rds-s3/guide-terraform.md
@@ -105,8 +105,8 @@ pwd
 ### (Optional) Configure Culling for Notebooks
 Enable culling for notebooks by following the [instructions]({{< ref "/docs/deployment/configure-notebook-culling.md#" >}}) in configure culling for notebooks guide.
 
-### (Optional) Configure AWS S3 to backup Terraform state
-Enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
+### (Recommended) Configure AWS S3 to backup Terraform state
+Optionally enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
 
 ### View all Configurations
 

--- a/website/content/en/docs/deployment/cognito/guide-terraform.md
+++ b/website/content/en/docs/deployment/cognito/guide-terraform.md
@@ -83,8 +83,8 @@ pwd
 ### (Optional) Configure Culling for Notebooks
 Enable culling for notebooks by following the [instructions]({{< ref "/docs/deployment/configure-notebook-culling.md#" >}}) in configure culling for notebooks guide.
 
-### (Optional) Configure AWS S3 to backup Terraform state
-Enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
+### (Recommended) Configure AWS S3 to backup Terraform state
+Optionally enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
 
 ### View all configurations
 

--- a/website/content/en/docs/deployment/cognito/guide-terraform.md
+++ b/website/content/en/docs/deployment/cognito/guide-terraform.md
@@ -83,6 +83,9 @@ pwd
 ### (Optional) Configure Culling for Notebooks
 Enable culling for notebooks by following the [instructions]({{< ref "/docs/deployment/configure-notebook-culling.md#" >}}) in configure culling for notebooks guide.
 
+### (Optional) Configure AWS S3 to backup Terraform state
+Enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
+
 ### View all configurations
 
 View [all possible configuration options of the terraform stack](https://github.com/awslabs/kubeflow-manifests/blob/main/deployments/cognito/terraform/variables.tf) in the `variables.tf` file.

--- a/website/content/en/docs/deployment/rds-s3/guide-terraform.md
+++ b/website/content/en/docs/deployment/rds-s3/guide-terraform.md
@@ -80,6 +80,9 @@ pwd
 ### (Optional) Configure Culling for Notebooks
 Enable culling for notebooks by following the [instructions]({{< ref "/docs/deployment/configure-notebook-culling.md#" >}}) in configure culling for notebooks guide.
 
+### (Optional) Configure AWS S3 to backup Terraform state
+Enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
+
 ### All Configurations
 
 A full list of inputs for the terraform stack can be found [here](https://github.com/awslabs/kubeflow-manifests/blob/main/deployments/rds-s3/terraform/variables.tf).

--- a/website/content/en/docs/deployment/rds-s3/guide-terraform.md
+++ b/website/content/en/docs/deployment/rds-s3/guide-terraform.md
@@ -80,8 +80,8 @@ pwd
 ### (Optional) Configure Culling for Notebooks
 Enable culling for notebooks by following the [instructions]({{< ref "/docs/deployment/configure-notebook-culling.md#" >}}) in configure culling for notebooks guide.
 
-### (Optional) Configure AWS S3 to backup Terraform state
-Enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
+### (Recommended) Configure AWS S3 to backup Terraform state
+Optionally enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
 
 ### All Configurations
 

--- a/website/content/en/docs/deployment/terraform-s3-backend.md
+++ b/website/content/en/docs/deployment/terraform-s3-backend.md
@@ -7,11 +7,9 @@ weight = 70
 ## Local vs. Remote state
 
 While Terraform manages the state of resources it has created through a `terraform.tfstate` file, by default this file only exists locally.
-
 This means that you will need to manually copy over the original `terraform.tfstate` file when managing previously created resources on a different host. Without having a local copy of the `terraform.tfstate` file, Terraform will attempt to recreate all the existing resource since it does not know their current state.
 
 Having multiple copies of the same `terraform.tfstate` can become difficult to manage and keep in sync between different hosts and users.
-
 Instead, by using a remote backend, such as AWS S3, state is consolidated in one shared remote location and can be re-used between multiple hosts. Additionally, the state will not be lost if the local `terraform.tfstate` file was accidentally deleted.
 
 For additional details on using AWS S3 as a Terraform backend, refer to the following Terraform [documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3#s3).

--- a/website/content/en/docs/deployment/terraform-s3-backend.md
+++ b/website/content/en/docs/deployment/terraform-s3-backend.md
@@ -6,13 +6,21 @@ weight = 70
 
 ## Local vs. Remote state
 
-While Terraform manages the state of resources it has created through a `terraform.tfstate`, by default this file only exists locally.
-This means that you will need to manually copy over the original `terraform.tfstate` file when managing previously created resources on a different host. 
-This can become difficult to manage and keep in sync when multiple copies exist between different hosts and users.
+While Terraform manages the state of resources it has created through a `terraform.tfstate` file, by default this file only exists locally.
 
-By using a remote backend, such as AWS S3, state is consolidated in one shared remote location and can be re-used between multiple hosts. Additionally, the state will not be lost if the local `terraform.tfstate` file was accidentally deleted.
+This means that you will need to manually copy over the original `terraform.tfstate` file when managing previously created resources on a different host. Without having a local copy of the `terraform.tfstate` file, Terraform will attempt to recreate all the existing resource since it does not know their current state.
+
+Having multiple copies of the same `terraform.tfstate` can become difficult to manage and keep in sync between different hosts and users.
+
+Instead, by using a remote backend, such as AWS S3, state is consolidated in one shared remote location and can be re-used between multiple hosts. Additionally, the state will not be lost if the local `terraform.tfstate` file was accidentally deleted.
 
 For additional details on using AWS S3 as a Terraform backend, refer to the following Terraform [documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3#s3).
+
+> **Important**
+>
+> Required Terraform variables will still need to be provided as input when deploying even if a remote state file is being used.
+>
+> For example, a cluster name will still need to be provided through the TF_VAR_cluster_name or `.tfvar` file before deploying.
 
 
 ## Permissions
@@ -32,7 +40,12 @@ The permissions required by the Terraform user to use AWS S3 as a Terraform back
 
 1. Create the S3 bucket:
     ```sh
-    aws s3api create-bucket --bucket ${BUCKET_NAME} --region ${BUCKET_REGION}
+    if [[ $BUCKET_REGION == "us-east-1" ]]; then
+        aws s3api create-bucket --bucket ${S3_BUCKET_NAME} --region ${BUCKET_REGION}
+    else
+        aws s3api create-bucket --bucket ${S3_BUCKET_NAME} --region ${BUCKET_REGION} \
+        --create-bucket-configuration LocationConstraint=${BUCKET_REGION}
+    fi
     ```
 
 1. Go to the respective Terraform deployment folder. For example, if Vanilla kubeflow is being deployed:
@@ -55,7 +68,7 @@ The permissions required by the Terraform user to use AWS S3 as a Terraform back
 
 1. Deploy Terraform to apply the above configuration.
 
-## Restoring from a Terraform state backup
+## Re-using a Terraform state backup
 
 1. Find the name and region for the created bucket, as well as the path in the bucket for where the `tfstate` file is stored.
 

--- a/website/content/en/docs/deployment/terraform-s3-backend.md
+++ b/website/content/en/docs/deployment/terraform-s3-backend.md
@@ -53,7 +53,7 @@ The permissions required by the Terraform user to use AWS S3 as a Terraform back
     EOF
     ```
 
-1. The above configuration will be used the next time Terraform is deployed.
+1. Deploy Terraform to apply the above configuration.
 
 ## Restoring from a Terraform state backup
 
@@ -84,4 +84,4 @@ The permissions required by the Terraform user to use AWS S3 as a Terraform back
     EOF
     ```
 
-1. The above configuration will be used the next time Terraform is deployed.
+1. Deploy Terraform to apply the above configuration.

--- a/website/content/en/docs/deployment/terraform-s3-backend.md
+++ b/website/content/en/docs/deployment/terraform-s3-backend.md
@@ -1,5 +1,5 @@
 +++
-title = "Using AWS S3 as a backend for Terraform"
+title = "Configure AWS S3 as a backend for storing Terraform State"
 description = "Backup terraform state to AWS S3"
 weight = 70
 +++
@@ -19,6 +19,8 @@ For additional details on using AWS S3 as a Terraform backend, refer to the foll
 > Required Terraform variables will still need to be provided as input when deploying even if a remote state file is being used.
 >
 > For example, a cluster name will still need to be provided through the TF_VAR_cluster_name or `.tfvar` file before deploying.
+>
+> Make sure you provide your .tfvars file in the deployment folder and export all the TF_VAR variables when making changes to an existing deployment.
 
 
 ## Permissions
@@ -64,7 +66,7 @@ The permissions required by the Terraform user to use AWS S3 as a Terraform back
     EOF
     ```
 
-1. Deploy Terraform to apply the above configuration.
+1. If you were following a Terraform deployment guide, resume following the guide to deploy Terraform using the above configuration. Otherwise, follow the respective Terraform deployment guide for your deployment type to apply the above configuration and deploy.
 
 ## Re-using a Terraform state backup
 
@@ -95,4 +97,4 @@ The permissions required by the Terraform user to use AWS S3 as a Terraform back
     EOF
     ```
 
-1. Deploy Terraform to apply the above configuration.
+1. If you were following a Terraform deployment guide, resume following the guide to deploy Terraform using the above configuration. Otherwise, follow the respective Terraform deployment guide for your deployment type to apply the above configuration and deploy.

--- a/website/content/en/docs/deployment/vanilla/guide-terraform.md
+++ b/website/content/en/docs/deployment/vanilla/guide-terraform.md
@@ -57,8 +57,8 @@ pwd
 ### (Optional) Configure Culling for Notebooks
 Enable culling for notebooks by following the [instructions]({{< ref "/docs/deployment/configure-notebook-culling.md#" >}}) in configure culling for notebooks guide.
 
-### (Optional) Configure AWS S3 to backup Terraform state
-Enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
+### (Recommended) Configure AWS S3 to backup Terraform state
+Optionally enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
 
 ### All Configurations
 

--- a/website/content/en/docs/deployment/vanilla/guide-terraform.md
+++ b/website/content/en/docs/deployment/vanilla/guide-terraform.md
@@ -57,6 +57,9 @@ pwd
 ### (Optional) Configure Culling for Notebooks
 Enable culling for notebooks by following the [instructions]({{< ref "/docs/deployment/configure-notebook-culling.md#" >}}) in configure culling for notebooks guide.
 
+### (Optional) Configure AWS S3 to backup Terraform state
+Enable AWS S3 as a Terraform backend by following the instructions [here]({{< ref "/docs/deployment/terraform-s3-backend.md#" >}}).
+
 ### All Configurations
 
 A full list of inputs for the terraform stack can be found [here](https://github.com/awslabs/kubeflow-manifests/blob/main/deployments/vanilla/terraform/variables.tf).


### PR DESCRIPTION
Minor updates to docs:
- Add a link to configuring AWS S3 to backup `.tfstate` to Terraform deployment guides
- Minor rewording in guides

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.