### PR TITLE
add sample profile to helm/kustomize Cognito-rds-s3

### DIFF
--- a/charts/common/user-namespace/templates/Profile/kubeflow-user-example-com-Profile.yaml
+++ b/charts/common/user-namespace/templates/Profile/kubeflow-user-example-com-Profile.yaml
@@ -6,8 +6,10 @@ spec:
   owner:
     kind: User
     name: user@example.com
+  {{- if .Values.awsIamForServiceAccount.awsIamRole }}
   plugins:
   - kind: AwsIamForServiceAccount
     spec:
       awsIamRole: '{{ .Values.awsIamForServiceAccount.awsIamRole }}'
       annotateOnly: true
+  {{- end }}

--- a/tests/e2e/resources/installation_config/cognito-rds-s3-static.yaml
+++ b/tests/e2e/resources/installation_config/cognito-rds-s3-static.yaml
@@ -324,7 +324,7 @@ user-namespace:
   installation_options:
     kustomize:
       paths: 
-        - ../../awsconfigs/common/user-namespace/overlay
+        - ../../upstream/common/user-namespace/base
     helm: 
       paths: ../../charts/common/user-namespace
 

--- a/tests/e2e/resources/installation_config/cognito-rds-s3-static.yaml
+++ b/tests/e2e/resources/installation_config/cognito-rds-s3-static.yaml
@@ -318,6 +318,17 @@ profiles-and-kfam:
         - key: kustomize.component
           value: profiles
 
+
+#user namespace
+user-namespace:
+  installation_options:
+    kustomize:
+      paths: 
+        - ../../awsconfigs/common/user-namespace/overlay
+    helm: 
+      paths: ../../charts/common/user-namespace
+
+
 #Ingress
 ingress:
   installation_options:

--- a/tests/e2e/resources/installation_config/cognito-rds-s3.yaml
+++ b/tests/e2e/resources/installation_config/cognito-rds-s3.yaml
@@ -361,6 +361,15 @@ aws-authservice:
         - key: app
           value: aws-authservice
 
+#user namespace
+user-namespace:
+  installation_options:
+    kustomize:
+      paths: 
+        - ../../awsconfigs/common/user-namespace/overlay
+    helm: 
+      paths: ../../charts/common/user-namespace
+
 #AWS Secrets Manager
 aws-secrets-manager:
   installation_options:

--- a/tests/e2e/resources/installation_config/cognito.yaml
+++ b/tests/e2e/resources/installation_config/cognito.yaml
@@ -317,6 +317,17 @@ profiles-and-kfam:
         - key: kustomize.component
           value: profiles
 
+
+#user namespace
+user-namespace:
+  installation_options:
+    kustomize:
+      paths: 
+        - ../../awsconfigs/common/user-namespace/overlay
+    helm: 
+      paths: ../../charts/common/user-namespace
+
+
 #Ingress
 ingress:
   installation_options:

--- a/tests/e2e/resources/installation_config/cognito.yaml
+++ b/tests/e2e/resources/installation_config/cognito.yaml
@@ -323,7 +323,7 @@ user-namespace:
   installation_options:
     kustomize:
       paths: 
-        - ../../awsconfigs/common/user-namespace/overlay
+        - ../../upstream/common/user-namespace/base
     helm: 
       paths: ../../charts/common/user-namespace
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Keep parity with Terraform deployment. Adds a sample user-profile configured with s3-bucket access to helm/kustomize cognito-rds-s3 deployments

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.