### PR TITLE
Migrate to v5 blueprints

### DIFF
--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -127,21 +127,11 @@ module "eks_blueprints" {
 }
 
 module "ebs_csi_driver_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.20"
-
-  role_name_prefix = "${local.cluster_name}-ebs-csi-driver-"
-
-  attach_ebs_csi_policy = true
-
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks_blueprints.eks_oidc_provider_arn
-      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
-    }
-  }
-
-  tags = local.tags
+  source                = "../../../iaac/terraform/aws-infra/ebs-csi-driver-irsa"
+  cluster_name          = local.cluster_name
+  cluster_region        = local.region
+  tags                  = local.tags
+  eks_oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
 }
 
 module "eks_blueprints_kubernetes_addons" {
@@ -191,8 +181,6 @@ depends_on = [module.ebs_csi_driver_irsa, module.eks_data_addons]
     namespace = "kube-system"
     chart_version = "1.5.1"
   }
-
-  enable_aws_fsx_csi_driver = true
 
   secrets_store_csi_driver = {
     namespace = "kube-system"

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -126,54 +126,88 @@ module "eks_blueprints" {
   tags = local.tags
 }
 
+module "ebs_csi_driver_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.20"
+
+  role_name_prefix = "${local.cluster_name}-ebs-csi-driver-"
+
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks_blueprints.eks_oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+
+  tags = local.tags
+}
+
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.32.1"
+  source = "aws-ia/eks-blueprints-addons/aws"
+  version = "~> 1.0" #ensure to update this to the latest/desired version
 
-  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
-  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider    = module.eks_blueprints.oidc_provider
-  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
+  cluster_name      = local.cluster_name
+  cluster_endpoint  = module.eks_blueprints.eks_cluster_endpoint
+  cluster_version   = module.eks_blueprints.eks_cluster_version
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
 
-  # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni            = true
-  enable_amazon_eks_coredns            = true
-  enable_amazon_eks_kube_proxy         = true
-  enable_amazon_eks_aws_ebs_csi_driver = true
+depends_on = [module.ebs_csi_driver_irsa, module.eks_data_addons]
 
-  # EKS Blueprints Add-ons
-  enable_cert_manager                 = true
-  enable_aws_load_balancer_controller = true
+  eks_addons = {
+    aws-ebs-csi-driver = {
+      most_recent = true
+      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+    }
+    coredns = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
+  }
 
