### PR TITLE
Add variable for disk size and increase default

### DIFF
--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -30,6 +30,7 @@ locals {
     min_size        = 5
     desired_size    = 5
     max_size        = 10
+    disk_size       = var.node_disk_size_cpu
     subnet_ids      = module.vpc.private_subnets
   }
 
@@ -40,7 +41,7 @@ locals {
     desired_size    = 3
     max_size        = 5
     ami_type        = "AL2_x86_64_GPU"
-    disk_size       = 75
+    disk_size       = var.node_disk_size_gpu
     subnet_ids      = module.vpc.private_subnets
   } : null
 

--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -40,6 +40,7 @@ locals {
     desired_size    = 3
     max_size        = 5
     ami_type        = "AL2_x86_64_GPU"
+    disk_size       = 75
     subnet_ids      = module.vpc.private_subnets
   } : null
 

--- a/deployments/cognito-rds-s3/terraform/variables.tf
+++ b/deployments/cognito-rds-s3/terraform/variables.tf
@@ -32,6 +32,18 @@ variable "node_instance_type_gpu" {
   default     = null
 }
 
+variable "node_disk_size_cpu" {
+  description = "The disk size of a cpu node."
+  type        = string
+  default     = 50
+}
+
+variable "node_disk_size_gpu" {
+  description = "The disk size of a gpu node."
+  type        = string
+  default     = 75
+}
+
 variable "kf_helm_repo_path" {
   description = "Full path to the location of the helm repo for KF"
   type        = string

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -30,6 +30,7 @@ locals {
     min_size        = 5
     desired_size    = 5
     max_size        = 10
+    disk_size       = var.node_disk_size_cpu
     subnet_ids      = module.vpc.private_subnets
   }
 
@@ -40,7 +41,7 @@ locals {
     desired_size    = 3
     max_size        = 5
     ami_type        = "AL2_x86_64_GPU"
-    disk_size       = 75
+    disk_size       = var.node_disk_size_gpu
     subnet_ids      = module.vpc.private_subnets
   } : null
 

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -40,6 +40,7 @@ locals {
     desired_size    = 3
     max_size        = 5
     ami_type        = "AL2_x86_64_GPU"
+    disk_size       = 75
     subnet_ids      = module.vpc.private_subnets
   } : null
 

--- a/deployments/cognito/terraform/variables.tf
+++ b/deployments/cognito/terraform/variables.tf
@@ -32,6 +32,18 @@ variable "node_instance_type_gpu" {
   default     = null
 }
 
+variable "node_disk_size_cpu" {
+  description = "The disk size of a cpu node."
+  type        = string
+  default     = 50
+}
+
+variable "node_disk_size_gpu" {
+  description = "The disk size of a gpu node."
+  type        = string
+  default     = 75
+}
+
 variable "cognito_user_pool_name" {
   description = "Cognito User Pool name"
   type        = string

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -30,6 +30,7 @@ locals {
     min_size        = 5
     desired_size    = 5
     max_size        = 10
+    disk_size       = var.node_disk_size_cpu
     subnet_ids      = module.vpc.private_subnets
   }
 
@@ -40,7 +41,7 @@ locals {
     desired_size    = 3
     max_size        = 5
     ami_type        = "AL2_x86_64_GPU"
-    disk_size       = 75
+    disk_size       = var.node_disk_size_gpu
     subnet_ids      = module.vpc.private_subnets
   } : null
 

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -40,6 +40,7 @@ locals {
     desired_size    = 3
     max_size        = 5
     ami_type        = "AL2_x86_64_GPU"
+    disk_size       = 75
     subnet_ids      = module.vpc.private_subnets
   } : null
 

--- a/deployments/rds-s3/terraform/variables.tf
+++ b/deployments/rds-s3/terraform/variables.tf
@@ -32,6 +32,18 @@ variable "node_instance_type_gpu" {
   default     = null
 }
 
+variable "node_disk_size_cpu" {
+  description = "The disk size of a cpu node."
+  type        = string
+  default     = 50
+}
+
+variable "node_disk_size_gpu" {
+  description = "The disk size of a gpu node."
+  type        = string
+  default     = 75
+}
+
 variable "use_rds" {
   type    = bool
   default = true

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -30,6 +30,7 @@ locals {
     min_size        = 5
     desired_size    = 5
     max_size        = 10
+    disk_size       = var.node_disk_size_cpu
     subnet_ids      = module.vpc.private_subnets
   }
 
@@ -40,7 +41,7 @@ locals {
     desired_size    = 3
     max_size        = 5
     ami_type        = "AL2_x86_64_GPU"
-    disk_size       = 75
+    disk_size       = var.node_disk_size_gpu
     subnet_ids      = module.vpc.private_subnets
   } : null
 

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -40,6 +40,7 @@ locals {
     desired_size    = 3
     max_size        = 5
     ami_type        = "AL2_x86_64_GPU"
+    disk_size       = 75
     subnet_ids      = module.vpc.private_subnets
   } : null
 

--- a/deployments/vanilla/terraform/variables.tf
+++ b/deployments/vanilla/terraform/variables.tf
@@ -32,6 +32,18 @@ variable "node_instance_type_gpu" {
   default     = null
 }
 
+variable "node_disk_size_cpu" {
+  description = "The disk size of a cpu node."
+  type        = string
+  default     = 50
+}
+
+variable "node_disk_size_gpu" {
+  description = "The disk size of a gpu node."
+  type        = string
+  default     = 75
+}
+
 variable "enable_aws_telemetry" {
   description = "Enable AWS telemetry component"
   type        = bool


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

DLC gpu images take up too much disk space, which leads to disk pressure errors. 

Second revision:

Adding a variable to configure disk size.

**Description of your changes:**
This PR increases the disk size from 50gb (default) to 75gb for gpu nodes.

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed
- Manually tested with public.ecr.aws/kubeflow-on-aws/notebook-servers/jupyter-pytorch:2.0.0-gpu-py310-cu118-ubuntu20.04-ec2-v1.0, no disk pressure errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.