### PR TITLE
Fix to pass variable mysql_engine_version to RDS module

### DIFF
--- a/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
+++ b/deployments/cognito-rds-s3/terraform/cognito-rds-s3-components/main.tf
@@ -130,6 +130,7 @@ module "rds" {
   db_password                    = coalesce(var.db_password, try(random_password.db_password[0].result, null))
   db_class                       = var.db_class
   db_allocated_storage           = var.db_allocated_storage
+  mysql_engine_version           = var.mysql_engine_version
   backup_retention_period        = var.backup_retention_period
   storage_type                   = var.storage_type
   deletion_protection            = var.deletion_protection

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -123,6 +123,7 @@ module "rds" {
   db_password                    = coalesce(var.db_password, try(random_password.db_password[0].result, null))
   db_class                       = var.db_class
   db_allocated_storage           = var.db_allocated_storage
+  mysql_engine_version           = var.mysql_engine_version
   backup_retention_period        = var.backup_retention_period
   storage_type                   = var.storage_type
   deletion_protection            = var.deletion_protection


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #780 

**Description of your changes:**
Fix to pass variable `mysql_engine_version` to RDS module.

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.