### PR TITLE
Version locking terraform aws provider

### DIFF
--- a/deployments/cognito-rds-s3/terraform/versions.tf
+++ b/deployments/cognito-rds-s3/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 5.0.0, < 6.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/deployments/cognito/terraform/versions.tf
+++ b/deployments/cognito/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 5.0.0, < 6.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/deployments/rds-s3/terraform/versions.tf
+++ b/deployments/rds-s3/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 5.0.0, < 6.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/deployments/vanilla/terraform/versions.tf
+++ b/deployments/vanilla/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.30.0"
+      version = ">= 5.0.0, < 6.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -109,6 +109,14 @@ def get_root_domain_name(request):
     return request.config.getoption("--root-domain-name")
 
 
+def get_pipeline_s3_credential_option(request):
+    pipeline_s3_credential_option = request.config.getoption(
+        "--pipeline_s3_credential_option"
+    )
+    if not pipeline_s3_credential_option:
+        pipeline_s3_credential_option = "static"
+    return pipeline_s3_credential_option
+
 @pytest.fixture(scope="class")
 def region(metadata, request):
     """

--- a/tests/e2e/tests/terraform/test_cognito.py
+++ b/tests/e2e/tests/terraform/test_cognito.py
@@ -14,7 +14,7 @@ TF_FOLDER = TO_ROOT + "deployments/cognito/terraform/"
 
 @pytest.fixture(scope="class")
 def installation(region, metadata, request):
-    cluster_name = rand_name(TEST_SUITE_NAME + "-")
+    cluster_name = rand_name(TEST_SUITE_NAME + "-")[:18]
     subdomain_name = rand_name("sub") + "." + get_root_domain_name(request)
     cognito_user_pool_name = rand_name("up-")
 

--- a/tests/e2e/tests/terraform/test_cognito_rds_s3.py
+++ b/tests/e2e/tests/terraform/test_cognito_rds_s3.py
@@ -20,7 +20,7 @@ TF_FOLDER = TO_ROOT + "deployments/cognito-rds-s3/terraform/"
 
 @pytest.fixture(scope="class")
 def installation(region, metadata, request):
-    cluster_name = rand_name(TEST_SUITE_NAME + "-")
+    cluster_name = rand_name(TEST_SUITE_NAME + "-")[:18]
     db_username = rand_name("user")
     db_password = rand_name("pw")
     subdomain_name = rand_name("sub") + "." + get_root_domain_name(request)

--- a/tests/e2e/tests/terraform/test_rds_s3.py
+++ b/tests/e2e/tests/terraform/test_rds_s3.py
@@ -29,7 +29,7 @@ TF_FOLDER = TO_ROOT + "deployments/rds-s3/terraform/"
 
 @pytest.fixture(scope="class")
 def installation(region, metadata, request):
-    cluster_name = rand_name(TEST_SUITE_NAME + "-")
+    cluster_name = rand_name(TEST_SUITE_NAME + "-")[:18]
     db_username = rand_name("user")
     db_password = rand_name("pw")
     pipeline_s3_credential_option = get_pipeline_s3_credential_option(request)

--- a/tests/e2e/tests/terraform/test_vanilla.py
+++ b/tests/e2e/tests/terraform/test_vanilla.py
@@ -27,7 +27,7 @@ TF_FOLDER = TO_ROOT + "deployments/vanilla/terraform/"
 
 @pytest.fixture(scope="class")
 def installation(region, metadata, request):
-    cluster_name = rand_name(TEST_SUITE_NAME + "-")
+    cluster_name = rand_name(TEST_SUITE_NAME + "-")[:18]
 
     input_variables = {
         "cluster_name": cluster_name,


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
**Description of your changes:**

- Locking terraform aws module to one major version (5.x.x)
- Various integ test bug fixes

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass - Vanilla and RDS-S3 pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.