### PR TITLE
Fix EKS 1.26 compatibility

### DIFF
--- a/charts/common/knative-serving/templates/HorizontalPodAutoscaler/webhook-knative-serving-HorizontalPodAutoscaler.yaml
+++ b/charts/common/knative-serving/templates/HorizontalPodAutoscaler/webhook-knative-serving-HorizontalPodAutoscaler.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:


### PR DESCRIPTION
Cherry-pick 627bf879 from upstream

**Which issue is resolved by this Pull Request:**
Resolves compatibility with EKS 1.26 (as reported by [`kube-no-trouble`](https://github.com/doitintl/kube-no-trouble).

**Description of your changes:**
Applied upstream commit from https://github.com/kubeflow/manifests/pull/2435.

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.