### PR TITLE
Cherry-Pick: Wait for notebook pod in canary test (#724)

### DIFF
--- a/tests/e2e/tests/test_sanity_portforward.py
+++ b/tests/e2e/tests/test_sanity_portforward.py
@@ -12,7 +12,7 @@ import time
 import pytest
 import boto3
 
-from e2e.utils.utils import get_s3_client
+from e2e.utils.utils import get_s3_client, kubectl_wait_pods
 
 from e2e.utils.constants import DEFAULT_USER_NAMESPACE
 from e2e.utils.utils import load_yaml_file, wait_for, rand_name, write_yaml_file, WaitForCircuitBreakerError
@@ -214,6 +214,9 @@ class TestSanity:
         sub_cmd = f"jupyter nbconvert --to notebook --execute ../uploaded/{ipynb_notebook_file} --stdout"
         cmd = f"kubectl -n kubeflow-user-example-com exec -it {notebook_name}-0 -- /bin/bash -c".split()
         cmd.append(sub_cmd)
+
+        # kubectl wait --for=condition=ready pod -l 'app in ({notebook_name})' --timeout=240s -n {DEFAULT_USER_NAMESPACE}
+        kubectl_wait_pods(notebook_name, DEFAULT_USER_NAMESPACE)
 
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode()
         print(output)


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
One canary test is flaky because the notebook pod does not become ready one time

**Description of your changes:**
- Added a wait to check if the pod became ready

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass - test_sanity_port_forward passed
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.