### PR TITLE
Change use_static to pipeline_s3_credential_option

### DIFF
--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/variables.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/variables.tf
@@ -36,9 +36,15 @@ variable "use_s3" {
   default = true
 }
 
-variable "use_static" {
-  type    = bool
-  default = false
+variable "pipeline_s3_credential_option" {
+  description = "The credential type to use to authenticate KFP to use S3. One of [irsa, static]"
+  type        = string
+  default     = "irsa"
+
+  validation {
+    condition     = "irsa" == var.pipeline_s3_credential_option || "static" == var.pipeline_s3_credential_option
+    error_message = "The pipeline_s3_credential_option must be one of [irsa, static]"
+  }
 }
 
 variable "use_cognito" {

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -232,12 +232,12 @@ module "kubeflow_components" {
   generate_db_password           = var.generate_db_password
 
   # s3
-  use_s3                      = var.use_s3
-  use_static                  = var.use_static
-  minio_service_region        = var.minio_service_region
-  force_destroy_s3_bucket     = var.force_destroy_s3_bucket
-  minio_aws_access_key_id     = var.minio_aws_access_key_id
-  minio_aws_secret_access_key = var.minio_aws_secret_access_key
+  use_s3                        = var.use_s3
+  pipeline_s3_credential_option = var.pipeline_s3_credential_option
+  minio_service_region          = var.minio_service_region
+  force_destroy_s3_bucket       = var.force_destroy_s3_bucket
+  minio_aws_access_key_id       = var.minio_aws_access_key_id
+  minio_aws_secret_access_key   = var.minio_aws_secret_access_key
 
   # cognito
   use_cognito                     = var.use_cognito

--- a/deployments/cognito-rds-s3/terraform/variables.tf
+++ b/deployments/cognito-rds-s3/terraform/variables.tf
@@ -43,9 +43,15 @@ variable "use_s3" {
   default = true
 }
 
-variable "use_static" {
-  type    = bool
-  default = false
+variable "pipeline_s3_credential_option" {
+  description = "The credential type to use to authenticate KFP to use S3. One of [irsa, static]"
+  type        = string
+  default     = "irsa"
+
+  validation {
+    condition     = "irsa" == var.pipeline_s3_credential_option || "static" == var.pipeline_s3_credential_option
+    error_message = "The pipeline_s3_credential_option must be one of [irsa, static]"
+  }
 }
 
 variable "use_cognito" {

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -204,9 +204,9 @@ module "kubeflow_components" {
   notebook_cull_idle_time        = var.notebook_cull_idle_time
   notebook_idleness_check_period = var.notebook_idleness_check_period
 
-  use_rds    = var.use_rds
-  use_s3     = var.use_s3
-  use_static = var.use_static
+  use_rds                       = var.use_rds
+  use_s3                        = var.use_s3
+  pipeline_s3_credential_option = var.pipeline_s3_credential_option
 
   vpc_id                         = module.vpc.vpc_id
   subnet_ids                     = var.publicly_accessible ? module.vpc.public_subnets : module.vpc.private_subnets

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -13,19 +13,22 @@ locals {
   secrets_manager_chart_s3     = "${var.kf_helm_repo_path}/charts/common/aws-secrets-manager/s3-only"
   secrets_manager_chart_rds_s3 = "${var.kf_helm_repo_path}/charts/common/aws-secrets-manager/rds-s3"
 
+  use_static = "static" == var.pipeline_s3_credential_option
+  use_irsa   = "irsa" == var.pipeline_s3_credential_option
+
   kfp_chart_map = {
     (local.kfp_chart_vanilla)           = !var.use_rds && !var.use_s3,
     (local.kfp_chart_rds_only)          = var.use_rds && !var.use_s3,
-    (local.kfp_chart_s3_only)           = !var.use_rds && var.use_s3 && !var.use_static,
-    (local.kfp_chart_rds_and_s3)        = var.use_rds && var.use_s3 && !var.use_static,
-    (local.kfp_chart_s3_only_static)    = !var.use_rds && var.use_s3 && var.use_static,
-    (local.kfp_chart_rds_and_s3_static) = var.use_rds && var.use_s3 && var.use_static
+    (local.kfp_chart_s3_only)           = !var.use_rds && var.use_s3 && local.use_irsa,
+    (local.kfp_chart_rds_and_s3)        = var.use_rds && var.use_s3 && local.use_irsa,
+    (local.kfp_chart_s3_only_static)    = !var.use_rds && var.use_s3 && local.use_static,
+    (local.kfp_chart_rds_and_s3_static) = var.use_rds && var.use_s3 && local.use_static
   }
 
   secrets_manager_chart_map = {
-    (local.secrets_manager_chart_rds)    = var.use_rds && var.use_s3 && !var.use_static,
-    (local.secrets_manager_chart_s3)     = !var.use_rds && var.use_s3 && var.use_static,
-    (local.secrets_manager_chart_rds_s3) = var.use_rds && var.use_s3 && var.use_static
+    (local.secrets_manager_chart_rds)    = var.use_rds && var.use_s3 && local.use_irsa,
+    (local.secrets_manager_chart_s3)     = !var.use_rds && var.use_s3 && local.use_static,
+    (local.secrets_manager_chart_rds_s3) = var.use_rds && var.use_s3 && local.use_static
   }
 
   katib_chart                      = var.use_rds ? local.katib_chart_rds : local.katib_chart_vanilla
@@ -46,19 +49,19 @@ resource "kubernetes_namespace" "kubeflow" {
 }
 
 data "aws_iam_role" "pipeline_irsa_iam_role" {
-  count      = var.use_static ? 0 : 1
+  count      = local.use_static ? 0 : 1
   name       = try(module.kubeflow_pipeline_irsa[0].irsa_iam_role_name, null)
   depends_on = [module.kubeflow_pipeline_irsa]
 }
 
 data "aws_iam_role" "user_namespace_irsa_iam_role" {
-  count      = var.use_static ? 0 : 1
+  count      = local.use_static ? 0 : 1
   name       = try(module.user_namespace_irsa[0].irsa_iam_role_name, null)
   depends_on = [module.user_namespace_irsa]
 }
 
 module "kubeflow_secrets_manager_irsa" {
-  count                             = var.use_static || var.use_rds ? 1 : 0
+  count                             = local.use_static || var.use_rds ? 1 : 0
   source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
@@ -73,7 +76,7 @@ module "kubeflow_secrets_manager_irsa" {
 }
 
 module "kubeflow_pipeline_irsa" {
-  count                             = var.use_static ? 0 : 1
+  count                             = local.use_static ? 0 : 1
   source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
@@ -88,7 +91,7 @@ module "kubeflow_pipeline_irsa" {
 }
 
 module "user_namespace_irsa" {
-  count                             = var.use_static ? 0 : 1
+  count                             = local.use_static ? 0 : 1
   source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
   kubernetes_namespace              = "kubeflow-user-example-com"
   create_kubernetes_namespace       = false
@@ -149,7 +152,7 @@ module "filter_secrets_manager_set_values" {
 }
 
 module "secrets_manager" {
-  count  = var.use_rds || (var.use_s3 && var.use_static) ? 1 : 0
+  count  = var.use_rds || (var.use_s3 && local.use_static) ? 1 : 0
   source = "../../../../iaac/terraform/common/aws-secrets-manager"
   helm_config = {
     chart = local.secrets_manager_chart

--- a/deployments/rds-s3/terraform/rds-s3-components/variables.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/variables.tf
@@ -36,9 +36,15 @@ variable "use_s3" {
   default = true
 }
 
-variable "use_static" {
-  type    = bool
-  default = false
+variable "pipeline_s3_credential_option" {
+  description = "The credential type to use to authenticate KFP to use S3. One of [irsa, static]"
+  type        = string
+  default     = "irsa"
+
+  validation {
+    condition     = "irsa" == var.pipeline_s3_credential_option || "static" == var.pipeline_s3_credential_option
+    error_message = "The pipeline_s3_credential_option must be one of [irsa, static]"
+  }
 }
 
 variable "vpc_id" {

--- a/deployments/rds-s3/terraform/variables.tf
+++ b/deployments/rds-s3/terraform/variables.tf
@@ -37,9 +37,15 @@ variable "use_s3" {
   default = true
 }
 
-variable "use_static" {
-  type    = bool
-  default = false
+variable "pipeline_s3_credential_option" {
+  description = "The credential type to use to authenticate KFP to use S3. One of [irsa, static]"
+  type        = string
+  default     = "irsa"
+
+  validation {
+    condition     = "irsa" == var.pipeline_s3_credential_option || "static" == var.pipeline_s3_credential_option
+    error_message = "The pipeline_s3_credential_option must be one of [irsa, static]"
+  }
 }
 
 variable "enable_aws_telemetry" {


### PR DESCRIPTION
**Description of your changes:**
- Changed the boolean Terraform variable `use_static` to the string Terraform variable `pipeline_s3_credential_option`
- Terraform variable `pipeline_s3_credential_option` has the options `static` and `irsa`
- `irsa` is the default value

**Testing:**
- Deployed and verified pipelines for rds-s3 and cognito-rds-s3 terraform deployments using both static and irsa inputs
- Passed invalid input and received validation error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.