### PR TITLE
[Testing in Progress] Create and provide EFS CSI driver policy to blueprints addons

### DIFF
--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -126,6 +126,12 @@ module "eks_blueprints" {
   tags = local.tags
 }
 
+module "pre_configuration" {
+  source = "../../../iaac/terraform/utils/pre-configuration"
+
+  cluster_name  = local.cluster_name
+}
+
 module "eks_blueprints_kubernetes_addons" {
   source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
@@ -148,6 +154,8 @@ module "eks_blueprints_kubernetes_addons" {
     namespace = "kube-system"
     version   = "2.4.1"
   }
+
+  aws_efs_csi_driver_irsa_policies = [module.pre_configuration.aws_efs_csi_driver_policy_arn]
 
   enable_aws_efs_csi_driver = true
 

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -127,6 +127,12 @@ module "eks_blueprints" {
   tags = local.tags
 }
 
+module "pre_configuration" {
+  source = "../../../iaac/terraform/utils/pre-configuration"
+
+  cluster_name  = local.cluster_name
+}
+
 module "eks_blueprints_kubernetes_addons" {
   source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
@@ -149,6 +155,8 @@ module "eks_blueprints_kubernetes_addons" {
     namespace = "kube-system"
     version   = "2.4.1"
   }
+
+  aws_efs_csi_driver_irsa_policies = [module.pre_configuration.aws_efs_csi_driver_policy_arn]
 
   enable_aws_efs_csi_driver = true
 

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -119,6 +119,12 @@ module "eks_blueprints" {
   tags = local.tags
 }
 
+module "pre_configuration" {
+  source = "../../../iaac/terraform/utils/pre-configuration"
+
+  cluster_name  = local.cluster_name
+}
+
 module "eks_blueprints_kubernetes_addons" {
   source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
@@ -141,6 +147,8 @@ module "eks_blueprints_kubernetes_addons" {
     namespace = "kube-system"
     version   = "2.4.1"
   }
+
+  aws_efs_csi_driver_irsa_policies = [module.pre_configuration.aws_efs_csi_driver_policy_arn]
 
   enable_aws_efs_csi_driver = true
 

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -118,6 +118,12 @@ module "eks_blueprints" {
   tags                = local.tags
 }
 
+module "pre_configuration" {
+  source = "../../../iaac/terraform/utils/pre-configuration"
+
+  cluster_name  = local.cluster_name
+}
+
 module "eks_blueprints_kubernetes_addons" {
   source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
@@ -140,6 +146,8 @@ module "eks_blueprints_kubernetes_addons" {
     namespace = "kube-system"
     version   = "2.4.1"
   }
+
+  aws_efs_csi_driver_irsa_policies = [module.pre_configuration.aws_efs_csi_driver_policy_arn]
 
   enable_aws_efs_csi_driver = true
 

--- a/iaac/terraform/utils/pre-configuration/main.tf
+++ b/iaac/terraform/utils/pre-configuration/main.tf
@@ -1,0 +1,10 @@
+data "http" "aws_efs_csi_driver_example_policy" {
+  url = "https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v1.5.4/docs/iam-policy-example.json"
+}
+
+resource "aws_iam_policy" "aws_efs_csi_driver_policy" {
+  name        = "efs-csi-driver-${var.cluster_name}"
+  description = "Policy for the AWS EFS CSI driver service account"
+
+  policy = data.http.aws_efs_csi_driver_example_policy.response_body
+}

--- a/iaac/terraform/utils/pre-configuration/outputs.tf
+++ b/iaac/terraform/utils/pre-configuration/outputs.tf
@@ -1,0 +1,3 @@
+output "aws_efs_csi_driver_policy_arn" {
+  value = aws_iam_policy.aws_efs_csi_driver_policy.arn
+}

--- a/iaac/terraform/utils/pre-configuration/variables.tf
+++ b/iaac/terraform/utils/pre-configuration/variables.tf
@@ -1,0 +1,4 @@
+variable "cluster_name" {
+  description = "Name of cluster"
+  type        = string
+}

--- a/iaac/terraform/utils/pre-configuration/versions.tf
+++ b/iaac/terraform/utils/pre-configuration/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.30.0"
+    }
+  }
+}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #717

**Description of your changes:**
The default IAM policy created for the EFS CSI driver service account is does not contain all the required permissions mentioned [here](https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/v1.5.4/docs/iam-policy-example.json).

The Terraform install was updated to create a policy using the above URL and pass that policy as an input to the Blueprints Addons module, in which the EFS CSI driver module would use the policy as an input when creating the IAM role for the EFS CSI driver service account.

**Testing:**

Tested both manual deployment and modified auto setup script cases.

Auto setup script diff:
```
ubuntu@ip-172-31-21-105:~/tf-efs/kubeflow-manifests$ git diff tests
diff --git a/tests/e2e/utils/auto-efs-setup.py b/tests/e2e/utils/auto-efs-setup.py
index 13866535..af331100 100755
--- a/tests/e2e/utils/auto-efs-setup.py
+++ b/tests/e2e/utils/auto-efs-setup.py
@@ -14,8 +14,8 @@ def main():

     verify_prerequisites()

-    setup_iam_authorization()
-    setup_efs_driver()
+    # setup_iam_authorization()
+    # setup_efs_driver()
     setup_efs_file_system()
     setup_efs_provisioning()
```

Verified notebook and volumes were created:
<img width="1544" alt="Screen Shot 2023-05-03 at 5 22 15 PM" src="https://user-images.githubusercontent.com/91350438/236078563-875d1cbf-7a1c-4657-83ed-61408537cf8d.png">

<img width="1540" alt="Screen Shot 2023-05-03 at 5 23 10 PM" src="https://user-images.githubusercontent.com/91350438/236078647-4b6e90ef-41d3-4911-9291-d5988360926b.png">

PVC yaml:
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: 'yes'
    pv.kubernetes.io/bound-by-controller: 'yes'
    volume.beta.kubernetes.io/storage-provisioner: efs.csi.aws.com
    volume.kubernetes.io/selected-node: ip-10-0-107-16.us-west-2.compute.internal
    volume.kubernetes.io/storage-provisioner: efs.csi.aws.com
  creationTimestamp: '2023-05-03T23:07:43+00:00'
  finalizers:
    - kubernetes.io/pvc-protection
  managedFields:
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:spec':
          'f:accessModes': {}
          'f:resources':
            'f:requests':
              .: {}
              'f:storage': {}
          'f:storageClassName': {}
          'f:volumeMode': {}
      manager: OpenAPI-Generator
      operation: Update
      time: '2023-05-03T23:07:43+00:00'
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            .: {}
            'f:volume.kubernetes.io/selected-node': {}
      manager: kube-scheduler
      operation: Update
      time: '2023-05-03T23:07:44+00:00'
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            'f:pv.kubernetes.io/bind-completed': {}
            'f:pv.kubernetes.io/bound-by-controller': {}
            'f:volume.beta.kubernetes.io/storage-provisioner': {}
            'f:volume.kubernetes.io/storage-provisioner': {}
        'f:spec':
          'f:volumeName': {}
      manager: kube-controller-manager
      operation: Update
      time: '2023-05-03T23:07:45+00:00'
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          'f:accessModes': {}
          'f:capacity':
            .: {}
            'f:storage': {}
          'f:phase': {}
      manager: kube-controller-manager
      operation: Update
      subresource: status
      time: '2023-05-03T23:07:45+00:00'
  name: tf-efs-auto-script-volume
  namespace: kubeflow-user-example-com
  resourceVersion: '126178'
  uid: e09f5782-61bb-49d7-bf67-d975f2e15870
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: efs-sc
  volumeMode: Filesystem
  volumeName: pvc-e09f5782-61bb-49d7-bf67-d975f2e15870
status:
  accessModes:
    - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound
```

Storage class configuration:
```
ubuntu@ip-172-31-21-105:~/tf-efs/kubeflow-manifests$ kubectl get sc -o yaml
apiVersion: v1
items:
- allowVolumeExpansion: true
  apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"allowVolumeExpansion":true,"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"annotations":{},"name":"efs-sc"},"mountOptions":["tls"],"parameters":{"directoryPerms":"700","fileSystemId":"fs-07bf42ce7f10f6b20","gid":"100","provisioningMode":"efs-ap","uid":"1000"},"provisioner":"efs.csi.aws.com","reclaimPolicy":"Delete","volumeBindingMode":"WaitForFirstConsumer"}
    creationTimestamp: "2023-05-03T23:03:45Z"
    name: efs-sc
    resourceVersion: "123612"
    uid: 426dd9fa-0014-43d6-83fb-85b682b5fb63
  mountOptions:
  - tls
  parameters:
    directoryPerms: "700"
    fileSystemId: fs-07bf42ce7f10f6b20
    gid: "100"
    provisioningMode: efs-ap
    uid: "1000"
  provisioner: efs.csi.aws.com
  reclaimPolicy: Delete
  volumeBindingMode: WaitForFirstConsumer
- apiVersion: storage.k8s.io/v1
  kind: StorageClass
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"},"name":"gp2"},"parameters":{"fsType":"ext4","type":"gp2"},"provisioner":"kubernetes.io/aws-ebs","volumeBindingMode":"WaitForFirstConsumer"}
      storageclass.kubernetes.io/is-default-class: "false"
    creationTimestamp: "2023-05-03T19:43:30Z"
    name: gp2
    resourceVersion: "84473"
    uid: 9ea8c1ec-5030-467d-895d-4df6cbc9d4d0
  parameters:
    fsType: ext4
    type: gp2
  provisioner: kubernetes.io/aws-ebs
  reclaimPolicy: Delete
  volumeBindingMode: WaitForFirstConsumer
kind: List
metadata:
  resourceVersion: ""
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.