### PR TITLE
fix: helm uninstall Kserve stuck at CRD clean up

### DIFF
--- a/tests/e2e/utils/kubeflow_uninstallation.py
+++ b/tests/e2e/utils/kubeflow_uninstallation.py
@@ -136,6 +136,13 @@ def delete_component(
                 else:
                     if check_helm_chart_exists(component_name, namespace):
                         uninstall_helm(component_name, namespace)
+                        if component_name == "kserve":
+                            # Helm uninstall returns before CRs are cleaned up which cause failure with CRD deletion
+                            # Kserve chart contains CRD and CRs for clusterservingruntime
+                            # TODO: explore --cascade delete option
+                            exec_shell(
+                                f"kubectl delete clusterservingruntime --all"
+                            )
                         if component_name == "ingress":
                             # Helm doesn't seem to delete ingress during uninstall
                             exec_shell(

--- a/tests/e2e/utils/kubeflow_uninstallation.py
+++ b/tests/e2e/utils/kubeflow_uninstallation.py
@@ -136,13 +136,6 @@ def delete_component(
                 else:
                     if check_helm_chart_exists(component_name, namespace):
                         uninstall_helm(component_name, namespace)
-                        if component_name == "kserve":
-                            # Helm uninstall returns before CRs are cleaned up which cause failure with CRD deletion
-                            # Kserve chart contains CRD and CRs for clusterservingruntime
-                            # TODO: explore --cascade delete option
-                            exec_shell(
-                                f"kubectl delete clusterservingruntime --all"
-                            )
                         if component_name == "ingress":
                             # Helm doesn't seem to delete ingress during uninstall
                             exec_shell(

--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -249,10 +249,10 @@ def uninstall_helm(chart_name, namespace=None):
     """
     if namespace:
         uninstall_retcode = subprocess.call(
-            f"helm uninstall {chart_name} -n {namespace}".split()
+            f"helm uninstall {chart_name} -n {namespace} --wait".split()
         )
     else:
-        uninstall_retcode = subprocess.call(f"helm uninstall {chart_name}".split())
+        uninstall_retcode = subprocess.call(f"helm uninstall {chart_name} --wait".split())
     assert uninstall_retcode == 0
 
 


### PR DESCRIPTION
**Description of your changes:**
Helm canaries cause frequent failures because KServe CRDs get stuck in deletion state. This is because the KServe helm chart installs both CRs and CRDs for [serving runtime](https://github.com/awslabs/kubeflow-manifests/tree/main/charts/common/kserve/templates/ClusterServingRuntime). Helm chart deletion does not wait for resources to be cleaned up from cluster which causes CRD deletion to hang(CRDs cannot be deleted if there are resources which reference it)

If this fix does not work, we can try deleting via kubectl 
```
if component_name == "kserve":
    exec_shell(
        f"kubectl delete clusterservingruntime --all"
    )
```

**Testing**
Tested using codebuild runs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.