### PR TITLE
Revert "Tests: describe pod if error on condition wait command"

### DIFF
--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -266,13 +266,7 @@ def kubectl_wait_pods(
     else:
         cmd = f"kubectl wait --for=condition={condition} pod -l '{identifier} in ({pods})' --timeout={timeout}s"
     print(f"running command: {cmd}")
-    retcode = os.system(cmd)
-
-    if retcode is not 0:
-        ns = f"-n {namespace}" if namespace else ""
-        debug_cmd = f"kubectl describe pod -l '{identifier} in ({pods})' --timeout={timeout}s {ns}"
-        os.system(debug_cmd)
-        raise Exception("Timeout/error waiting for pod condition")
+    assert os.system(cmd) == 0
 
 
 def kubectl_wait_crd(crd, timeout=60, condition="established"):


### PR DESCRIPTION
There is a spike in KFP/ACK canary test failures, may due to awslabs/kubeflow-manifests#769
Reverts awslabs/kubeflow-manifests#769