### PR TITLE
Fix ack helm chart pull failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,9 @@ install-terraform:
 	terraform --version
 
 install-helm: 
-	curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+	wget https://get.helm.sh/helm-v3.12.2-linux-amd64.tar.gz
+	tar -zxvf helm-v3.12.2-linux-amd64.tar.gz
+	sudo mv linux-amd64/helm /usr/local/bin/helm
 	helm version
 
 install-python:

--- a/tests/e2e/utils/kubeflow_installation.py
+++ b/tests/e2e/utils/kubeflow_installation.py
@@ -247,7 +247,7 @@ def install_ack_controller():
         + "helm registry login --username AWS --password-stdin public.ecr.aws"
     )
     exec_shell(
-        f"helm pull https://{CHART_REPO} --version {RELEASE_VERSION} -d {CHART_EXPORT_PATH}"
+        f"helm pull oci://{CHART_REPO} --version {RELEASE_VERSION} -d {CHART_EXPORT_PATH}"
     )
     exec_shell(f"tar xvf {CHART_EXPORT_PATH}/{CHART_PACKAGE} -C {CHART_EXPORT_PATH}")
     exec_shell(


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
when do `helm pull oci://public.ecr.aws/aws-controllers-k8s/sagemaker-chart --version v1.2.1 -d ack-controller` in testing, see
`Error: unexpected status from HEAD request to https://public.ecr.aws/v2/aws-controllers-k8s/sagemaker-chart/manifests/v1.2.1: 400 Bad Request`

**Description of your changes:**
- try to replace oci with https. https://gallery.ecr.aws/aws-controllers-k8s/sagemaker-controller

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.