### PR TITLE
Adding virtual service for oidc-authservice

### DIFF
--- a/charts/common/oidc-authservice/templates/VirtualService/doidc-authservice-VirtualService.yaml
+++ b/charts/common/oidc-authservice/templates/VirtualService/doidc-authservice-VirtualService.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: authservice
+  namespace: istio-system
+spec:
+  gateways:
+    - kubeflow/kubeflow-gateway
+  hosts:
+    - "*"
+  http:
+    - match:
+        - uri:
+            prefix: /authservice/
+      route:
+        - destination:
+            host: authservice.istio-system.svc.cluster.local
+            port:
+              number: 8080


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #702

**Description of your changes:**
Adding virtualservice to the helm charts of the oidc-authservice in kubeflow 1.7. In the Dex configmap redirectURI has changed to /authservice/oidc/callback and oidc-authservice is using /authservice prefix. However oidc-authservice helm chart is missing virtualservice that can expose /authservice in istio. This pull request will add a necessary virtualservice to the helm charts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.