### PR TITLE
fix: helm uninstall Kserve stuck at CRD clean up (#800)

### DIFF
--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -249,10 +249,10 @@ def uninstall_helm(chart_name, namespace=None):
     """
     if namespace:
         uninstall_retcode = subprocess.call(
-            f"helm uninstall {chart_name} -n {namespace}".split()
+            f"helm uninstall {chart_name} -n {namespace} --wait".split()
         )
     else:
-        uninstall_retcode = subprocess.call(f"helm uninstall {chart_name}".split())
+        uninstall_retcode = subprocess.call(f"helm uninstall {chart_name} --wait".split())
     assert uninstall_retcode == 0
 
 


### PR DESCRIPTION
**Description of your changes:**
Helm canaries cause frequent failures because KServe CRDs get stuck in deletion state. This is because the KServe helm chart installs both CRs and CRDs for [serving
runtime](https://github.com/awslabs/kubeflow-manifests/tree/main/charts/common/kserve/templates/ClusterServingRuntime). Helm chart deletion does not wait for resources to be cleaned up from cluster which causes CRD deletion to hang(CRDs cannot be deleted if there are resources which reference it)

If this fix does not work, we can try deleting via kubectl 
```
if component_name == "kserve":
    exec_shell(
        f"kubectl delete clusterservingruntime --all"
    )
```

**Testing**
Tested using codebuild runs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.