### PR TITLE
Upgrading eks blueprints to v4.32.1

### DIFF
--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
@@ -69,7 +69,7 @@ data "aws_iam_role" "user_namespace_irsa_iam_role" {
 }
 
 module "kubeflow_secrets_manager_irsa" {
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.32.1"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = true
@@ -84,7 +84,7 @@ module "kubeflow_secrets_manager_irsa" {
 
 module "kubeflow_pipeline_irsa" {
   count                             = local.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.32.1"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false
@@ -99,7 +99,7 @@ module "kubeflow_pipeline_irsa" {
 
 module "user_namespace_irsa" {
   count                             = local.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.32.1"
   kubernetes_namespace              = "kubeflow-user-example-com"
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -112,7 +112,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.31.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.32.1"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -127,7 +127,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.31.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.32.1"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -113,7 +113,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.31.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.32.1"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -128,7 +128,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.31.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.32.1"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -105,7 +105,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.31.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.32.1"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -120,7 +120,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.31.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.32.1"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -62,7 +62,7 @@ data "aws_iam_role" "user_namespace_irsa_iam_role" {
 
 module "kubeflow_secrets_manager_irsa" {
   count                             = local.use_static || var.use_rds ? 1 : 0
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.32.1"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = true
@@ -77,7 +77,7 @@ module "kubeflow_secrets_manager_irsa" {
 
 module "kubeflow_pipeline_irsa" {
   count                             = local.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.32.1"
   kubernetes_namespace              = kubernetes_namespace.kubeflow.metadata[0].name
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false
@@ -92,7 +92,7 @@ module "kubeflow_pipeline_irsa" {
 
 module "user_namespace_irsa" {
   count                             = local.use_static ? 0 : 1
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.32.1"
   kubernetes_namespace              = "kubeflow-user-example-com"
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -105,7 +105,7 @@ data "aws_ec2_instance_type_offerings" "availability_zones_gpu" {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.31.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.32.1"
 
   cluster_name    = local.cluster_name
   cluster_version = local.eks_version
@@ -119,7 +119,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.31.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.32.1"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/iaac/terraform/apps/admission-webhook/main.tf
+++ b/iaac/terraform/apps/admission-webhook/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/central-dashboard/main.tf
+++ b/iaac/terraform/apps/central-dashboard/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/jupyter-web-app/main.tf
+++ b/iaac/terraform/apps/jupyter-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/katib/main.tf
+++ b/iaac/terraform/apps/katib/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/kubeflow-pipelines/main.tf
+++ b/iaac/terraform/apps/kubeflow-pipelines/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/models-web-app/main.tf
+++ b/iaac/terraform/apps/models-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/notebook-controller/main.tf
+++ b/iaac/terraform/apps/notebook-controller/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -5,7 +5,7 @@ resource "aws_iam_policy" "profile_controller_policy" {
 }
 
 module "irsa" {
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.32.1"
   kubernetes_namespace              = "kubeflow"
   create_kubernetes_namespace       = false
   create_kubernetes_service_account = false
@@ -19,7 +19,7 @@ module "irsa" {
 }
 
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/tensorboard-controller/main.tf
+++ b/iaac/terraform/apps/tensorboard-controller/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/tensorboards-web-app/main.tf
+++ b/iaac/terraform/apps/tensorboards-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/training-operator/main.tf
+++ b/iaac/terraform/apps/training-operator/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/apps/volumes-web-app/main.tf
+++ b/iaac/terraform/apps/volumes-web-app/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -5,7 +5,7 @@ resource "aws_iam_policy" "sagemaker_ack_controller_studio_access" {
 }
 
 module "irsa" {
-  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.31.0"
+  source                            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.32.1"
   kubernetes_namespace              = local.namespace
   create_kubernetes_namespace       = true
   create_kubernetes_service_account = false
@@ -19,7 +19,7 @@ module "irsa" {
 }
 
 module "helm_addon" {
-  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   manage_via_gitops = false
   helm_config       = local.helm_config
   set_values = [

--- a/iaac/terraform/common/aws-authservice/main.tf
+++ b/iaac/terraform/common/aws-authservice/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-secrets-manager/main.tf
+++ b/iaac/terraform/common/aws-secrets-manager/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/aws-telemetry/main.tf
+++ b/iaac/terraform/common/aws-telemetry/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/cluster-local-gateway/main.tf
+++ b/iaac/terraform/common/cluster-local-gateway/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/dex/main.tf
+++ b/iaac/terraform/common/dex/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/istio/main.tf
+++ b/iaac/terraform/common/istio/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/knative-eventing/main.tf
+++ b/iaac/terraform/common/knative-eventing/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/knative-serving/main.tf
+++ b/iaac/terraform/common/knative-serving/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kserve/main.tf
+++ b/iaac/terraform/common/kserve/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-issuer/main.tf
+++ b/iaac/terraform/common/kubeflow-issuer/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-istio-resources/main.tf
+++ b/iaac/terraform/common/kubeflow-istio-resources/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/kubeflow-roles/main.tf
+++ b/iaac/terraform/common/kubeflow-roles/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/oidc-authservice/main.tf
+++ b/iaac/terraform/common/oidc-authservice/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }

--- a/iaac/terraform/common/user-namespace/main.tf
+++ b/iaac/terraform/common/user-namespace/main.tf
@@ -1,5 +1,5 @@
 module "helm_addon" {
-  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.31.0"
+  source        = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.32.1"
   helm_config   = local.helm_config
   addon_context = var.addon_context
 }


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Terraform deployments are not working because eks blueprints before v4.32.1 did not pin their version in the main.tf file. As a result terraform pulled the modules from the main branch. Last week eks blueprints removed the modules as part of their refactoring effort which breaks any version before v4.32.1.

Further reading:

https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1699
https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1630#issuecomment-1577525242

**Description of your changes:**

Upgrade terraform-aws-eks-blueprints from `v4.31.0` to `v4.32.1`

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.