### PR TITLE
[terraform] Pinning aws-load-balancer controller version

### DIFF
--- a/deployments/cognito-rds-s3/terraform/main.tf
+++ b/deployments/cognito-rds-s3/terraform/main.tf
@@ -179,6 +179,10 @@ module "eks_blueprints_kubernetes_addons" {
     chart_version = "2.4.1"
   }
 
+  aws_load_balancer_controller = {
+    chart_version = "v1.4.8"
+  }
+
   aws_fsx_csi_driver = {
     namespace     = "kube-system"
     chart_version = "1.5.1"

--- a/deployments/cognito/terraform/main.tf
+++ b/deployments/cognito/terraform/main.tf
@@ -180,6 +180,10 @@ module "eks_blueprints_kubernetes_addons" {
     chart_version = "2.4.1"
   }
 
+  aws_load_balancer_controller = {
+    chart_version = "v1.4.8"
+  }
+
   aws_fsx_csi_driver = {
     namespace     = "kube-system"
     chart_version = "1.5.1"

--- a/deployments/rds-s3/terraform/main.tf
+++ b/deployments/rds-s3/terraform/main.tf
@@ -172,6 +172,10 @@ module "eks_blueprints_kubernetes_addons" {
     chart_version = "2.4.1"
   }
 
+  aws_load_balancer_controller = {
+    chart_version = "v1.4.8"
+  }
+
   aws_fsx_csi_driver = {
     namespace     = "kube-system"
     chart_version = "1.5.1"

--- a/deployments/vanilla/terraform/main.tf
+++ b/deployments/vanilla/terraform/main.tf
@@ -171,6 +171,10 @@ module "eks_blueprints_kubernetes_addons" {
     chart_version = "2.4.1"
   }
 
+  aws_load_balancer_controller = {
+    chart_version = "v1.4.8"
+  }
+
   aws_fsx_csi_driver = {
     namespace     = "kube-system"
     chart_version = "1.5.1"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Running into the same issue as https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/233 sporadically. Out of 9 code build runs this issue happened 4 times. 

While the user can still re run the deployment to fix this, it will break any kind of automation systems.

**Description of your changes:**
- Downgrade load balancer controller version to 2.4.7(lbc version) ie v1.4.8(helm chart version). We use v2.4.7(lbc version) for the non terraform installations. v4 blueprints used a very old version.

**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass - pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.