### PR TITLE
Adding aws load balancer controller module

### DIFF
--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -142,7 +142,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   # EKS Blueprints Add-ons
   enable_cert_manager                 = true
-  enable_aws_load_balancer_controller = true
+  enable_aws_load_balancer_controller = false
 
   aws_efs_csi_driver_helm_config = {
     namespace = "kube-system"
@@ -186,6 +186,15 @@ module "eks_blueprints_kubernetes_addons" {
 
   tags = local.tags
 
+}
+
+module "aws_load_balancer_controller" {
+  source = "../../../iaac/terraform/common/aws-load-balancer-controller"
+
+  cluster_name      = local.cluster_name
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
+
+  tags = local.tags
 }
 
 # todo: update the blueprints repo code to export the desired values as outputs
@@ -248,6 +257,8 @@ module "kubeflow_components" {
   load_balancer_scheme            = var.load_balancer_scheme
 
   tags = local.tags
+
+  depends_on = [module.aws_load_balancer_controller]
 
   providers = {
     aws          = aws

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -143,7 +143,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   # EKS Blueprints Add-ons
   enable_cert_manager                 = true
-  enable_aws_load_balancer_controller = true
+  enable_aws_load_balancer_controller = false
 
   aws_efs_csi_driver_helm_config = {
     namespace = "kube-system"
@@ -177,6 +177,15 @@ module "eks_blueprints_outputs" {
   tags = local.tags
 }
 
+module "aws_load_balancer_controller" {
+  source = "../../../iaac/terraform/common/aws-load-balancer-controller"
+
+  cluster_name      = local.cluster_name
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
+
+  tags = local.tags
+}
+
 module "kubeflow_components" {
   source = "./cognito-components"
 
@@ -195,6 +204,8 @@ module "kubeflow_components" {
   load_balancer_scheme            = var.load_balancer_scheme
 
   tags = local.tags
+
+  depends_on = [module.aws_load_balancer_controller]
 
   providers = {
     aws          = aws

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -135,7 +135,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   # EKS Blueprints Add-ons
   enable_cert_manager                 = true
-  enable_aws_load_balancer_controller = true
+  enable_aws_load_balancer_controller = false
 
   aws_efs_csi_driver_helm_config = {
     namespace = "kube-system"
@@ -193,6 +193,14 @@ module "eks_blueprints_outputs" {
   tags = local.tags
 }
 
+module "aws_load_balancer_controller" {
+  source = "../../../iaac/terraform/common/aws-load-balancer-controller"
+
+  cluster_name      = local.cluster_name
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
+  tags = local.tags
+}
+
 module "kubeflow_components" {
   source = "./rds-s3-components"
 
@@ -233,6 +241,8 @@ module "kubeflow_components" {
   minio_aws_secret_access_key = var.minio_aws_secret_access_key
 
   tags = local.tags
+
+  depends_on = [module.aws_load_balancer_controller]
 }
 
 #---------------------------------------------------------------

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -134,7 +134,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   # EKS Blueprints Add-ons
   enable_cert_manager                 = true
-  enable_aws_load_balancer_controller = true
+  enable_aws_load_balancer_controller = false
 
   aws_efs_csi_driver_helm_config = {
     namespace = "kube-system"
@@ -154,6 +154,14 @@ module "eks_blueprints_kubernetes_addons" {
 
   tags = local.tags
 
+}
+
+module "aws_load_balancer_controller" {
+  source = "../../../iaac/terraform/common/aws-load-balancer-controller"
+
+  cluster_name      = local.cluster_name
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
+  tags = local.tags
 }
 
 
@@ -180,6 +188,8 @@ module "kubeflow_components" {
   notebook_idleness_check_period = var.notebook_idleness_check_period
 
   tags = local.tags
+
+  depends_on = [module.aws_load_balancer_controller]
 }
 
 #---------------------------------------------------------------
@@ -219,4 +229,5 @@ module "vpc" {
   }
 
   tags = local.tags
+
 }

--- a/iaac/terraform/common/aws-load-balancer-controller/main.tf
+++ b/iaac/terraform/common/aws-load-balancer-controller/main.tf
@@ -1,0 +1,41 @@
+module "aws_load_balancer_controller" {
+  source  = "aws-ia/eks-blueprints-addon/aws"
+  version = "1.1.0"
+
+  # https://github.com/aws/eks-charts/blob/master/stable/aws-load-balancer-controller/Chart.yaml
+  name        = "aws-load-balancer-controller"
+  description = "A Helm chart to deploy aws-load-balancer-controller for ingress resources"
+  namespace   = "kube-system"
+  # namespace creation is false here as kube-system already exists by default
+  create_namespace = false
+  chart            = "aws-load-balancer-controller"
+  chart_version    = try(var.chart_version, "1.5.5") 
+  repository       = try(var.chart_repo, "https://aws.github.io/eks-charts")  
+
+  set = [
+    {
+      name  = "serviceAccount.name"
+      value = "aws-load-balancer-controller-sa"
+      }, {
+      name  = "clusterName"
+      value = var.cluster_name
+    }]
+
+  # IAM role for service account (IRSA)
+  create_role                   = true
+  set_irsa_names                = ["serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"]
+  role_name                     = try(var.role_name, "alb-controller")
+  role_name_use_prefix          = try(var.role_name_use_prefix, true)
+
+  source_policy_documents       = [file("../../../awsconfigs/infra_configs/iam_alb_ingress_policy.json")]
+  policy_description            = "IAM Policy for AWS Load Balancer Controller"
+
+  oidc_providers = {
+    this = {
+      provider_arn = var.oidc_provider_arn
+      service_account = "aws-load-balancer-controller-sa"
+    }
+  }
+
+  tags = var.tags
+}

--- a/iaac/terraform/common/aws-load-balancer-controller/variables.tf
+++ b/iaac/terraform/common/aws-load-balancer-controller/variables.tf
@@ -1,0 +1,35 @@
+# Required vars
+variable "cluster_name" {
+    type = string
+}
+
+variable "oidc_provider_arn" {
+    type = string
+}
+
+# Optional vars
+
+variable "chart_version" {
+    type = string
+    default = "1.5.5"
+}
+
+variable "chart_repo" {
+    type = string
+    default = "https://aws.github.io/eks-charts"
+}
+
+variable "role_name" {
+    type = string
+    default = "alb-controller"
+}
+
+variable "role_name_use_prefix" {
+    type = bool
+    default = true
+}
+
+variable "tags" {
+    type = any
+    default = {}
+}

--- a/iaac/terraform/common/aws-load-balancer-controller/versions.tf
+++ b/iaac/terraform/common/aws-load-balancer-controller/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.2.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.30.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.13.1"
+    }
+  }
+}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #775 

**Description of your changes:**
Creating a custom module for the AWS Load Balancer controller. Ideally this would be present in the module by aws-ia but policy size limitations prevent it for v5 and changes aren't being accepted for v4.

I tried using v5 but ran into issues with policy sizes. This solution uses the eks blueprint addon. The same method as the actual v5 load balancer addon but with a shortened policy size.

The policy specified [here](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/1f4b8c466587a41b4810d01e6ac0ccdac416c6e9/main.tf#L895) has 6001 characters. The new permissions require 402 characters which makes the policy more than 6144 characters ie the [character size limit](https://repost.aws/knowledge-center/iam-increase-policy-size). Even specifying a custom policy does not seem to work.


**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass - Congnito and vanilla pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.