-  aws_efs_csi_driver_helm_config = {
-    namespace = "kube-system"
-    version   = "2.4.1"
+  enable_aws_load_balancer_controller    = true
+  enable_cert_manager                    = true
+
+  cert_manager = {
+    chart_version = "v1.10.0"
   }
 
   enable_aws_efs_csi_driver = true
+  enable_aws_fsx_csi_driver = true
 
-  aws_fsx_csi_driver_helm_config = {
+
+  aws_efs_csi_driver = {
     namespace = "kube-system"
-    version   = "1.5.1"
+    chart_version = "2.4.1"
+  }
+
+  aws_fsx_csi_driver = {
+    namespace = "kube-system"
+    chart_version = "1.5.1"
   }
 
   enable_aws_fsx_csi_driver = true
 
-  enable_nvidia_device_plugin = local.using_gpu
-
-  secrets_store_csi_driver_helm_config = {
+  secrets_store_csi_driver = {
     namespace = "kube-system"
-    version   = "1.3.2"
+    chart_version   = "1.3.2"
     set = [
       {
         name  = "syncSecret.enabled",
         value = "true"
       }
-    ]
+    ] 
   }
+  
   enable_secrets_store_csi_driver = true
 
-
-  csi_secrets_store_provider_aws_helm_config = {
+  secrets_store_csi_driver_provider_aws = {
     namespace = "kube-system"
     set = [
       {
@@ -182,10 +216,19 @@ module "eks_blueprints_kubernetes_addons" {
       }
     ]
   }
+  
   enable_secrets_store_csi_driver_provider_aws = true
 
   tags = local.tags
+}
 
+module "eks_data_addons" {
+  source = "aws-ia/eks-data-addons/aws"
+  version = "~> 1.0" # ensure to update this to the latest/desired version
+
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
+
+  enable_nvidia_gpu_operator = local.using_gpu
 }
 
 # todo: update the blueprints repo code to export the desired values as outputs
@@ -248,6 +291,7 @@ module "kubeflow_components" {
   load_balancer_scheme            = var.load_balancer_scheme
 
   tags = local.tags
+
 
   providers = {
     aws          = aws

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -135,7 +135,7 @@ module "ebs_csi_driver_irsa" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "aws-ia/eks-blueprints-addons/aws"
+  source  = "aws-ia/eks-blueprints-addons/aws"
   version = "~> 1.0" #ensure to update this to the latest/desired version
 
   cluster_name      = local.cluster_name
@@ -143,11 +143,11 @@ module "eks_blueprints_kubernetes_addons" {
   cluster_version   = module.eks_blueprints.eks_cluster_version
   oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
 
-depends_on = [module.ebs_csi_driver_irsa, module.eks_data_addons]
+  depends_on = [module.ebs_csi_driver_irsa, module.eks_data_addons]
 
   eks_addons = {
     aws-ebs-csi-driver = {
-      most_recent = true
+      most_recent              = true
       service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
     }
     coredns = {
@@ -161,8 +161,8 @@ depends_on = [module.ebs_csi_driver_irsa, module.eks_data_addons]
     }
   }
 
-  enable_aws_load_balancer_controller    = true
-  enable_cert_manager                    = true
+  enable_aws_load_balancer_controller = true
+  enable_cert_manager                 = true
 
   cert_manager = {
     chart_version = "v1.10.0"
@@ -173,26 +173,26 @@ depends_on = [module.ebs_csi_driver_irsa, module.eks_data_addons]
 
 
   aws_efs_csi_driver = {
-    namespace = "kube-system"
+    namespace     = "kube-system"
     chart_version = "2.4.1"
   }
 
   aws_fsx_csi_driver = {
-    namespace = "kube-system"
+    namespace     = "kube-system"
     chart_version = "1.5.1"
   }
 
   secrets_store_csi_driver = {
-    namespace = "kube-system"
-    chart_version   = "1.3.2"
+    namespace     = "kube-system"
+    chart_version = "1.3.2"
     set = [
       {
         name  = "syncSecret.enabled",
         value = "true"
       }
-    ] 
+    ]
   }
-  
+
   enable_secrets_store_csi_driver = true
 
   secrets_store_csi_driver_provider_aws = {
@@ -204,14 +204,14 @@ depends_on = [module.ebs_csi_driver_irsa, module.eks_data_addons]
       }
     ]
   }
-  
+
   enable_secrets_store_csi_driver_provider_aws = true
 
   tags = local.tags
 }
 
 module "eks_data_addons" {
-  source = "aws-ia/eks-data-addons/aws"
+  source  = "aws-ia/eks-data-addons/aws"
   version = "~> 1.0" # ensure to update this to the latest/desired version
 
   oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -136,7 +136,7 @@ module "ebs_csi_driver_irsa" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "aws-ia/eks-blueprints-addons/aws"
+  source  = "aws-ia/eks-blueprints-addons/aws"
   version = "~> 1.0" #ensure to update this to the latest/desired version
 
   cluster_name      = local.cluster_name
@@ -148,7 +148,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_addons = {
     aws-ebs-csi-driver = {
-      most_recent = true
+      most_recent              = true
       service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
     }
     coredns = {
@@ -162,8 +162,8 @@ module "eks_blueprints_kubernetes_addons" {
     }
   }
 
-  enable_aws_load_balancer_controller    = true
-  enable_cert_manager                    = true
+  enable_aws_load_balancer_controller = true
+  enable_cert_manager                 = true
 
   cert_manager = {
     chart_version = "v1.10.0"
@@ -174,12 +174,12 @@ module "eks_blueprints_kubernetes_addons" {
 
 
   aws_efs_csi_driver = {
-    namespace = "kube-system"
+    namespace     = "kube-system"
     chart_version = "2.4.1"
   }
 
   aws_fsx_csi_driver = {
-    namespace = "kube-system"
+    namespace     = "kube-system"
     chart_version = "1.5.1"
   }
 
@@ -187,7 +187,7 @@ module "eks_blueprints_kubernetes_addons" {
 }
 
 module "eks_data_addons" {
-  source = "aws-ia/eks-data-addons/aws"
+  source  = "aws-ia/eks-data-addons/aws"
   version = "~> 1.0" # ensure to update this to the latest/desired version
 
   oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -128,21 +128,11 @@ module "eks_blueprints" {
 }
 
 module "ebs_csi_driver_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.20"
-
-  role_name_prefix = "${local.cluster_name}-ebs-csi-driver-"
-
-  attach_ebs_csi_policy = true
-
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks_blueprints.eks_oidc_provider_arn
-      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
-    }
-  }
-
-  tags = local.tags
+  source                = "../../../iaac/terraform/aws-infra/ebs-csi-driver-irsa"
+  cluster_name          = local.cluster_name
+  cluster_region        = local.region
+  tags                  = local.tags
+  eks_oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
 }
 
 module "eks_blueprints_kubernetes_addons" {

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -127,42 +127,82 @@ module "eks_blueprints" {
   tags = local.tags
 }
 
+module "ebs_csi_driver_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.20"
+
+  role_name_prefix = "${local.cluster_name}-ebs-csi-driver-"
+
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks_blueprints.eks_oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+
+  tags = local.tags
+}
+
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.32.1"
+  source = "aws-ia/eks-blueprints-addons/aws"
+  version = "~> 1.0" #ensure to update this to the latest/desired version
 
-  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
-  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider    = module.eks_blueprints.oidc_provider
-  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
+  cluster_name      = local.cluster_name
+  cluster_endpoint  = module.eks_blueprints.eks_cluster_endpoint
+  cluster_version   = module.eks_blueprints.eks_cluster_version
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
 
-  # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni            = true
-  enable_amazon_eks_coredns            = true
-  enable_amazon_eks_kube_proxy         = true
-  enable_amazon_eks_aws_ebs_csi_driver = true
+  depends_on = [module.ebs_csi_driver_irsa, module.eks_data_addons]
 
-  # EKS Blueprints Add-ons
-  enable_cert_manager                 = true
-  enable_aws_load_balancer_controller = true
+  eks_addons = {
+    aws-ebs-csi-driver = {
+      most_recent = true
+      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+    }
+    coredns = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
+  }
 
-  aws_efs_csi_driver_helm_config = {
-    namespace = "kube-system"
-    version   = "2.4.1"
+  enable_aws_load_balancer_controller    = true
+  enable_cert_manager                    = true
+
+  cert_manager = {
+    chart_version = "v1.10.0"
   }
 
   enable_aws_efs_csi_driver = true
-
-  aws_fsx_csi_driver_helm_config = {
-    namespace = "kube-system"
-    version   = "1.5.1"
-  }
-
   enable_aws_fsx_csi_driver = true
 
-  enable_nvidia_device_plugin = local.using_gpu
+
+  aws_efs_csi_driver = {
+    namespace = "kube-system"
+    chart_version = "2.4.1"
+  }
+
+  aws_fsx_csi_driver = {
+    namespace = "kube-system"
+    chart_version = "1.5.1"
+  }
 
   tags = local.tags
+}
 
+module "eks_data_addons" {
+  source = "aws-ia/eks-data-addons/aws"
+  version = "~> 1.0" # ensure to update this to the latest/desired version
+
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
+
+  enable_nvidia_gpu_operator = local.using_gpu
 }
 
 # todo: update the blueprints repo code to export the desired values as outputs

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -120,21 +120,11 @@ module "eks_blueprints" {
 }
 
 module "ebs_csi_driver_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.20"
-
-  role_name_prefix = "${local.cluster_name}-ebs-csi-driver-"
-
-  attach_ebs_csi_policy = true
-
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks_blueprints.eks_oidc_provider_arn
-      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
-    }
-  }
-
-  tags = local.tags
+  source                = "../../../iaac/terraform/aws-infra/ebs-csi-driver-irsa"
+  cluster_name          = local.cluster_name
+  cluster_region        = local.region
+  tags                  = local.tags
+  eks_oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
 }
 
 module "eks_blueprints_kubernetes_addons" {

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -128,7 +128,7 @@ module "ebs_csi_driver_irsa" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "aws-ia/eks-blueprints-addons/aws"
+  source  = "aws-ia/eks-blueprints-addons/aws"
   version = "~> 1.0" #ensure to update this to the latest/desired version
 
   cluster_name      = local.cluster_name
@@ -140,7 +140,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_addons = {
     aws-ebs-csi-driver = {
-      most_recent = true
+      most_recent              = true
       service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
     }
     coredns = {
@@ -154,8 +154,8 @@ module "eks_blueprints_kubernetes_addons" {
     }
   }
 
-  enable_aws_load_balancer_controller    = true
-  enable_cert_manager                    = true
+  enable_aws_load_balancer_controller = true
+  enable_cert_manager                 = true
 
   cert_manager = {
     chart_version = "v1.10.0"
@@ -166,26 +166,26 @@ module "eks_blueprints_kubernetes_addons" {
 
 
   aws_efs_csi_driver = {
-    namespace = "kube-system"
+    namespace     = "kube-system"
     chart_version = "2.4.1"
   }
 
   aws_fsx_csi_driver = {
-    namespace = "kube-system"
+    namespace     = "kube-system"
     chart_version = "1.5.1"
   }
 
   secrets_store_csi_driver = {
-    namespace = "kube-system"
-    chart_version   = "1.3.2"
+    namespace     = "kube-system"
+    chart_version = "1.3.2"
     set = [
       {
         name  = "syncSecret.enabled",
         value = "true"
       }
-    ] 
+    ]
   }
-  
+
   enable_secrets_store_csi_driver = true
 
   secrets_store_csi_driver_provider_aws = {
@@ -197,14 +197,14 @@ module "eks_blueprints_kubernetes_addons" {
       }
     ]
   }
-  
+
   enable_secrets_store_csi_driver_provider_aws = true
 
   tags = local.tags
 }
 
 module "eks_data_addons" {
-  source = "aws-ia/eks-data-addons/aws"
+  source  = "aws-ia/eks-data-addons/aws"
   version = "~> 1.0" # ensure to update this to the latest/desired version
 
   oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -119,54 +119,86 @@ module "eks_blueprints" {
   tags = local.tags
 }
 
+module "ebs_csi_driver_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.20"
+
+  role_name_prefix = "${local.cluster_name}-ebs-csi-driver-"
+
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks_blueprints.eks_oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+
+  tags = local.tags
+}
+
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.32.1"
+  source = "aws-ia/eks-blueprints-addons/aws"
+  version = "~> 1.0" #ensure to update this to the latest/desired version
 
-  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
-  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider    = module.eks_blueprints.oidc_provider
-  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
+  cluster_name      = local.cluster_name
+  cluster_endpoint  = module.eks_blueprints.eks_cluster_endpoint
+  cluster_version   = module.eks_blueprints.eks_cluster_version
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
 
-  # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni            = true
-  enable_amazon_eks_coredns            = true
-  enable_amazon_eks_kube_proxy         = true
-  enable_amazon_eks_aws_ebs_csi_driver = true
+  depends_on = [module.ebs_csi_driver_irsa, module.eks_data_addons]
 
-  # EKS Blueprints Add-ons
-  enable_cert_manager                 = true
-  enable_aws_load_balancer_controller = true
+  eks_addons = {
+    aws-ebs-csi-driver = {
+      most_recent = true
+      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+    }
+    coredns = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
+  }
 
-  aws_efs_csi_driver_helm_config = {
-    namespace = "kube-system"
-    version   = "2.4.1"
+  enable_aws_load_balancer_controller    = true
+  enable_cert_manager                    = true
+
+  cert_manager = {
+    chart_version = "v1.10.0"
   }
 
   enable_aws_efs_csi_driver = true
-
-  aws_fsx_csi_driver_helm_config = {
-    namespace = "kube-system"
-    version   = "1.5.1"
-  }
-
   enable_aws_fsx_csi_driver = true
 
-  enable_nvidia_device_plugin = local.using_gpu
 
-  secrets_store_csi_driver_helm_config = {
+  aws_efs_csi_driver = {
     namespace = "kube-system"
-    version   = "1.3.2"
+    chart_version = "2.4.1"
+  }
+
+  aws_fsx_csi_driver = {
+    namespace = "kube-system"
+    chart_version = "1.5.1"
+  }
+
+  secrets_store_csi_driver = {
+    namespace = "kube-system"
+    chart_version   = "1.3.2"
     set = [
       {
         name  = "syncSecret.enabled",
         value = "true"
       }
-    ]
+    ] 
   }
+  
   enable_secrets_store_csi_driver = true
 
-
-  csi_secrets_store_provider_aws_helm_config = {
+  secrets_store_csi_driver_provider_aws = {
     namespace = "kube-system"
     set = [
       {
@@ -175,10 +207,19 @@ module "eks_blueprints_kubernetes_addons" {
       }
     ]
   }
+  
   enable_secrets_store_csi_driver_provider_aws = true
 
   tags = local.tags
+}
 
+module "eks_data_addons" {
+  source = "aws-ia/eks-data-addons/aws"
+  version = "~> 1.0" # ensure to update this to the latest/desired version
+
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
+
+  enable_nvidia_gpu_operator = local.using_gpu
 }
 
 # todo: update the blueprints repo code to export the desired values as outputs

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -119,21 +119,11 @@ module "eks_blueprints" {
 }
 
 module "ebs_csi_driver_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.20"
-
-  role_name_prefix = "${local.cluster_name}-ebs-csi-driver-"
-
-  attach_ebs_csi_policy = true
-
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks_blueprints.eks_oidc_provider_arn
-      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
-    }
-  }
-
-  tags = local.tags
+  source                = "../../../iaac/terraform/aws-infra/ebs-csi-driver-irsa"
+  cluster_name          = local.cluster_name
+  cluster_region        = local.region
+  tags                  = local.tags
+  eks_oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
 }
 
 module "eks_blueprints_kubernetes_addons" {

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -118,44 +118,83 @@ module "eks_blueprints" {
   tags                = local.tags
 }
 
+module "ebs_csi_driver_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.20"
+
+  role_name_prefix = "${local.cluster_name}-ebs-csi-driver-"
+
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks_blueprints.eks_oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+
+  tags = local.tags
+}
+
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.32.1"
+  source = "aws-ia/eks-blueprints-addons/aws"
+  version = "~> 1.0" #ensure to update this to the latest/desired version
 
-  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
-  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider    = module.eks_blueprints.oidc_provider
-  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
+  cluster_name      = local.cluster_name
+  cluster_endpoint  = module.eks_blueprints.eks_cluster_endpoint
+  cluster_version   = module.eks_blueprints.eks_cluster_version
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
 
-  # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni            = true
-  enable_amazon_eks_coredns            = true
-  enable_amazon_eks_kube_proxy         = true
-  enable_amazon_eks_aws_ebs_csi_driver = true
+  depends_on = [module.ebs_csi_driver_irsa, module.eks_data_addons]
 
-  # EKS Blueprints Add-ons
-  enable_cert_manager                 = true
-  enable_aws_load_balancer_controller = true
+  eks_addons = {
+    aws-ebs-csi-driver = {
+      most_recent = true
+      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+    }
+    coredns = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
+  }
 
-  aws_efs_csi_driver_helm_config = {
-    namespace = "kube-system"
-    version   = "2.4.1"
+  enable_aws_load_balancer_controller    = true
+  enable_cert_manager                    = true
+
+  cert_manager = {
+    chart_version = "v1.10.0"
   }
 
   enable_aws_efs_csi_driver = true
-
-  aws_fsx_csi_driver_helm_config = {
-    namespace = "kube-system"
-    version   = "1.5.1"
-  }
-
   enable_aws_fsx_csi_driver = true
 
-  enable_nvidia_device_plugin = local.using_gpu
+
+  aws_efs_csi_driver = {
+    namespace = "kube-system"
+    chart_version = "2.4.1"
+  }
+
+  aws_fsx_csi_driver = {
+    namespace = "kube-system"
+    chart_version = "1.5.1"
+  }
 
   tags = local.tags
-
 }
 
+module "eks_data_addons" {
+  source = "aws-ia/eks-data-addons/aws"
+  version = "~> 1.0" # ensure to update this to the latest/desired version
+
+  oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn
+
+  enable_nvidia_gpu_operator = local.using_gpu
+}
 
 # todo: update the blueprints repo code to export the desired values as outputs
 module "eks_blueprints_outputs" {
@@ -178,6 +217,7 @@ module "kubeflow_components" {
   notebook_enable_culling        = var.notebook_enable_culling
   notebook_cull_idle_time        = var.notebook_cull_idle_time
   notebook_idleness_check_period = var.notebook_idleness_check_period
+
 
   tags = local.tags
 }

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -127,7 +127,7 @@ module "ebs_csi_driver_irsa" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "aws-ia/eks-blueprints-addons/aws"
+  source  = "aws-ia/eks-blueprints-addons/aws"
   version = "~> 1.0" #ensure to update this to the latest/desired version
 
   cluster_name      = local.cluster_name
@@ -139,7 +139,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_addons = {
     aws-ebs-csi-driver = {
-      most_recent = true
+      most_recent              = true
       service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
     }
     coredns = {
@@ -153,8 +153,8 @@ module "eks_blueprints_kubernetes_addons" {
     }
   }
 
-  enable_aws_load_balancer_controller    = true
-  enable_cert_manager                    = true
+  enable_aws_load_balancer_controller = true
+  enable_cert_manager                 = true
 
   cert_manager = {
     chart_version = "v1.10.0"
@@ -165,12 +165,12 @@ module "eks_blueprints_kubernetes_addons" {
 
 
   aws_efs_csi_driver = {
-    namespace = "kube-system"
+    namespace     = "kube-system"
     chart_version = "2.4.1"
   }
 
   aws_fsx_csi_driver = {
-    namespace = "kube-system"
+    namespace     = "kube-system"
     chart_version = "1.5.1"
   }
 
@@ -178,7 +178,7 @@ module "eks_blueprints_kubernetes_addons" {
 }
 
 module "eks_data_addons" {
-  source = "aws-ia/eks-data-addons/aws"
+  source  = "aws-ia/eks-data-addons/aws"
   version = "~> 1.0" # ensure to update this to the latest/desired version
 
   oidc_provider_arn = module.eks_blueprints.eks_oidc_provider_arn

--- a/iaac/terraform/aws-infra/ebs-csi-driver-irsa/main.tf
+++ b/iaac/terraform/aws-infra/ebs-csi-driver-irsa/main.tf
@@ -1,0 +1,17 @@
+module "ebs_csi_driver_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.20"
+
+  role_name_prefix = "${var.cluster_name}-${var.cluster_region}-ebs-csi-driver-"
+
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = var.eks_oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+
+  tags = var.tags
+}

--- a/iaac/terraform/aws-infra/ebs-csi-driver-irsa/outputs.tf
+++ b/iaac/terraform/aws-infra/ebs-csi-driver-irsa/outputs.tf
@@ -1,0 +1,19 @@
+output "iam_role_arn" {
+  description = "ARN of IAM role"
+  value       = module.ebs_csi_driver_irsa.iam_role_arn
+}
+
+output "iam_role_name" {
+  description = "Name of IAM role"
+  value       = module.ebs_csi_driver_irsa.iam_role_name
+}
+
+output "iam_role_path" {
+  description = "Path of IAM role"
+  value       = module.ebs_csi_driver_irsa.iam_role_path
+}
+
+output "iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = module.ebs_csi_driver_irsa.iam_role_unique_id
+}

--- a/iaac/terraform/aws-infra/ebs-csi-driver-irsa/outputs.tf
+++ b/iaac/terraform/aws-infra/ebs-csi-driver-irsa/outputs.tf
@@ -7,13 +7,3 @@ output "iam_role_name" {
   description = "Name of IAM role"
   value       = module.ebs_csi_driver_irsa.iam_role_name
 }
-
-output "iam_role_path" {
-  description = "Path of IAM role"
-  value       = module.ebs_csi_driver_irsa.iam_role_path
-}
-
-output "iam_role_unique_id" {
-  description = "Unique ID of IAM role"
-  value       = module.ebs_csi_driver_irsa.iam_role_unique_id
-}

--- a/iaac/terraform/aws-infra/ebs-csi-driver-irsa/variables.tf
+++ b/iaac/terraform/aws-infra/ebs-csi-driver-irsa/variables.tf
@@ -1,12 +1,12 @@
 variable "cluster_name" {
-    type    = string
+  type = string
 }
 variable "cluster_region" {
-    type    = string
+  type = string
 }
 variable "eks_oidc_provider_arn" {
-    type    = string
+  type = string
 }
 variable "tags" {
-    type    = any
+  type = any
 }

--- a/iaac/terraform/aws-infra/ebs-csi-driver-irsa/variables.tf
+++ b/iaac/terraform/aws-infra/ebs-csi-driver-irsa/variables.tf
@@ -1,0 +1,12 @@
+variable "cluster_name" {
+    type    = string
+}
+variable "cluster_region" {
+    type    = string
+}
+variable "eks_oidc_provider_arn" {
+    type    = string
+}
+variable "tags" {
+    type    = any
+}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #775

**Description of your changes:**

Upgrade to v5 blueprints for the eks addons

Major changes:

1. v5 does not have an option to enable the ebs csi driver, will need to do with the help of another module
2. v5 does not have an option for enabling the nvidia plugin, an operator is used instead.
3. V5/V4 parameters are different.

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass - WIP Cognito, rds-s3-static, rds/s3-irsa passes, efs/fsx look fine manually. Need to test nvidia.
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.