### PR TITLE
Removed timeout from "kubectl describe" call (one-line change)

### DIFF
--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -270,7 +270,7 @@ def kubectl_wait_pods(
 
     if retcode is not 0:
         ns = f"-n {namespace}" if namespace else ""
-        debug_cmd = f"kubectl describe pod -l '{identifier} in ({pods})' --timeout={timeout}s {ns}"
+        debug_cmd = f"kubectl describe pod -l '{identifier} in ({pods})' {ns}"
         os.system(debug_cmd)
         raise Exception("Timeout/error waiting for pod condition")
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #810 

In case of timeout waiting for a pod to come online, a `kubectl describe` command is called, but it erroneously has a "timeout" flag. Removed the timeout flag to prevent confusion.


**Testing:**
Tested that this resolved the secondary error for my use case. Did not run through the whole test suite though.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.