### PR TITLE
Describe name fix in auto setup script for internal scheme ALBs

### DIFF
--- a/tests/e2e/utils/aws/elbv2.py
+++ b/tests/e2e/utils/aws/elbv2.py
@@ -39,12 +39,16 @@ class ElasticLoadBalancingV2:
         """
         Workaround to extract load balancer name from dns.
 
-        If ALB DNS is 72d70454-istiosystem-istio-2ab2-xxxxxxxxxx.us-east-1.elb.amazonaws.com
+        If ALB DNS is internal-72d70454-istiosystem-istio-2ab2-xxxxxxxxxx.us-east-1.elb.amazonaws.com
         ALB name is 72d70454-istiosystem-istio-2ab2
         """
-        dns_prefix = dns.split(".")[0]
+
+        # 'internal-' is not a valid prefix according to ALB validation so we strip it here
+        dns_stripped = dns.lstrip("internal-")
+
+        dns_prefix = dns_stripped.lstrip("internal-").split(".")[0]
         last_hypen_index = dns_prefix.rfind("-")
         if last_hypen_index != -1:
-            return dns[:last_hypen_index]
+            return dns_stripped[:last_hypen_index]
         else:
             return dns_prefix

--- a/tests/e2e/utils/aws/elbv2.py
+++ b/tests/e2e/utils/aws/elbv2.py
@@ -46,7 +46,7 @@ class ElasticLoadBalancingV2:
         # 'internal-' is not a valid prefix according to ALB validation so we strip it here
         dns_stripped = dns.lstrip("internal-")
 
-        dns_prefix = dns_stripped.lstrip("internal-").split(".")[0]
+        dns_prefix = dns_stripped.split(".")[0]
         last_hypen_index = dns_prefix.rfind("-")
         if last_hypen_index != -1:
             return dns_stripped[:last_hypen_index]


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/awslabs/kubeflow-manifests/issues/552

**Description of your changes:**
Currently the ALB name is extracted from the ALB DNS. For internal scheme ALBs the DNS contains a `internal-` prefix that is not part of the ALB name.

<img width="972" alt="Screen Shot 2023-05-10 at 2 08 12 PM" src="https://github.com/awslabs/kubeflow-manifests/assets/91350438/352b099f-a21e-47f9-8aac-934b79271483">


The changes in this PR strip `internal-` from the front of the DNS name. ALB validation prevents ALBs with `internal-` as a prefix from being created.

**Testing:**

Tested auto setup script:

