### PR TITLE
Install specific version of Helm (v3.12.2) in Make File

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,9 @@ install-terraform:
 	terraform --version
 
 install-helm: 
-	curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+	wget https://get.helm.sh/helm-v3.12.2-linux-amd64.tar.gz
+	tar -zxvf helm-v3.12.2-linux-amd64.tar.gz
+	sudo mv linux-amd64/helm /usr/local/bin/helm
 	helm version
 
 install-python:

--- a/tests/canary/Dockerfile.canary
+++ b/tests/canary/Dockerfile.canary
@@ -32,9 +32,10 @@ RUN curl --silent --location "https://github.com/kubernetes-sigs/kustomize/relea
 
 
 #Install helm
-RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 \
- && chmod +x get_helm.sh \
- && ./get_helm.sh
+RUN curl -fsSL -o helm-v3.12.2-linux-amd64.tar.gz https://get.helm.sh/helm-v3.12.2-linux-amd64.tar.gz \
+ && tar -zxvf helm-v3.12.2-linux-amd64.tar.gz \
+ && mv linux-amd64/helm /usr/local/bin/helm \
+ && rm -rf linux-amd64 helm-v3.12.2-linux-amd64.tar.gz
 
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.26.1/yq_linux_amd64.tar.gz -O - | tar xz \
  && mv yq_linux_amd64 /usr/bin/yq \


### PR DESCRIPTION


**Which issue is resolved by this Pull Request:**
The current script install the latest version of Helm. Yet the newer version of helm (v3.13.0) failed to pull ack-controller helm chart:
```
helm version
version.BuildInfo{Version:"v3.13.0", GitCommit:"825e86f6a7a38cef1112bfa606e4127a706749b1", GitTreeState:"clean", GoVersion:"go1.20.8"}
```

```
helm pull oci://public.ecr.aws/aws-controllers-k8s/sagemaker-chart --version v1.2.1 -d ack-controller 
Error: unexpected status from HEAD request to https://public.ecr.aws/v2/aws-controllers-k8s/sagemaker-chart/manifests/v1.2.1: 400 Bad Request
```

Modify helm version to be 3.12.2 and it will pull the chart successfully.
```
helm version                                
version.BuildInfo{Version:"v3.12.2", GitCommit:"1e210a2c8cc5117d1055bfaa5d40f51bbc2e345e", GitTreeState:"clean", GoVersion:"go1.20.5"}
```

```
helm pull oci://public.ecr.aws/aws-controllers-k8s/sagemaker-chart --version v1.2.1 -d ack-controller
Pulled: public.ecr.aws/aws-controllers-k8s/sagemaker-chart:v1.2.1
Digest: sha256:1b6c99433a9844f3c9be652f560d4b8790d90d064f9ee7d32959cdc188b0a7a1
```

**Description of your changes:**


**Testing:**
- [ ] Unit tests pass
- [x] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.