### PR TITLE
Tests: describe pod if error on condition wait command

### DIFF
--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -266,7 +266,13 @@ def kubectl_wait_pods(
     else:
         cmd = f"kubectl wait --for=condition={condition} pod -l '{identifier} in ({pods})' --timeout={timeout}s"
     print(f"running command: {cmd}")
-    assert os.system(cmd) == 0
+    retcode = os.system(cmd)
+
+    if retcode is not 0:
+        ns = f"-n {namespace}" if namespace else ""
+        debug_cmd = f"kubectl describe pod -l '{identifier} in ({pods})' --timeout={timeout}s {ns}"
+        os.system(debug_cmd)
+        raise Exception("Timeout/error waiting for pod condition")
 
 
 def kubectl_wait_crd(crd, timeout=60, condition="established"):


### PR DESCRIPTION
**Description of your changes:**
Encountered some failures in our canaries where tests timed out waiting to be ready, however we don't have any details on pod status, etc. to root cause and fix the issue.

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.