### PR TITLE
Update the EKS blueprints module version in use to release v4.31

### DIFF
--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
@@ -69,7 +69,7 @@ data "aws_iam_role" "user_namespace_irsa_iam_role" {
 }
 
 module "kubeflow_secrets_manager_irsa" {
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = true
@@ -84,7 +84,7 @@ module "kubeflow_secrets_manager_irsa" {
 
 module "kubeflow_pipeline_irsa" {
   count                             = local.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false
@@ -99,7 +99,7 @@ module "kubeflow_pipeline_irsa" {
 
 module "user_namespace_irsa" {
   count                             = local.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
   kubernetes_namespace              = "kubeflow-user-example-com"
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -112,7 +112,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.31.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -127,7 +127,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.31.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -113,7 +113,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.31.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -128,7 +128,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.31.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -105,7 +105,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.31.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -120,7 +120,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.31.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -62,7 +62,7 @@ data "aws_iam_role" "user_namespace_irsa_iam_role" {
 
 module "kubeflow_secrets_manager_irsa" {
   count                             = local.use_static || var.use_rds ? 1 : 0
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = true
@@ -77,7 +77,7 @@ module "kubeflow_secrets_manager_irsa" {
 
 module "kubeflow_pipeline_irsa" {
   count                             = local.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false
@@ -92,7 +92,7 @@ module "kubeflow_pipeline_irsa" {
 
 module "user_namespace_irsa" {
   count                             = local.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
   kubernetes_namespace              = "kubeflow-user-example-com"
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -105,7 +105,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.31.0"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -119,7 +119,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.31.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/iaac/terraform/apps/admission-webhook/main.tf
+++ b/iaac/terraform/apps/admission-webhook/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/central-dashboard/main.tf
+++ b/iaac/terraform/apps/central-dashboard/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/jupyter-web-app/main.tf
+++ b/iaac/terraform/apps/jupyter-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/katib/main.tf
+++ b/iaac/terraform/apps/katib/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/kubeflow-pipelines/main.tf
+++ b/iaac/terraform/apps/kubeflow-pipelines/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/models-web-app/main.tf
+++ b/iaac/terraform/apps/models-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/notebook-controller/main.tf
+++ b/iaac/terraform/apps/notebook-controller/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -5,7 +5,7 @@ resource "aws_iam_policy" "profile_controller_policy" {
 }
 
 module "irsa" {
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
   kubernetes_namespace              = "kubeflow"
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false
@@ -19,7 +19,7 @@ module "irsa" {
 }
 
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/tensorboard-controller/main.tf
+++ b/iaac/terraform/apps/tensorboard-controller/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/tensorboards-web-app/main.tf
+++ b/iaac/terraform/apps/tensorboards-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/training-operator/main.tf
+++ b/iaac/terraform/apps/training-operator/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/volumes-web-app/main.tf
+++ b/iaac/terraform/apps/volumes-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -5,7 +5,7 @@ resource "aws_iam_policy" "sagemaker_ack_controller_studio_access" {
 }
 
 module "irsa" {
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.28.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
   kubernetes_namespace              = local.namespace
   create_kubernetes_namespace       = true
   create_kubernetes_service_account = false
@@ -19,7 +19,7 @@ module "irsa" {
 }
 
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   manage_via_gitops = false
   helm_config       = local.helm_config
   set_values = [

--- a/iaac/terraform/common/aws-authservice/main.tf
+++ b/iaac/terraform/common/aws-authservice/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-secrets-manager/main.tf
+++ b/iaac/terraform/common/aws-secrets-manager/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-telemetry/main.tf
+++ b/iaac/terraform/common/aws-telemetry/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/cluster-local-gateway/main.tf
+++ b/iaac/terraform/common/cluster-local-gateway/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/dex/main.tf
+++ b/iaac/terraform/common/dex/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/istio/main.tf
+++ b/iaac/terraform/common/istio/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/knative-eventing/main.tf
+++ b/iaac/terraform/common/knative-eventing/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/knative-serving/main.tf
+++ b/iaac/terraform/common/knative-serving/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kserve/main.tf
+++ b/iaac/terraform/common/kserve/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-issuer/main.tf
+++ b/iaac/terraform/common/kubeflow-issuer/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-istio-resources/main.tf
+++ b/iaac/terraform/common/kubeflow-istio-resources/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-roles/main.tf
+++ b/iaac/terraform/common/kubeflow-roles/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/oidc-authservice/main.tf
+++ b/iaac/terraform/common/oidc-authservice/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/user-namespace/main.tf
+++ b/iaac/terraform/common/user-namespace/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.28.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/tests/e2e/utils/auto-efs-setup.py
+++ b/tests/e2e/utils/auto-efs-setup.py
@@ -14,8 +14,10 @@ def main():
 
     verify_prerequisites()
 
-    setup_iam_authorization()
-    setup_efs_driver()
+    if not SETUP_FOR_TERRAFORM:
+        setup_iam_authorization()
+        setup_efs_driver()
+
     setup_efs_file_system()
     setup_efs_provisioning()
 
@@ -51,9 +53,15 @@ def verify_oidc_provider_prerequisite():
 def is_oidc_provider_present() -> bool:
     eks_client = get_eks_client()
     try:
-        https_oidc_provider = eks_client.describe_cluster(
-            name=CLUSTER_NAME,
-        ).get('cluster').get('identity').get('oidc').get('issuer')
+        https_oidc_provider = (
+            eks_client.describe_cluster(
+                name=CLUSTER_NAME,
+            )
+            .get("cluster")
+            .get("identity")
+            .get("oidc")
+            .get("issuer")
+        )
         return True if "oidc" in https_oidc_provider else False
     except:
         return False
@@ -340,7 +348,6 @@ def wait_for_efs_file_system_to_become_available(efs_file_system_creation_token)
     print("Waiting for EFS file system to become available...")
 
     while status != "available":
-
         status = efs_client.describe_file_systems(
             CreationToken=efs_file_system_creation_token
         )["FileSystems"][0]["LifeCycleState"]
@@ -422,7 +429,6 @@ def create_mount_targets(efs_client, efs_security_group_id, file_system_id, subn
 
 def wait_for_mount_target_to_become_available(efs_client, mount_target_ids):
     for mount_target_id in mount_target_ids:
-
         status = None
 
         print(f"Waiting for EFS mount target {mount_target_id} to become available...")
@@ -586,6 +592,14 @@ parser.add_argument(
     help=f"Specify the path to the source files if different. Default is set to empty.",
     required=False,
 )
+SETUP_FOR_TERRAFORM_DEFAULT = False
+parser.add_argument(
+    "--setup-for-terraform",
+    default=SETUP_FOR_TERRAFORM_DEFAULT,
+    action="store_true",
+    help=f"Skips the creation of the service account for the EFS controller and skips installing the EFS CSI driver since the default Terraform installation performs these steps by default.",
+    required=False,
+)
 
 args, _ = parser.parse_known_args()
 
@@ -599,6 +613,7 @@ if __name__ == "__main__":
     EFS_GID = args.efs_gid
     EFS_UID = args.efs_uid
     DIRECTORY_PATH = args.directory
+    SETUP_FOR_TERRAFORM = args.setup_for_terraform
 
     AWS_ACCOUNT_ID = boto3.client("sts").get_caller_identity()["Account"]
     EFS_IAM_POLICY_NAME = "AmazonEKS_EFS_CSI_Driver_Policy" + EFS_FILE_SYSTEM_NAME

--- a/tests/e2e/utils/auto-efs-setup.py
+++ b/tests/e2e/utils/auto-efs-setup.py
@@ -12,9 +12,8 @@ from time import sleep
 def main():
     header()
 
-    verify_prerequisites()
-
-    if not SETUP_FOR_TERRAFORM:
+    if not SKIP_DRIVER_INSTALLATION:
+        verify_prerequisites()
         setup_iam_authorization()
         setup_efs_driver()
 
@@ -592,10 +591,10 @@ parser.add_argument(
     help=f"Specify the path to the source files if different. Default is set to empty.",
     required=False,
 )
-SETUP_FOR_TERRAFORM_DEFAULT = False
+SKIP_DRIVER_INSTALLATION_DEFAULT = False
 parser.add_argument(
-    "--setup-for-terraform",
-    default=SETUP_FOR_TERRAFORM_DEFAULT,
+    "--skip-driver-installation",
+    default=SKIP_DRIVER_INSTALLATION_DEFAULT,
     action="store_true",
     help=f"Skips the creation of the service account for the EFS controller and skips installing the EFS CSI driver since the default Terraform installation performs these steps by default.",
     required=False,
@@ -613,7 +612,7 @@ if __name__ == "__main__":
     EFS_GID = args.efs_gid
     EFS_UID = args.efs_uid
     DIRECTORY_PATH = args.directory
-    SETUP_FOR_TERRAFORM = args.setup_for_terraform
+    SKIP_DRIVER_INSTALLATION = args.skip_driver_installation
 
     AWS_ACCOUNT_ID = boto3.client("sts").get_caller_identity()["Account"]
     EFS_IAM_POLICY_NAME = "AmazonEKS_EFS_CSI_Driver_Policy" + EFS_FILE_SYSTEM_NAME

--- a/website/content/en/docs/add-ons/storage/efs/guide.md
+++ b/website/content/en/docs/add-ons/storage/efs/guide.md
@@ -39,17 +39,9 @@ export CLAIM_NAME=<efs-claim>
 
 ## 2.0 Set up EFS
 
-#### Setup for Manifest deployments
-
 You can either use Automated or Manual setup to set up the resources required. If you choose the manual route, you get another choice between **static and dynamic provisioning**, so pick whichever suits you. On the other hand, for the automated script we currently only support **dynamic provisioning**. Whichever combination you pick, be sure to continue picking the appropriate sections through the rest of this guide. 
 
-#### Setup for Terraform deployments
-
-Follow the Manual setup to set up the resources required. As part of the Manual setup, you get another choice between **static and dynamic provisioning**, so pick whichever suits you.
-
 ### 2.1 [Option 1] Automated setup
-
-> Important: Terraform deployment users should not follow these Automated setup instructions and should follow the [Manual setup instructions](#22-option-2-manual-setup).
 
 The script automates all the manual resource creation steps but is currently only available for **Dynamic Provisioning** option.  
 It performs the required cluster configuration, creates an EFS file system and it also takes care of creating a storage class for dynamic provisioning. Once done, move to section 3.0. 
@@ -62,15 +54,22 @@ cd $GITHUB_ROOT/tests/e2e
 pip install -r requirements.txt
 ```
 
-3. Run the automated script.
+3. Run the appropriate automated script command for your deployment type.
 
 > Note: If you want the script to create a new security group for EFS, specify a name here. On the other hand, if you want to use an existing Security group, you can specify that name too. We have used the same name as the claim we are going to create. 
 
-```bash
+{{< tabpane persistLang=false >}}
+{{< tab header="Manifest" lang="toml" >}}
 export SECURITY_GROUP_TO_CREATE=$CLAIM_NAME
 
 python utils/auto-efs-setup.py --region $CLUSTER_REGION --cluster $CLUSTER_NAME --efs_file_system_name $CLAIM_NAME --efs_security_group_name $SECURITY_GROUP_TO_CREATE
-```
+{{< /tab >}}
+{{< tab header="Terraform" lang="toml" >}}
+export SECURITY_GROUP_TO_CREATE=$CLAIM_NAME
+
+python utils/auto-efs-setup.py --region $CLUSTER_REGION --cluster $CLUSTER_NAME --efs_file_system_name $CLAIM_NAME --efs_security_group_name $SECURITY_GROUP_TO_CREATE --skip-driver-installation
+{{< /tab >}}
+{{< /tabpane >}}
 
 4. The script above takes care of creating the `StorageClass (SC)` which is a cluster scoped resource. In order to create the `PersistentVolumeClaim (PVC)` you can either use the yaml file provided in this directory or use the Kubeflow UI directly. 
 The PVC needs to be in the namespace you will be accessing it from. Replace the `kubeflow-user-example-com` namespace specified the below with the namespace for your kubeflow user and edit the `efs/dynamic-provisioning/pvc.yaml` file accordingly. 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #717

**Description of your changes:**
- Updated the EKS Blueprints module version in use to v4.31, which contains the updated permissions fix for the EFS CSI driver to work correctly with Kubeflow. Details [here](https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1581).
- Added the `--setup-for-terraform` flag to the EFS auto setup script as a temporary workaround for the missing full Terraform EFS add-on support 

**Testing:**

Tested vanilla Kubeflow with Terraform + modified EFS auto setup script.

### Testing the new flag

With flag:
```
ubuntu@ip-172-31-21-105:~/kfdistro/tf-efs/kubeflow-manifests/tests/e2e$ python utils/auto-efs-setup.py --region $CLUSTER_REGION --cluster $CLUSTER_NAME --efs_file_system_name $CLAIM_NAME --efs_security_group_name $SECURITY_GROUP_TO_CREATE --setup-for-terraform
=================================================================
                          EFS Setup
=================================================================
                   Prerequisites Verification
=================================================================
Verifying OIDC provider...
OIDC provider found
Verifying eksctl is installed...
eksctl found!
Verifying kubectl is installed...
kubectl found!
=================================================================
                      EFS File System Setup
=================================================================
Creating security group 'tf-efs-v4-31-claim'...
VPC_ID:   vpc-068818258b1eeeb17
CIDR:  10.0.0.0/16
Security group created!
Creating EFS file system...
Waiting for EFS file system to become available...
EFS file system is available!
EFS filesystem tf-efs-v4-31-claim created! filesystem id: fs-0a0806e124d8ff137
CLUSTER NODEGROUPS:  ['managed-ondemand-cpu-20230508220131128100000009']
CLUSTER PUBLIC SUBNETS:   ['subnet-0acec358a5a9ceb95', 'subnet-0ea03fe1381126b02', 'subnet-07a276a27d1beaaf9']
Creating mount target in subnet subnet-0acec358a5a9ceb95...
Mount target fsmt-0110832c15a962e54 created!
Creating mount target in subnet subnet-0ea03fe1381126b02...
Mount target fsmt-06840003799d610ea created!
Creating mount target in subnet subnet-07a276a27d1beaaf9...
Mount target fsmt-07a850419cebcbcbc created!
Waiting for EFS mount target fsmt-0110832c15a962e54 to become available...
fsmt-0110832c15a962e54 mount target is available!
Waiting for EFS mount target fsmt-06840003799d610ea to become available...
fsmt-06840003799d610ea mount target is available!
Waiting for EFS mount target fsmt-07a850419cebcbcbc to become available...
fsmt-07a850419cebcbcbc mount target is available!
=================================================================
                      EFS Provisioning Setup
=================================================================
Setting up dynamic provisioning...
Editing storage class with appropriate values...
Creating storage class...
storageclass.storage.k8s.io/efs-sc created
Storage class created!
Dynamic provisioning setup done!
=================================================================
                      EFS Setup Complete
=================================================================
```

Without flag:
Error during script is due to resource contention with the existing Terraform setup, however all steps run as expected when the flag is not provided.
```
ubuntu@ip-172-31-21-105:~/kfdistro/tf-efs/kubeflow-manifests/tests/e2e$ python utils/auto-efs-setup.py --region $CLUSTER_REGION --cluster $CLUSTER_NAME --efs_file_system_name $CLAIM_NAME --efs_security_group_name $SECURITY_GROUP_TO_CREATE
=================================================================
                          EFS Setup
=================================================================
                   Prerequisites Verification
=================================================================
Verifying OIDC provider...
OIDC provider found
Verifying eksctl is installed...
eksctl found!
Verifying kubectl is installed...
kubectl found!
=================================================================
                   IAM Authorization Setup
=================================================================
Creating EFS IAM policy...
EFS IAM policy created!
Creating EFS IAM service account...
2023-05-08 22:54:56 [ℹ]  1 iamserviceaccount (kube-system/efs-csi-controller-sa) was included (based on the include/exclude rules)
2023-05-08 22:54:56 [!]  metadata of serviceaccounts that exist in Kubernetes will be updated, as --override-existing-serviceaccounts was set
2023-05-08 22:54:56 [ℹ]  1 task: {
    2 sequential sub-tasks: {
        create IAM role for serviceaccount "kube-system/efs-csi-controller-sa",
        create serviceaccount "kube-system/efs-csi-controller-sa",
    } }2023-05-08 22:54:56 [ℹ]  building iamserviceaccount stack "eksctl-tf-efs-v4-31-addon-iamserviceaccount-kube-system-efs-csi-controller-sa"
2023-05-08 22:54:57 [ℹ]  deploying stack "eksctl-tf-efs-v4-31-addon-iamserviceaccount-kube-system-efs-csi-controller-sa"
2023-05-08 22:54:57 [ℹ]  waiting for CloudFormation stack "eksctl-tf-efs-v4-31-addon-iamserviceaccount-kube-system-efs-csi-controller-sa"
2023-05-08 22:55:27 [ℹ]  waiting for CloudFormation stack "eksctl-tf-efs-v4-31-addon-iamserviceaccount-kube-system-efs-csi-controller-sa"
2023-05-08 22:55:27 [ℹ]  created serviceaccount "kube-system/efs-csi-controller-sa"
EFS IAM service account created!
=================================================================
                      EFS Driver Setup
=================================================================
Installing EFS driver...
Warning: resource serviceaccounts/efs-csi-controller-sa is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl a
pply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
serviceaccount/efs-csi-controller-sa configured
serviceaccount/efs-csi-node-sa created
Warning: resource clusterroles/efs-csi-external-provisioner-role is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply.
kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatical
ly.
clusterrole.rbac.authorization.k8s.io/efs-csi-external-provisioner-role configured
Warning: resource clusterrolebindings/efs-csi-provisioner-binding is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply.
 kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatica
lly.
clusterrolebinding.rbac.authorization.k8s.io/efs-csi-provisioner-binding configured
Warning: resource deployments/efs-csi-controller is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply sh
ould only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
Warning: resource daemonsets/efs-csi-node is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should on
ly be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
Warning: resource csidrivers/efs.csi.aws.com is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should
 only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
csidriver.storage.k8s.io/efs.csi.aws.com configured
Error from server (Invalid): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":
{\"app.kubernetes.io/name\":\"aws-efs-csi-driver\"},\"name\":\"efs-csi-controller\",\"namespace\":\"kube-system\"},\"spec\":{\"replicas\":2,\"selector\":{\"matchLabels\":{\"app
\":\"efs-csi-controller\",\"app.kubernetes.io/instance\":\"kustomize\",\"app.kubernetes.io/name\":\"aws-efs-csi-driver\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"efs
-csi-controller\",\"app.kubernetes.io/instance\":\"kustomize\",\"app.kubernetes.io/name\":\"aws-efs-csi-driver\"}},\"spec\":{\"containers\":[{\"args\":[\"--endpoint=$(CSI_ENDPO
INT)\",\"--logtostderr\",\"--v=2\",\"--delete-access-point-root-dir=false\"],\"env\":[{\"name\":\"CSI_ENDPOINT\",\"value\":\"unix:///var/lib/csi/sockets/pluginproxy/csi.sock\"}
,{\"name\":\"CSI_NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}}],\"image\":\"amazon/aws-efs-csi-driver:v1.5.3\",\"imagePullPolicy\":\"IfNotPresent\
",\"livenessProbe\":{\"failureThreshold\":5,\"httpGet\":{\"path\":\"/healthz\",\"port\":\"healthz\"},\"initialDelaySeconds\":10,\"periodSeconds\":10,\"timeoutSeconds\":3},\"nam
e\":\"efs-plugin\",\"ports\":[{\"containerPort\":9909,\"name\":\"healthz\",\"protocol\":\"TCP\"}],\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/
var/lib/csi/sockets/pluginproxy/\",\"name\":\"socket-dir\"}]},{\"args\":[\"--csi-address=$(ADDRESS)\",\"--v=2\",\"--feature-gates=Topology=true\",\"--extra-create-metadata\",\"
--leader-election\"],\"env\":[{\"name\":\"ADDRESS\",\"value\":\"/var/lib/csi/sockets/pluginproxy/csi.sock\"}],\"image\":\"public.ecr.aws/eks-distro/kubernetes-csi/external-prov
isioner:v3.3.0-eks-1-25-latest\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"csi-provisioner\",\"volumeMounts\":[{\"mountPath\":\"/var/lib/csi/sockets/pluginproxy/\",\"name
\":\"socket-dir\"}]},{\"args\":[\"--csi-address=/csi/csi.sock\",\"--health-port=9909\"],\"image\":\"public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.8.0-eks-1-25-lates
t\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"liveness-probe\",\"volumeMounts\":[{\"mountPath\":\"/csi\",\"name\":\"socket-dir\"}]}],\"nodeSelector\":{\"kubernetes.io/os\
":\"linux\"},\"priorityClassName\":\"system-cluster-critical\",\"serviceAccountName\":\"efs-csi-controller-sa\",\"volumes\":[{\"emptyDir\":{},\"name\":\"socket-dir\"}]}}}}\n"}}
,"spec":{"selector":{"matchLabels":{"app.kubernetes.io/instance":"kustomize"}},"template":{"metadata":{"labels":{"app.kubernetes.io/instance":"kustomize"}},"spec":{"$setElement
Order/containers":[{"name":"efs-plugin"},{"name":"csi-provisioner"},{"name":"liveness-probe"}],"containers":[{"args":["--endpoint=$(CSI_ENDPOINT)","--logtostderr","--v=2","--de
lete-access-point-root-dir=false"],"image":"amazon/aws-efs-csi-driver:v1.5.3","name":"efs-plugin"}],"serviceAccountName":"efs-csi-controller-sa"}}}}
to:
Resource: "apps/v1, Resource=deployments", GroupVersionKind: "apps/v1, Kind=Deployment"
Name: "efs-csi-controller", Namespace: "kube-system"
for: "https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v1.5.4": error when patching "https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v1.5.4": Deployment.apps "efs-csi-controller" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"efs-csi-controller", "app.kubernetes.io/instance":"kustomize", "app.kubernetes.io/name":"aws-efs-csi-driver"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
Error from server (Invalid): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"apps/v1\",\"kind\":\"DaemonSet\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/name\":\"aws-efs-csi-driver\"},\"name\":\"efs-csi-node\",\"namespace\":\"kube-system\"},\"spec\":{\"selector\":{\"matchLabels\":{\"app\":\"efs-csi-node\",\"app.kubernetes.io/instance\":\"kustomize\",\"app.kubernetes.io/name\":\"aws-efs-csi-driver\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"efs-csi-node\",\"app.kubernetes.io/instance\":\"kustomize\",\"app.kubernetes.io/name\":\"aws-efs-csi-driver\"}},\"spec\":{\"affinity\":{\"nodeAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":{\"nodeSelectorTerms\":[{\"matchExpressions\":[{\"key\":\"eks.amazonaws.com/compute-type\",\"operator\":\"NotIn\",\"values\":[\"fargate\"]}]}]}}},\"containers\":[{\"args\":[\"--endpoint=$(CSI_ENDPOINT)\",\"--logtostderr\",\"--v=2\",\"--vol-metrics-opt-in=false\",\"--vol-metrics-refresh-period=240\",\"--vol-metrics-fs-rate-limit=5\"],\"env\":[{\"name\":\"CSI_ENDPOINT\",\"value\":\"unix:/csi/csi.sock\"}],\"image\":\"amazon/aws-efs-csi-driver:v1.5.3\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"failureThreshold\":5,\"httpGet\":{\"path\":\"/healthz\",\"port\":\"healthz\"},\"initialDelaySeconds\":10,\"periodSeconds\":2,\"timeoutSeconds\":3},\"name\":\"efs-plugin\",\"ports\":[{\"containerPort\":9809,\"name\":\"healthz\",\"protocol\":\"TCP\"}],\"securityContext\":{\"privileged\":true},\"volumeMounts\":[{\"mountPath\":\"/var/lib/kubelet\",\"mountPropagation\":\"Bidirectional\",\"name\":\"kubelet-dir\"},{\"mountPath\":\"/csi\",\"name\":\"plugin-dir\"},{\"mountPath\":\"/var/run/efs\",\"name\":\"efs-state-dir\"},{\"mountPath\":\"/var/amazon/efs\",\"name\":\"efs-utils-config\"},{\"mountPath\":\"/etc/amazon/efs-legacy\",\"name\":\"efs-utils-config-legacy\"}]},{\"args\":[\"--csi-address=$(ADDRESS)\",\"--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)\",\"--v=2\"],\"env\":[{\"name\":\"ADDRESS\",\"value\":\"/csi/csi.sock\"},{\"name\":\"DRIVER_REG_SOCK_PATH\",\"value\":\"/var/lib/kubelet/plugins/efs.csi.aws.com/csi.sock\"},{\"name\":\"KUBE_NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}}],\"image\":\"public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.6.2-eks-1-25-latest\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"csi-driver-registrar\",\"volumeMounts\":[{\"mountPath\":\"/csi\",\"name\":\"plugin-dir\"},{\"mountPath\":\"/registration\",\"name\":\"registration-dir\"}]},{\"args\":[\"--csi-address=/csi/csi.sock\",\"--health-port=9809\",\"--v=2\"],\"image\":\"public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.8.0-eks-1-25-latest\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"liveness-probe\",\"volumeMounts\":[{\"mountPath\":\"/csi\",\"name\":\"plugin-dir\"}]}],\"dnsPolicy\":\"ClusterFirst\",\"hostNetwork\":true,\"nodeSelector\":{\"kubernetes.io/os\":\"linux\"},\"priorityClassName\":\"system-node-critical\",\"serviceAccountName\":\"efs-csi-node-sa\",\"tolerations\":[{\"operator\":\"Exists\"}],\"volumes\":[{\"hostPath\":{\"path\":\"/var/lib/kubelet\",\"type\":\"Directory\"},\"name\":\"kubelet-dir\"},{\"hostPath\":{\"path\":\"/var/lib/kubelet/plugins/efs.csi.aws.com/\",\"type\":\"DirectoryOrCreate\"},\"name\":\"plugin-dir\"},{\"hostPath\":{\"path\":\"/var/lib/kubelet/plugins_registry/\",\"type\":\"Directory\"},\"name\":\"registration-dir\"},{\"hostPath\":{\"path\":\"/var/run/efs\",\"type\":\"DirectoryOrCreate\"},\"name\":\"efs-state-dir\"},{\"hostPath\":{\"path\":\"/var/amazon/efs\",\"type\":\"DirectoryOrCreate\"},\"name\":\"efs-utils-config\"},{\"hostPath\":{\"path\":\"/etc/amazon/efs\",\"type\":\"DirectoryOrCreate\"},\"name\":\"efs-utils-config-legacy\"}]}}}}\n"}},"spec":{"selector":{"matchLabels":{"app.kubernetes.io/instance":"kustomize"}},"template":{"metadata":{"labels":{"app.kubernetes.io/instance":"kustomize"}},"spec":{"$setElementOrder/containers":[{"name":"efs-plugin"},{"name":"csi-driver-registrar"},{"name":"liveness-probe"}],"containers":[{"args":["--endpoint=$(CSI_ENDPOINT)","--logtostderr","--v=2","--vol-metrics-opt-in=false","--vol-metrics-refresh-period=240","--vol-metrics-fs-rate-limit=5"],"image":"amazon/aws-efs-csi-driver:v1.5.3","name":"efs-plugin"}],"serviceAccountName":"efs-csi-node-sa"}}}}
to:
Resource: "apps/v1, Resource=daemonsets", GroupVersionKind: "apps/v1, Kind=DaemonSet"
Name: "efs-csi-node", Namespace: "kube-system"
for: "https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v1.5.4": error when patching "https://github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=tags/v1.5.4": DaemonSet.apps "efs-csi-node" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"efs-csi-node", "app.kubernetes.io/instance":"kustomize", "app.kubernetes.io/name":"aws-efs-csi-driver"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
EFS driver installed!
=================================================================
                      EFS File System Setup
=================================================================
Skipping EFS file system creation, file system 'tf-efs-v4-31-claim' already exists!
=================================================================
                      EFS Provisioning Setup
=================================================================
Setting up dynamic provisioning...
Editing storage class with appropriate values...
Creating storage class...
storageclass.storage.k8s.io/efs-sc unchanged
Storage class created!
Dynamic provisioning setup done!
=================================================================
                      EFS Setup Complete
=================================================================
```

### Testing notebook dynamic provisioning

Notebook yaml after provisioning:
```
apiVersion: kubeflow.org/v1beta1
kind: Notebook
metadata:
  annotations:
    notebooks.kubeflow.org/server-type: jupyter
  creationTimestamp: '2023-05-08T22:51:24Z'
  generation: 1
  labels:
    app: test-tf-efs-v4-31
  managedFields:
    - apiVersion: kubeflow.org/v1beta1
      fieldsType: FieldsV1
      fieldsV1:
        f:metadata:
          f:annotations:
            .: {}
            f:notebooks.kubeflow.org/server-type: {}
          f:labels:
            .: {}
            f:app: {}
        f:spec:
          .: {}
          f:template:
            .: {}
            f:spec:
              .: {}
              f:containers: {}
              f:serviceAccountName: {}
              f:tolerations: {}
              f:volumes: {}
      manager: OpenAPI-Generator
      operation: Update
      time: '2023-05-08T22:51:24Z'
    - apiVersion: kubeflow.org/v1beta1
      fieldsType: FieldsV1
      fieldsV1:
        f:status:
          .: {}
          f:conditions: {}
          f:containerState:
            .: {}
            f:running:
              .: {}
              f:startedAt: {}
          f:readyReplicas: {}
      manager: manager
      operation: Update
      subresource: status
      time: '2023-05-08T22:53:16Z'
  name: test-tf-efs-v4-31
  namespace: kubeflow-user-example-com
  resourceVersion: '35161'
  uid: 72ab4f63-3f62-402d-b2e4-71269787b8b6
spec:
  template:
    spec:
      containers:
        - env: []
          image: >-
            public.ecr.aws/kubeflow-on-aws/notebook-servers/jupyter-tensorflow:2.12.0-cpu-py310-ubuntu20.04-ec2-v1.0
          imagePullPolicy: IfNotPresent
          name: test-tf-efs-v4-31
          resources:
            limits:
              cpu: '0.6'
              memory: 1.2Gi
            requests:
              cpu: '0.5'
              memory: 1Gi
          volumeMounts:
            - mountPath: /dev/shm
              name: dshm
            - mountPath: /home/jovyan
              name: test-tf-efs-v4-31-volume
      serviceAccountName: default-editor
      tolerations: []
      volumes:
        - emptyDir:
            medium: Memory
          name: dshm
        - name: test-tf-efs-v4-31-volume
          persistentVolumeClaim:
            claimName: test-tf-efs-v4-31-volume
status:
  conditions:
    - lastProbeTime: '2023-05-08T22:53:16Z'
      lastTransitionTime: '2023-05-08T22:51:35Z'
      status: 'True'
      type: Initialized
    - lastProbeTime: '2023-05-08T22:53:16Z'
      lastTransitionTime: '2023-05-08T22:53:16Z'
      status: 'True'
      type: Ready
    - lastProbeTime: '2023-05-08T22:53:16Z'
      lastTransitionTime: '2023-05-08T22:53:16Z'
      status: 'True'
      type: ContainersReady
    - lastProbeTime: '2023-05-08T22:53:16Z'
      lastTransitionTime: '2023-05-08T22:51:27Z'
      status: 'True'
      type: PodScheduled
  containerState:
    running:
      startedAt: '2023-05-08T22:53:15Z'
  readyReplicas: 1

```

Notebook volume PVC after provisioning:
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: 'yes'
    pv.kubernetes.io/bound-by-controller: 'yes'
    volume.beta.kubernetes.io/storage-provisioner: efs.csi.aws.com
    volume.kubernetes.io/selected-node: ip-10-0-191-58.us-west-2.compute.internal
    volume.kubernetes.io/storage-provisioner: efs.csi.aws.com
  creationTimestamp: '2023-05-08T22:51:24+00:00'
  finalizers:
    - kubernetes.io/pvc-protection
  managedFields:
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:spec':
          'f:accessModes': {}
          'f:resources':
            'f:requests':
              .: {}
              'f:storage': {}
          'f:storageClassName': {}
          'f:volumeMode': {}
      manager: OpenAPI-Generator
      operation: Update
      time: '2023-05-08T22:51:24+00:00'
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            'f:pv.kubernetes.io/bind-completed': {}
            'f:pv.kubernetes.io/bound-by-controller': {}
            'f:volume.beta.kubernetes.io/storage-provisioner': {}
            'f:volume.kubernetes.io/storage-provisioner': {}
        'f:spec':
          'f:volumeName': {}
      manager: kube-controller-manager
      operation: Update
      time: '2023-05-08T22:51:26+00:00'
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          'f:accessModes': {}
          'f:capacity':
            .: {}
            'f:storage': {}
          'f:phase': {}
      manager: kube-controller-manager
      operation: Update
      subresource: status
      time: '2023-05-08T22:51:26+00:00'
    - apiVersion: v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            .: {}
            'f:volume.kubernetes.io/selected-node': {}
      manager: kube-scheduler
      operation: Update
      time: '2023-05-08T22:51:26+00:00'
  name: test-tf-efs-v4-31-volume
  namespace: kubeflow-user-example-com
  resourceVersion: '33977'
  uid: 3a252a3d-f2b1-4a36-8961-8cc88c46153f
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: efs-sc
  volumeMode: Filesystem
  volumeName: pvc-3a252a3d-f2b1-4a36-8961-8cc88c46153f
status:
  accessModes:
    - ReadWriteOnce
  capacity:
    storage: 1Gi
  phase: Bound

```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.