### PR TITLE
fix for issue oidc-authservice container at gcr.io does not exist

### DIFF
--- a/charts/common/oidc-authservice/templates/StatefulSet/authservice-istio-system-StatefulSet.yaml
+++ b/charts/common/oidc-authservice/templates/StatefulSet/authservice-istio-system-StatefulSet.yaml
@@ -22,7 +22,7 @@ spec:
             name: oidc-authservice-client
         - configMapRef:
             name: oidc-authservice-parameters
-        image: gcr.io/arrikto/kubeflow/oidc-authservice:e236439
+        image: kubeflowmanifestswg/oidc-authservice:28c59ef
         imagePullPolicy: Always
         name: authservice
         ports:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #823 

**Description of your changes:**
I have changed the image registry for oidc-authservice container from gcr.io to docker.io

**Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.