```
ubuntu@ip-172-31-21-105:~/kfdistro/internal-lb-name/kubeflow-manifests/tests/e2e$ PYTHONPATH=.. python utils/load_balancer/setup_load_balancer.py
=================================================================
                          Reading Config
=================================================================
=================================================================
                  Creating Subdomain in Route 53
=================================================================
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:e2e.utils.aws.route53:created hosted zone internallb.rkharse.people.aws.dev with id Z00017732SEX83VY6HBBP
INFO:e2e.utils.aws.route53:waiting for for change id: C00290083SGKI7MGQMU9J to be IN_SYNC in hosted zone: Z09881373FTWJWBP0QN22, domain: rkharse.people.aws.dev
=================================================================
                   Creating Certificate in ACM
=================================================================
INFO:e2e.utils.aws.acm:requested DNS validation for domain *.rkharse.people.aws.dev.                 certificate ARN is arn:aws:acm:us-west-2:556017915589:certificate/f7447c75-
2e88-4cd9-a0bf-2c5633f20848.
INFO:e2e.utils.aws.acm:arn:aws:acm:us-west-2:556017915589:certificate/f7447c75-2e88-4cd9-a0bf-2c5633f20848: waiting for domain validation record ...
INFO:e2e.utils.aws.route53:waiting for for change id: C0167757FA3S1JHWEKFT to be IN_SYNC in hosted zone: Z09881373FTWJWBP0QN22, domain: rkharse.people.aws.dev
INFO:e2e.utils.aws.acm:arn:aws:acm:us-west-2:556017915589:certificate/f7447c75-2e88-4cd9-a0bf-2c5633f20848: waiting for validation ...
INFO:e2e.utils.aws.acm:requested DNS validation for domain *.internallb.rkharse.people.aws.dev.                 certificate ARN is arn:aws:acm:us-west-2:556017915589:certificat
e/52ae7c85-d7ac-466e-9e38-c2f70994d634.
INFO:e2e.utils.aws.acm:arn:aws:acm:us-west-2:556017915589:certificate/52ae7c85-d7ac-466e-9e38-c2f70994d634: waiting for domain validation record ...
INFO:e2e.utils.aws.route53:waiting for for change id: C06197623SXTC35K87BBZ to be IN_SYNC in hosted zone: Z00017732SEX83VY6HBBP, domain: internallb.rkharse.people.aws.dev
INFO:e2e.utils.aws.acm:arn:aws:acm:us-west-2:556017915589:certificate/52ae7c85-d7ac-466e-9e38-c2f70994d634: waiting for validation ...
=================================================================
    Configuring Ingress and load balancer controller manifests
=================================================================
2023-05-10 20:46:43 [ℹ]  IAM Open ID Connect provider is already associated with cluster "internal-lb-name" in "us-west-2"
INFO:e2e.utils.aws.iam:created iam policy arn:aws:iam::556017915589:policy/alb_ingress_controller_internal-lb-namefzw5ugcgzo.
2023-05-10 20:46:45 [ℹ]  3 existing iamserviceaccount(s) (kube-system/aws-load-balancer-controller,kube-system/aws-node,kube-system/ebs-csi-controller-sa) will be excluded
2023-05-10 20:46:45 [ℹ]  1 iamserviceaccount (kube-system/aws-load-balancer-controller) was excluded (based on the include/exclude rules)
2023-05-10 20:46:45 [!]  metadata of serviceaccounts that exist in Kubernetes will be updated, as --override-existing-serviceaccounts was set
2023-05-10 20:46:45 [ℹ]  no tasks
=================================================================
Creating Ingress, load balancer and updating the domain's DNS record
=================================================================
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
2023/05/10 20:46:45 well-defined vars that were never replaced: clusterName
customresourcedefinition.apiextensions.k8s.io/ingressclassparams.elbv2.k8s.aws unchanged
customresourcedefinition.apiextensions.k8s.io/targetgroupbindings.elbv2.k8s.aws unchanged
serviceaccount/aws-load-balancer-controller unchanged
role.rbac.authorization.k8s.io/aws-load-balancer-controller-leader-election-role unchanged
clusterrole.rbac.authorization.k8s.io/aws-load-balancer-controller-role configured
rolebinding.rbac.authorization.k8s.io/aws-load-balancer-controller-leader-election-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/aws-load-balancer-controller-rolebinding unchanged
configmap/istio-ingress-parameters unchanged
configmap/aws-load-balancer-controller-config unchanged
service/aws-load-balancer-webhook-service unchanged
deployment.apps/aws-load-balancer-controller unchanged
certificate.cert-manager.io/aws-load-balancer-serving-cert unchanged
issuer.cert-manager.io/aws-load-balancer-selfsigned-issuer unchanged
ingress.networking.k8s.io/istio-ingress unchanged
mutatingwebhookconfiguration.admissionregistration.k8s.io/aws-load-balancer-webhook configured
validatingwebhookconfiguration.admissionregistration.k8s.io/aws-load-balancer-webhook configured
running command: ['kubectl', 'wait', '--for', 'condition=established', '--timeout=60s', 'crd/ingressclassparams.elbv2.k8s.aws']
customresourcedefinition.apiextensions.k8s.io/ingressclassparams.elbv2.k8s.aws condition met
customresourcedefinition.apiextensions.k8s.io/ingressclassparams.elbv2.k8s.aws unchanged
customresourcedefinition.apiextensions.k8s.io/targetgroupbindings.elbv2.k8s.aws unchanged
serviceaccount/aws-load-balancer-controller unchanged
role.rbac.authorization.k8s.io/aws-load-balancer-controller-leader-election-role unchanged
clusterrole.rbac.authorization.k8s.io/aws-load-balancer-controller-role configured
rolebinding.rbac.authorization.k8s.io/aws-load-balancer-controller-leader-election-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/aws-load-balancer-controller-rolebinding unchanged
configmap/istio-ingress-parameters unchanged
configmap/aws-load-balancer-controller-config unchanged
service/aws-load-balancer-webhook-service unchanged
deployment.apps/aws-load-balancer-controller unchanged
certificate.cert-manager.io/aws-load-balancer-serving-cert unchanged
issuer.cert-manager.io/aws-load-balancer-selfsigned-issuer unchanged
ingress.networking.k8s.io/istio-ingress unchanged
mutatingwebhookconfiguration.admissionregistration.k8s.io/aws-load-balancer-webhook configured
validatingwebhookconfiguration.admissionregistration.k8s.io/aws-load-balancer-webhook configured
INFO:__main__:waiting for ALB creation ...
INFO:__main__: internal-k8s-istiosys-istioing-a54524e5ec-369534536.us-west-2.elb.amazonaws.com waiting for ALB status = active ...
INFO:e2e.utils.aws.route53:waiting for for change id: C1000779Z3PLM25PI2F7 to be IN_SYNC in hosted zone: Z00017732SEX83VY6HBBP, domain: internallb.rkharse.people.aws.dev
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.