### PR TITLE
Delete ClusterServingRuntimes with kubectl

### DIFF
--- a/tests/e2e/utils/kubeflow_uninstallation.py
+++ b/tests/e2e/utils/kubeflow_uninstallation.py
@@ -141,6 +141,9 @@ def delete_component(
                             exec_shell(
                                 f"kubectl delete ingress -n istio-system istio-ingress"
                             )
+                        # Helm uninstallation is async. Delete the Cluster Serving runtimes with Kubectl.
+                        if component_name == "kserve":
+                            kubectl_delete(f"{installation_path}/templates/ClusterServingRuntime")
                     if os.path.isdir(f"{installation_path}/crds"):
                         print(f"deleting {component_name} crds ...")
                         kubectl_delete(f"{installation_path}/crds")

--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -249,10 +249,10 @@ def uninstall_helm(chart_name, namespace=None):
     """
     if namespace:
         uninstall_retcode = subprocess.call(
-            f"helm uninstall {chart_name} -n {namespace} --wait".split()
+            f"helm uninstall {chart_name} -n {namespace}".split()
         )
     else:
-        uninstall_retcode = subprocess.call(f"helm uninstall {chart_name} --wait".split())
+        uninstall_retcode = subprocess.call(f"helm uninstall {chart_name}".split())
     assert uninstall_retcode == 0
 
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

Installation getting stuck at helm

**Description of your changes:**
- Introduce a kubectl delete for ClusterServingRuntime
- Look into using helm wait in the future (https://helm.sh/docs/helm/helm_uninstall/). Fix the race condition before reintroducing.

**Testing:**
WIP
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.