### PR TITLE
Removed split command from load balancer helm installation

### DIFF
--- a/tests/e2e/utils/kubeflow_installation.py
+++ b/tests/e2e/utils/kubeflow_installation.py
@@ -215,7 +215,7 @@ def install_certmanager():
 
 
 def install_alb_controller(cluster_name):
-    exec_shell(f"helm repo add eks https://aws.github.io/eks-charts".split())
+    exec_shell(f"helm repo add eks https://aws.github.io/eks-charts")
 
     exec_shell(f"helm repo update")
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #546

**Description of your changes:**

Removed split command from load balancer helm installation

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass


Wait for 60s for website to be available...
PASSED=================================================================
You are uninstalling kubeflow cognito deployment with helm with static

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.