### PR TITLE
Minor validation and docs update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install-jq:
 	sudo apt-get install jq -y
 
 install-terraform:
-	$(eval TERRAFORM_VERSION:=1.2.7)
+	$(eval TERRAFORM_VERSION:=1.4.5)
 	curl "https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_linux_amd64.zip" -o "terraform.zip"
 	unzip -o -q terraform.zip
 	sudo install -o root -g root -m 0755 terraform /usr/local/bin/terraform

--- a/deployments/cognito-rds-s3/terraform/variables.tf
+++ b/deployments/cognito-rds-s3/terraform/variables.tf
@@ -2,6 +2,11 @@
 variable "cluster_name" {
   description = "Name of cluster"
   type        = string
+
+  validation {
+    condition     = length(var.cluster_name) > 0 && length(var.cluster_name) <= 19
+    error_message = "The cluster name must be between [1, 19] characters"
+  }
 }
 
 variable "cluster_region" {

--- a/deployments/cognito/terraform/variables.tf
+++ b/deployments/cognito/terraform/variables.tf
@@ -2,6 +2,11 @@
 variable "cluster_name" {
   description = "Name of cluster"
   type        = string
+
+  validation {
+    condition     = length(var.cluster_name) > 0 && length(var.cluster_name) <= 19
+    error_message = "The cluster name must be between [1, 19] characters"
+  }
 }
 
 variable "cluster_region" {

--- a/deployments/rds-s3/terraform/variables.tf
+++ b/deployments/rds-s3/terraform/variables.tf
@@ -2,6 +2,11 @@
 variable "cluster_name" {
   description = "Name of cluster"
   type        = string
+
+  validation {
+    condition     = length(var.cluster_name) > 0 && length(var.cluster_name) <= 19
+    error_message = "The cluster name must be between [1, 19] characters"
+  }
 }
 
 variable "cluster_region" {

--- a/deployments/vanilla/terraform/variables.tf
+++ b/deployments/vanilla/terraform/variables.tf
@@ -2,6 +2,11 @@
 variable "cluster_name" {
   description = "Name of cluster"
   type        = string
+
+  validation {
+    condition     = length(var.cluster_name) > 0 && length(var.cluster_name) <= 19
+    error_message = "The cluster name must be between [1, 19] characters"
+  }
 }
 
 variable "cluster_region" {

--- a/website/content/en/docs/add-ons/load-balancer/guide.md
+++ b/website/content/en/docs/add-ons/load-balancer/guide.md
@@ -37,7 +37,7 @@ This guide assumes that you have:
 
 ## Create Load Balancer
 
-If you prefer to create a load balancer using automated scripts, you **only** need to follow the steps in the [automated script section](#automated-script). You can read the following sections in this guide to understand what happens when you run the automated script or to walk through all of the steps manually.
+If you prefer to create a load balancer using automated scripts and are not using Terraform, you **only** need to follow the steps in the [automated script section](#automated-script). You can read the following sections in this guide to understand what happens when you run the automated script or to walk through all of the steps manually.
 
 ### Create domain and certificates
 
@@ -104,10 +104,12 @@ Set up resources required for the Load Balancer controller:
         - `kubernetes.io/role/internal-elb`. Add this tag only to private subnets.
         - `kubernetes.io/role/elb`. Add this tag only to public subnets.
 1. The Load balancer controller uses [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)(IRSA) to access AWS services. An OIDC provider must exist for your cluster to use IRSA. Create an OIDC provider and associate it with your EKS cluster by running the following command if your cluster doesn’t already have one:
+    > Important: If you have deployed Kubeflow using any of the Terraform deployment options and have not set `enable_aws_load_balancer_controller = false` then skip this step.
     ```bash
     eksctl utils associate-iam-oidc-provider --cluster ${CLUSTER_NAME} --region ${CLUSTER_REGION} --approve
     ```
 1. Create an IAM role with [the necessary permissions](https://github.com/awslabs/kubeflow-manifests/blob/main/awsconfigs/infra_configs/iam_alb_ingress_policy.json) for the Load Balancer controller to use via a service account to access AWS services.
+    > Important: If you have deployed Kubeflow using any of the Terraform deployment options and have not set `enable_aws_load_balancer_controller = false` then skip this step.
     ```bash
     export LBC_POLICY_NAME=alb_ingress_controller_${CLUSTER_REGION}_${CLUSTER_NAME}
     export LBC_POLICY_ARN=$(aws iam create-policy --policy-name $LBC_POLICY_NAME --policy-document file://awsconfigs/infra_configs/iam_alb_ingress_policy.json --output text --query 'Policy.Arn')
@@ -139,6 +141,8 @@ while ! kustomize build deployments/add-ons/load-balancer | kubectl apply -f -; 
 3. The central dashboard should now be available at `https://kubeflow.platform.example.com`. Open a browser and navigate to this URL.
 
 ### Automated script
+
+> Important: If you have deployed Kubeflow using any of the Terraform deployment options and have not set `enable_aws_load_balancer_controller = false` then do not follow the instructions in this section. Instead follow the manual steps above.
 
 1. Install dependencies for the script
     ```bash
@@ -197,6 +201,7 @@ while ! kustomize build deployments/add-ons/load-balancer | kubectl apply -f -; 
 > Note: It might a few minutes for DNS changes to propagate and for your URL to work. Check if the DNS entry propogated with the [Google Admin Toolbox](https://toolbox.googleapps.com/apps/dig/#CNAME/)
 
 ## Clean up
+> Important: If you have deployed Kubeflow using any of the Terraform deployment options and have not set `enable_aws_load_balancer_controller = false` then do not follow the instructions in this section.
 
 To delete the resources created in this guide, run the following commands from the root of your repository:
 > Note: Make sure that you have the configuration file created by the script in `tests/e2e/utils/load_balancer/config.yaml`. If you did not use the script, plug in the name, ARN, or ID of the resources that you created in the configuration file by referring to the sample in Step 4 of the [previous section](#automated-script).

--- a/website/content/en/docs/add-ons/load-balancer/guide.md
+++ b/website/content/en/docs/add-ons/load-balancer/guide.md
@@ -95,7 +95,7 @@ If you choose DNS validation for the validation of the certificates, you will be
     ```bash
     printf 'certArn='$certArn'' > awsconfigs/common/istio-ingress/overlays/https/params.env
     ```
-### Configure and Install Load Balancer Controller
+### Configure Load Balancer Controller
 
 > Important: Skip this step if you are using a Terraform deployment since the AWS Load Balancer Controller is installed by default unless you set `enable_aws_load_balancer_controller = false`.
 
@@ -131,10 +131,17 @@ Set up resources required for the Load Balancer controller:
     printf 'clusterName='$CLUSTER_NAME'' > awsconfigs/common/aws-alb-ingress-controller/base/params.env
     ```
 
-1. Run the following command to build and install the components specified in the Load Balancer [kustomize](https://github.com/awslabs/kubeflow-manifests/blob/main/deployments/add-ons/load-balancer/kustomization.yaml) file.
-    ```bash
-    while ! kustomize build deployments/add-ons/load-balancer | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 30; done
-    ```
+### Install Load Balancer Controller
+
+> Important: Skip this step if you are using a Terraform deployment since the AWS Load Balancer Controller is installed by default unless you set `enable_aws_load_balancer_controller = false`.
+
+Run the following command to build and install the Load Balancer controller [kustomize](https://github.com/awslabs/kubeflow-manifests/blob/main/awsconfigs/common/aws-alb-ingress-controller/base/kustomization.yaml) file.
+
+```bash
+kustomize build awsconfigs/common/aws-alb-ingress-controller/base | kubectl apply -f -
+kubectl wait --for condition=established crd/ingressclassparams.elbv2.k8s.aws
+kustomize build awsconfigs/common/aws-alb-ingress-controller/base | kubectl apply -f -
+```
 
 ### Create Ingress
 

--- a/website/content/en/docs/add-ons/load-balancer/guide.md
+++ b/website/content/en/docs/add-ons/load-balancer/guide.md
@@ -39,7 +39,14 @@ This guide assumes that you have:
 
 ## Create Load Balancer
 
-If you prefer to create a load balancer using automated scripts and are not using Terraform, you **only** need to follow the steps in the [automated script section](#automated-script). You can read the following sections in this guide to understand what happens when you run the automated script or to walk through all of the steps manually.
+
+#### Setup for Kustomize deployments
+
+If you prefer to create a load balancer using automated scripts, you **only** need to follow the steps in the [automated script section](#automated-script). You can read the following sections in this guide to understand what happens when you run the automated script or to walk through all of the steps manually.
+
+#### Setup for Terraform deployments
+
+Follow the manual steps below. 
 
 ### Create domain and certificates
 
@@ -92,7 +99,7 @@ If you choose DNS validation for the validation of the certificates, you will be
 
 Set up resources required for the Load Balancer controller:
 
-#### 1. Verify Subnet configuration
+#### 1. Verify subnet configurations
 
 1. Make sure that all the subnets (public and private) corresponding to the EKS cluster are tagged according to the **Prerequisites** section in the [Application load balancing on Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html) guide. Ignore the requirement to have an existing ALB provisioned on the cluster. We will deploy Load Balancer controller version 1.1.5 later on.
     - Check if the following tags exist on the subnets:
@@ -113,12 +120,10 @@ Set up resources required for the Load Balancer controller:
 > Important: Terraform deployent users should skip this step.
 
 1. The Load balancer controller uses [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)(IRSA) to access AWS services. An OIDC provider must exist for your cluster to use IRSA. Create an OIDC provider and associate it with your EKS cluster by running the following command if your cluster doesn’t already have one:
-    > Important: If you have deployed Kubeflow using any of the Terraform deployment options and have not set `enable_aws_load_balancer_controller = false` then skip this step.
     ```bash
     eksctl utils associate-iam-oidc-provider --cluster ${CLUSTER_NAME} --region ${CLUSTER_REGION} --approve
     ```
 1. Create an IAM role with [the necessary permissions](https://github.com/awslabs/kubeflow-manifests/blob/main/awsconfigs/infra_configs/iam_alb_ingress_policy.json) for the Load Balancer controller to use via a service account to access AWS services.
-    > Important: If you have deployed Kubeflow using any of the Terraform deployment options and have not set `enable_aws_load_balancer_controller = false` then skip this step.
     ```bash
     export LBC_POLICY_NAME=alb_ingress_controller_${CLUSTER_REGION}_${CLUSTER_NAME}
     export LBC_POLICY_ARN=$(aws iam create-policy --policy-name $LBC_POLICY_NAME --policy-document file://awsconfigs/infra_configs/iam_alb_ingress_policy.json --output text --query 'Policy.Arn')

--- a/website/content/en/docs/add-ons/storage/efs/guide.md
+++ b/website/content/en/docs/add-ons/storage/efs/guide.md
@@ -37,6 +37,8 @@ export CLAIM_NAME=<efs-claim>
 
 ## 2.0 Set up EFS
 
+> Important: If you have deployed Kubeflow using any of the Terraform deployment options and have not set `enable_aws_efs_csi_driver = false` then skip this section.
+
 You can either use Automated or Manual setup to set up the resources required. If you choose the manual route, you get another choice between **static and dynamic provisioning**, so pick whichever suits you. On the other hand, for the automated script we currently only support **dynamic provisioning**. Whichever combination you pick, be sure to continue picking the appropriate sections through the rest of this guide. 
 
 ### 2.1 [Option 1] Automated setup

--- a/website/content/en/docs/add-ons/storage/efs/guide.md
+++ b/website/content/en/docs/add-ons/storage/efs/guide.md
@@ -6,6 +6,8 @@ weight = 10
 
 This guide describes how to use Amazon EFS as Persistent storage on top of an existing Kubeflow deployment.  
 
+> Note: For Terraform deployment users, some steps that should be skipped will have a note indicating such below.
+
 ## 1.0 Prerequisites
 For this guide, we assume that you already have an EKS Cluster with Kubeflow installed. The FSx CSI Driver can be installed and configured as a separate resource on top of an existing Kubeflow deployment. See the [deployment options]({{< ref "/docs/deployment" >}}) and [general prerequisites]({{< ref "/docs/deployment/vanilla/guide.md" >}}) for more information.
 
@@ -37,11 +39,18 @@ export CLAIM_NAME=<efs-claim>
 
 ## 2.0 Set up EFS
 
-> Important: If you have deployed Kubeflow using any of the Terraform deployment options and have not set `enable_aws_efs_csi_driver = false` then skip this section.
+#### Setup for Kustomize deployments
 
 You can either use Automated or Manual setup to set up the resources required. If you choose the manual route, you get another choice between **static and dynamic provisioning**, so pick whichever suits you. On the other hand, for the automated script we currently only support **dynamic provisioning**. Whichever combination you pick, be sure to continue picking the appropriate sections through the rest of this guide. 
 
+#### Setup for Terraform deployments
+
+Follow the Manual setup to set up the resources required. As part of the Manual setup, you get another choice between **static and dynamic provisioning**, so pick whichever suits you.
+
 ### 2.1 [Option 1] Automated setup
+
+> Important: Terraform deployment users should not follow these Automated setup instructions and should follow the [Manual setup instructions](#22-option-2-manual-setup).
+
 The script automates all the manual resource creation steps but is currently only available for **Dynamic Provisioning** option.  
 It performs the required cluster configuration, creates an EFS file system and it also takes care of creating a storage class for dynamic provisioning. Once done, move to section 3.0. 
 1. Run the following commands from the `tests/e2e` directory:
@@ -82,7 +91,11 @@ If you prefer to manually setup each component then you can follow this manual g
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
 ```
 
-#### 1. Install the EFS CSI driver
+#### 1. Driver install and IAM configuration
+
+> Important: Terraform deployent users should skip this step.
+
+##### 1. Install the EFS CSI driver
 We recommend installing the EFS CSI Driver v1.5.4 directly from the [the aws-efs-csi-driver github repo](https://github.com/kubernetes-sigs/aws-efs-csi-driver) as follows:
 
 ```bash
@@ -97,7 +110,7 @@ NAME              ATTACHREQUIRED   PODINFOONMOUNT   MODES        AGE
 efs.csi.aws.com   false            false            Persistent   5d17h
 ```
 
-#### 2. Create the IAM Policy for the CSI driver
+##### 2. Create the IAM Policy for the CSI driver
 The CSI driver's service account (created during installation) requires IAM permission to make calls to AWS APIs on your behalf. Here, we will be annotating the Service Account `efs-csi-controller-sa` with an IAM Role which has the required permissions.
 
 1. Download the IAM policy document from GitHub as follows.
@@ -131,7 +144,7 @@ eksctl create iamserviceaccount \
 kubectl describe -n kube-system serviceaccount efs-csi-controller-sa
 ```
 
-#### 3. Manually create an instance of the EFS filesystem
+#### 2. Manually create an instance of the EFS filesystem
 Please refer to the official [AWS EFS CSI Document](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html#efs-create-filesystem) for detailed instructions on creating an EFS filesystem. 
 
 > Note: For this guide, we assume that you are creating your EFS Filesystem in the same VPC as your EKS Cluster. 
@@ -139,7 +152,7 @@ Please refer to the official [AWS EFS CSI Document](https://docs.aws.amazon.com/
 #### Choose between dynamic and static provisioning  
 In the following section, you have to choose between setting up [dynamic provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) or setting up static provisioning.
 
-#### 4. [Option 1] Dynamic provisioning  
+#### 3. [Option 1] Dynamic provisioning  
 1. Use the `$file_system_id` you recorded in section 3 above or use the AWS Console to get the filesystem id of the EFS file system you want to use. Now edit the `dynamic-provisioning/sc.yaml` file by chaning `<YOUR_FILE_SYSTEM_ID>` with your `fs-xxxxxx` file system id. You can also change it using the following command :  
 ```bash
 file_system_id=$file_system_id yq e '.parameters.fileSystemId = env(file_system_id)' -i $GITHUB_STORAGE_DIR/efs/dynamic-provisioning/sc.yaml
@@ -163,7 +176,7 @@ kubectl apply -f $GITHUB_STORAGE_DIR/efs/dynamic-provisioning/pvc.yaml
 
 Note : The `StorageClass` is a cluster scoped resource which means we only need to do this step once per cluster. 
 
-#### 4. [Option 2] Static Provisioning
+#### 3. [Option 2] Static Provisioning
 Using [this sample](https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/examples/kubernetes/multiple_pods), we provided the required spec files in the sample subdirectory. However, you can create the PVC another way. 
 
 1. Use the `$file_system_id` you recorded in section 3 above or use the AWS Console to get the filesystem id of the EFS file system you want to use. Now edit the last line of the static-provisioning/pv.yaml file to specify the `volumeHandle` field to point to your EFS filesystem. Replace `$file_system_id` if it is not already set. 

--- a/website/content/en/docs/add-ons/storage/efs/guide.md
+++ b/website/content/en/docs/add-ons/storage/efs/guide.md
@@ -39,7 +39,7 @@ export CLAIM_NAME=<efs-claim>
 
 ## 2.0 Set up EFS
 
-#### Setup for Kustomize deployments
+#### Setup for Manifest deployments
 
 You can either use Automated or Manual setup to set up the resources required. If you choose the manual route, you get another choice between **static and dynamic provisioning**, so pick whichever suits you. On the other hand, for the automated script we currently only support **dynamic provisioning**. Whichever combination you pick, be sure to continue picking the appropriate sections through the rest of this guide. 
 
@@ -93,9 +93,9 @@ export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output t
 
 #### 1. Driver install and IAM configuration
 
-> Important: Terraform deployent users should skip this step.
+> Important: Skip this step if you are using a Terraform deployment since EFS CSI driver is installed by default unless you set `enable_aws_efs_csi_driver = false`.
 
-##### 1. Install the EFS CSI driver
+##### 1.1 Install the EFS CSI driver
 We recommend installing the EFS CSI Driver v1.5.4 directly from the [the aws-efs-csi-driver github repo](https://github.com/kubernetes-sigs/aws-efs-csi-driver) as follows:
 
 ```bash
@@ -110,7 +110,7 @@ NAME              ATTACHREQUIRED   PODINFOONMOUNT   MODES        AGE
 efs.csi.aws.com   false            false            Persistent   5d17h
 ```
 
-##### 2. Create the IAM Policy for the CSI driver
+##### 1.2. Create the IAM Policy for the CSI driver
 The CSI driver's service account (created during installation) requires IAM permission to make calls to AWS APIs on your behalf. Here, we will be annotating the Service Account `efs-csi-controller-sa` with an IAM Role which has the required permissions.
 
 1. Download the IAM policy document from GitHub as follows.

--- a/website/content/en/docs/add-ons/storage/fsx-for-lustre/guide.md
+++ b/website/content/en/docs/add-ons/storage/fsx-for-lustre/guide.md
@@ -39,7 +39,7 @@ export CLAIM_NAME=<fsx-claim>
 
 ## 2.0 Setup FSx for Lustre
 
-#### Setup for Kustomize deployments
+#### Setup for Manifest deployments
 
 You can either use Automated or Manual setup. We currently only support **Static provisioning** for FSx.  
 
@@ -88,7 +88,7 @@ If you prefer to manually setup each component then you can follow this manual g
 
 #### 1. Driver install and IAM configuration
 
-> Important: Terraform deployent users should skip this step.
+> Important: Skip this step if you are using a Terraform deployment since EFS CSI driver is installed by default unless you set `enable_aws_fsx_csi_driver = false`.
 
 ##### 1. Install the FSx CSI Driver
 We recommend installing the FSx CSI Driver v0.9.0 directly from the [the aws-fsx-csi-driver GitHub repository](https://github.com/kubernetes-sigs/aws-fsx-csi-driver) as follows:

--- a/website/content/en/docs/add-ons/storage/fsx-for-lustre/guide.md
+++ b/website/content/en/docs/add-ons/storage/fsx-for-lustre/guide.md
@@ -36,6 +36,9 @@ export CLAIM_NAME=<fsx-claim>
 ```
 
 ## 2.0 Setup FSx for Lustre
+
+> Important: If you have deployed Kubeflow using any of the Terraform deployment options and have not set `enable_aws_fsx_csi_driver = false` then skip this section.
+
 You can either use Automated or Manual setup. We currently only support **Static provisioning** for FSx.  
 
 ### 2.1 [Option 1] Automated setup

--- a/website/content/en/docs/component-guides/profiles.md
+++ b/website/content/en/docs/component-guides/profiles.md
@@ -47,7 +47,7 @@ You can find documentation about the `AwsIamForServiceAccount` plugin for specif
 
 After installing Kubeflow on AWS with one of the available [deployment options]({{< ref "/docs/deployment" >}}), you can configure Kubeflow Profiles with the following steps:
 
-### 1. Setup
+### 1. Setup Environment Variables
 
 1. Define the following environment variables:
 

--- a/website/content/en/docs/component-guides/profiles.md
+++ b/website/content/en/docs/component-guides/profiles.md
@@ -43,7 +43,11 @@ You can find documentation about the `AwsIamForServiceAccount` plugin for specif
 
 ## Configuration steps
 
+> Note: For Terraform deployment users, some steps that should be skipped will have a note indicating such below.
+
 After installing Kubeflow on AWS with one of the available [deployment options]({{< ref "/docs/deployment" >}}), you can configure Kubeflow Profiles with the following steps:
+
+### 1. Environment Variables
 
 1. Define the following environment variables:
 
@@ -55,7 +59,11 @@ After installing Kubeflow on AWS with one of the available [deployment options](
    export PROFILE_CONTROLLER_POLICY_NAME=<the name of the profile controller policy to be created>
    ```
 
-2. Create an IAM policy using the [IAM Profile controller policy](https://github.com/awslabs/kubeflow-manifests/blob/main/awsconfigs/infra_configs/iam_profile_controller_policy.json) file.
+### 2. Configure the IAM Profile controller
+
+> Important: Terraform deployent users should skip this step.
+
+1. Create an IAM policy using the [IAM Profile controller policy](https://github.com/awslabs/kubeflow-manifests/blob/main/awsconfigs/infra_configs/iam_profile_controller_policy.json) file.
 
    ```bash
    aws iam create-policy \
@@ -66,7 +74,7 @@ After installing Kubeflow on AWS with one of the available [deployment options](
 
    As a principle of least privilege, we recommend scoping the resources in the [IAM Profile controller policy](https://github.com/awslabs/kubeflow-manifests/blob/main/awsconfigs/infra_configs/iam_profile_controller_policy.json) to the specific policy arns of the policies created in step 6.
 
-3. Associate IAM OIDC with your cluster.
+2. Associate IAM OIDC with your cluster.
 
    ```bash
    aws --region $CLUSTER_REGION eks update-kubeconfig --name $CLUSTER_NAME
@@ -74,7 +82,7 @@ After installing Kubeflow on AWS with one of the available [deployment options](
    eksctl utils associate-iam-oidc-provider --cluster $CLUSTER_NAME --region $CLUSTER_REGION --approve
    ```
 
-4. Create an IRSA for the Profile controller using the policy.
+3. Create an IRSA for the Profile controller using the policy.
 
    ```bash
    eksctl create iamserviceaccount \
@@ -87,7 +95,9 @@ After installing Kubeflow on AWS with one of the available [deployment options](
    --approve
    ```
 
-5. Create an IAM trust policy to authorize federated requests from the OIDC provider.
+### 3. Create a Profile
+
+1. Create an IAM trust policy to authorize federated requests from the OIDC provider.
 
    ```bash
    export OIDC_URL=$(aws eks describe-cluster --region $CLUSTER_REGION --name $CLUSTER_NAME  --query "cluster.identity.oidc.issuer" --output text | cut -c9-)
@@ -113,9 +123,9 @@ After installing Kubeflow on AWS with one of the available [deployment options](
    EOF
    ```
 
-6. [Create an IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html) to scope the permissions for the Profile. For simplicity, we will use the `arn:aws:iam::aws:policy/AmazonS3FullAccess` policy as an example.
+2. [Create an IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html) to scope the permissions for the Profile. For simplicity, we will use the `arn:aws:iam::aws:policy/AmazonS3FullAccess` policy as an example.
 
-7. [Create an IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create.html) for the Profile using the scoped policy from the previous step.
+3. [Create an IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create.html) for the Profile using the scoped policy from the previous step.
 
    ```bash
    aws iam create-role --role-name $PROFILE_NAME-$CLUSTER_NAME-role --assume-role-policy-document file://trust.json
@@ -123,7 +133,7 @@ After installing Kubeflow on AWS with one of the available [deployment options](
    aws iam attach-role-policy --role-name $PROFILE_NAME-$CLUSTER_NAME-role --policy-arn arn:aws:iam::aws:policy/AmazonS3FullAccess
    ```
 
-8. Create a user in your configured auth provider (e.g. Cognito or Dex) or use an existing user.
+4. Create a user in your configured auth provider (e.g. Cognito or Dex) or use an existing user.
 
    Export the user as an environment variable. For simplicity, we will use the `user@example.com` user that is created by default by most of our provided deployment options.
 
@@ -131,7 +141,7 @@ After installing Kubeflow on AWS with one of the available [deployment options](
    export PROFILE_USER="user@example.com"
    ```
 
-9. Create a Profile using the `PROFILE_NAME`.
+5. Create a Profile using the `PROFILE_NAME`.
 
    ```bash
    cat <<EOF > profile_iam.yaml

--- a/website/content/en/docs/component-guides/profiles.md
+++ b/website/content/en/docs/component-guides/profiles.md
@@ -47,7 +47,7 @@ You can find documentation about the `AwsIamForServiceAccount` plugin for specif
 
 After installing Kubeflow on AWS with one of the available [deployment options]({{< ref "/docs/deployment" >}}), you can configure Kubeflow Profiles with the following steps:
 
-### 1. Environment Variables
+### 1. Setup
 
 1. Define the following environment variables:
 
@@ -59,7 +59,7 @@ After installing Kubeflow on AWS with one of the available [deployment options](
    export PROFILE_CONTROLLER_POLICY_NAME=<the name of the profile controller policy to be created>
    ```
 
-### 2. Configure the IAM Profile controller
+### 2. Configure the Profile Controller
 
 > Important: Terraform deployent users should skip this step.
 

--- a/website/content/en/docs/deployment/cognito/manifest/guide.md
+++ b/website/content/en/docs/deployment/cognito/manifest/guide.md
@@ -157,7 +157,7 @@ yq e '.LOGOUT_URL = env(CognitoLogoutURL)' -i charts/common/aws-authservice/valu
     {{< /tab >}}
     {{< /tabpane >}}
 
-1. Follow the [Configure Load Balancer Controller]({{< ref "/docs/add-ons/load-balancer/guide.md#configure-load-balancer-controller" >}}) section of the load balancer guide to setup the resources required by the load balancer controller.
+1. Follow the [Configure Load Balancer Controller]({{< ref "/docs/add-ons/load-balancer/guide.md#configure-and-install-load-balancer-controller" >}}) section of the load balancer guide to setup the resources required by the load balancer controller.
 
 ### (Optional) Configure Culling for Notebooks
 Enable culling for notebooks by following the [instructions]({{< ref "/docs/deployment/configure-notebook-culling.md#" >}}) in configure culling for notebooks guide.

--- a/website/content/en/docs/deployment/cognito/manifest/guide.md
+++ b/website/content/en/docs/deployment/cognito/manifest/guide.md
@@ -157,7 +157,7 @@ yq e '.LOGOUT_URL = env(CognitoLogoutURL)' -i charts/common/aws-authservice/valu
     {{< /tab >}}
     {{< /tabpane >}}
 
-1. Follow the [Configure Load Balancer Controller]({{< ref "/docs/add-ons/load-balancer/guide.md#configure-and-install-load-balancer-controller" >}}) section of the load balancer guide to setup the resources required by the load balancer controller.
+1. Follow the [Configure Load Balancer Controller]({{< ref "/docs/add-ons/load-balancer/guide.md#configure-load-balancer-controller" >}}) section of the load balancer guide to setup the resources required by the load balancer controller.
 
 ### (Optional) Configure Culling for Notebooks
 Enable culling for notebooks by following the [instructions]({{< ref "/docs/deployment/configure-notebook-culling.md#" >}}) in configure culling for notebooks guide.


### PR DESCRIPTION
- Enforce cluster name is between [1, 19] characters to prevent empty cluster names and too long cluster names from being propagated down to IRSA role creation and causing role creation to fail due to role length being greater than 64 characters
- Highlight which deployment add-on steps can be skipped when following the Terraform deployment guides


**Testing:**
- Tested cluster name length validation via empty string, "ack-sagemaker-controller-irsa-tf-vanilla-uwiqgwfq-ap-southeast-1", and "ack-sagemaker-controller-irsa-tf-vanilla-uwiqgwfqu3-ap-southeast-1"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.